### PR TITLE
fix diffusers model path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ import torch
 from diffusers import SanaPipeline
 
 pipe = SanaPipeline.from_pretrained(
-    "Efficient-Large-Model/SANA1.5_1.6B_1024px",
+    "Efficient-Large-Model/SANA1.5_1.6B_1024px_diffusers",
     torch_dtype=torch.bfloat16,
 )
 pipe.to("cuda")


### PR DESCRIPTION
For the diffuser example in readme, it should be`Efficient-Large-Model/SANA1.5_1.6B_1024px_diffusers` instead of `Efficient-Large-Model/SANA1.5_1.6B_1024px`.