### PR TITLE
Fixed Sana Sprint 0.6b config for train_scm_ladd

### DIFF
--- a/configs/sana_sprint_config/1024ms/SanaSprint_600M_1024px_allqknorm_bf16_scm_ladd.yaml
+++ b/configs/sana_sprint_config/1024ms/SanaSprint_600M_1024px_allqknorm_bf16_scm_ladd.yaml
@@ -15,12 +15,12 @@ data:
   sort_dataset: false
 # model config
 model:
-  model: SanaMSCM_600M_P1_D20
+  model: SanaMSCM_600M_P1_D28 
   image_size: 1024
   mixed_precision: bf16
   fp32_attention: true
-  teacher_model: hf://Efficient-Large-Model/Sana_1600M_1024px_BF16/checkpoints/Sana_600M_1024px.pth # TODO: change to the path of the teacher model
-  load_from: hf://Efficient-Large-Model/Sana_1600M_1024px_BF16/checkpoints/Sana_600M_1024px.pth
+  teacher_model: hf://Efficient-Large-Model/Sana_Sprint_0.6B_1024px_teacher/checkpoints/Sana_Sprint_0.6B_1024px_teacher.pth
+  load_from: hf://Efficient-Large-Model/Sana_Sprint_0.6B_1024px/checkpoints/Sana_Sprint_0.6B_1024px.pth
   resume_from:
   aspect_ratio_type: ASPECT_RATIO_1024
   multi_scale: true


### PR DESCRIPTION
Hey,
I stumbled upon errors when running `train_scm_ladd.py` with the sana sprint 0.6b config
I think the model name `SanaMSCM_600M_P1_D20` was a copy-paste error from the 1.6b config, it seems the 0.6b model [has depth=28](https://github.com/NVlabs/Sana/blob/c76ba2e5713d557aac74d3b8e77e93b5c04f9a6d/diffusion/model/nets/sana.py#L447)
Please let me know if I got anything wrong / missed something. Thanks!