### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVlabs/Sana)
+
 <p align="center" style="border-radius: 10px">
   <img src="asset/logo.png" width="35%" alt="logo"/>
 </p>


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/NVlabs/Sana) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.