### PR TITLE
[feat] Add ltx vae refiner & SGLang support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <h3 align="center">
-<a href="https://nvlabs.github.io/Sana/docs/"><b>📚 Docs</b></a> | <a href="https://nvlabs.github.io/Sana/"><b>SANA</b></a> | <a href="https://nvlabs.github.io/Sana/Sana-1.5/"><b>SANA-1.5</b></a> | <a href="https://nvlabs.github.io/Sana/Sprint/"><b>SANA-Sprint</b></a> | <a href="https://nvlabs.github.io/Sana/Video/"><b>SANA-Video</b></a> | <a href="https://nv-sana.mit.edu/"><b>Demo</b></a> | <a href="https://huggingface.co/collections/Efficient-Large-Model/sana"><b>🤗 HuggingFace</b></a> | <a href="https://github.com/lawrence-cj/ComfyUI_ExtraModels"><b>ComfyUI</b></a>
+<a href="https://nvlabs.github.io/Sana/docs/"><b>📚 Docs</b></a> | <a href="https://nvlabs.github.io/Sana/"><b>SANA</b></a> | <a href="https://nvlabs.github.io/Sana/Sana-1.5/"><b>SANA-1.5</b></a> | <a href="https://nvlabs.github.io/Sana/Sprint/"><b>SANA-Sprint</b></a> | <a href="https://nvlabs.github.io/Sana/Video/"><b>SANA-Video</b></a> | <a href="https://nv-sana.mit.edu/"><b>Demo</b></a> | <a href="https://huggingface.co/collections/Efficient-Large-Model/sana"><b>🤗 HuggingFace</b></a> | <a href="https://github.com/lawrence-cj/ComfyUI_ExtraModels"><b>ComfyUI</b></a> | <a href="https://github.com/sgl-project/sglang"><b>SGLang</b></a>
 </h3>
 
 <p align="center">
@@ -31,6 +31,7 @@ Join our [Discord](https://discord.gg/rde6eaE5Ta) to engage in discussions with 
 
 ## 🔥🔥 News
 
+- (🔥 New) [2026/02] 🚀**SANA is now supported in [SGLang](https://github.com/sgl-project/sglang)!** High-performance serving with OpenAI-compatible API. [[Guidance]](https://nvlabs.github.io/Sana/docs/sglang/)
 - (🔥 New) [2026/01/26] **SANA-Video is accepted as Oral by ICLR-2026.** 🎉🎉🎉
 - (🔥 New) [2025/12/09] 🎬 [LongSANA](https://nvlabs.github.io/Sana/docs/longsana/): 27FPS real-time minute-length video generation model, training and inference code are all released. Thanks to [LongLive Team](https://github.com/NVlabs/LongLive). Refer to: [[Train]](https://nvlabs.github.io/Sana/docs/longsana/#how-to-train) | [[Test]](https://nvlabs.github.io/Sana/docs/longsana/#how-to-inference) | [[Weight]](https://nvlabs.github.io/Sana/docs/model_zoo/#sana-video)
 - (🔥 New) [2025/11/24] 🪶 [Blog](https://hanlab.mit.edu/blog/infinite-context-length-with-global-but-constant-attention-memory): how Causal Linear Attention unlocks infinite context for LLMs and long video generation.
@@ -157,6 +158,7 @@ image[0].save("sana.png")
 - [LoRA / DreamBooth](https://nvlabs.github.io/Sana/docs/sana_lora_dreambooth/)
 - [Quantization (4bit / 8bit)](https://nvlabs.github.io/Sana/docs/4bit_sana/)
 - [ComfyUI](https://nvlabs.github.io/Sana/docs/ComfyUI/comfyui/)
+- [SGLang](https://nvlabs.github.io/Sana/docs/sglang/)
 
 ## Performance
 

--- a/app/sana_video_refiner_pipeline_diffusers.py
+++ b/app/sana_video_refiner_pipeline_diffusers.py
@@ -1,0 +1,243 @@
+import gc
+from functools import wraps
+
+import fire
+import torch
+from diffusers import FlowMatchEulerDiscreteScheduler, SanaVideoPipeline
+from diffusers.pipelines.ltx2 import LTX2LatentUpsamplePipeline, LTX2Pipeline
+from diffusers.pipelines.ltx2.export_utils import encode_video
+from diffusers.pipelines.ltx2.latent_upsampler import LTX2LatentUpsamplerModel
+from diffusers.pipelines.ltx2.utils import STAGE_2_DISTILLED_SIGMA_VALUES
+from diffusers.utils import export_to_video
+
+
+def cli(func):
+    wraps(func)
+
+    def wrapper(*args, **kwargs):
+        return fire.Fire(func)
+
+    return wrapper
+
+
+@cli
+def sana_video_ltx2_refine(
+    prompt: str = "A cat and a dog baking a cake together in a kitchen. The cat is carefully measuring flour, while the dog is stirring the batter with a wooden spoon. The kitchen is cozy, with sunlight streaming through the window.",
+    negative_prompt: str = "A chaotic sequence with misshapen, deformed limbs in heavy motion blur, sudden disappearance, jump cuts, jerky movements, rapid shot changes, frames out of sync, inconsistent character shapes, temporal artifacts, jitter, and ghosting effects, creating a disorienting visual experience.",
+    sana_model_id: str = "/home/junsongc/junsongc/code/diffusion/Sana/output/Sana_1600M_720px_ltx2_t2v_ltx_resample/checkpoints/sana_ltxvae",
+    ltx2_model_id: str = "Lightricks/LTX-2",
+    sana_height: int = 704,
+    sana_width: int = 1280,
+    sana_frames: int = 81,
+    motion_score: int = 30,
+    sana_guidance_scale: float = 6.0,
+    sana_num_steps: int = 50,
+    frame_rate: float = 16.0,
+    seed: int = 42,
+    output_path: str = "sana_ltx2_refined.mp4",
+    save_sana_output: str = "sana_original.mp4",
+    skip_audio: bool = True,
+    skip_upsampler: bool = True,
+):
+    """
+    Use SanaVideoPipeline to generate video latent, then use LTX2 Pipeline for Stage-2 refinement.
+
+    Key technical points:
+    1. Manually pack video latent to skip diffusers' normalize step (consistent with original LTX-2 code)
+    2. Create audio latent such that it becomes zero after normalize (consistent with zero audio latent in original code)
+    """
+
+    device = "cuda"
+    dtype = torch.bfloat16
+
+    # Step 1: Generate latent using Sana Video Pipeline
+    sana_pipe = SanaVideoPipeline.from_pretrained(sana_model_id, torch_dtype=dtype)
+    sana_pipe.text_encoder.to(dtype)
+    sana_pipe.enable_model_cpu_offload(gpu_id=0)
+
+    full_prompt = prompt + f" motion score: {motion_score}."
+    generator = torch.Generator(device=device).manual_seed(seed)
+
+    sana_output = sana_pipe(
+        prompt=full_prompt,
+        negative_prompt=negative_prompt,
+        height=sana_height,
+        width=sana_width,
+        frames=sana_frames,
+        guidance_scale=sana_guidance_scale,
+        num_inference_steps=sana_num_steps,
+        generator=generator,
+        output_type="latent",
+        return_dict=True,
+    )
+
+    # Extract video latent
+    video_latent = None
+    for key in ("latents", "video_latents", "latent", "dit_latents", "dit_latent", "frames", "videos"):
+        if hasattr(sana_output, key):
+            video_latent = getattr(sana_output, key)
+            if video_latent is not None:
+                break
+
+    if video_latent is None:
+        raise ValueError("Failed to extract latents from Sana output.")
+    if isinstance(video_latent, (list, tuple)):
+        video_latent = video_latent[0]
+    if video_latent.dim() == 4:
+        video_latent = video_latent.unsqueeze(0)
+
+    del sana_pipe, sana_output
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    # Step 2: Load LTX2 Pipeline
+    ltx2_pipe = LTX2Pipeline.from_pretrained(ltx2_model_id, torch_dtype=dtype)
+
+    # Save Sana original output
+    if save_sana_output:
+        ltx2_pipe.vae.to(device)
+        ltx2_pipe.vae.enable_tiling(
+            tile_sample_min_height=512,
+            tile_sample_min_width=512,
+            tile_sample_stride_height=448,
+            tile_sample_stride_width=448,
+        )
+
+        sana_latent_for_decode = video_latent.to(device=device, dtype=ltx2_pipe.vae.dtype)
+        latents_mean = ltx2_pipe.vae.latents_mean.view(1, -1, 1, 1, 1).to(
+            sana_latent_for_decode.device, sana_latent_for_decode.dtype
+        )
+        latents_std = ltx2_pipe.vae.latents_std.view(1, -1, 1, 1, 1).to(
+            sana_latent_for_decode.device, sana_latent_for_decode.dtype
+        )
+        sana_latent_denorm = sana_latent_for_decode * latents_std / ltx2_pipe.vae.config.scaling_factor + latents_mean
+
+        timestep = (
+            None
+            if not ltx2_pipe.vae.config.timestep_conditioning
+            else torch.tensor([0.0], device=device, dtype=sana_latent_denorm.dtype)
+        )
+        with torch.no_grad():
+            sana_decoded = ltx2_pipe.vae.decode(sana_latent_denorm, timestep, return_dict=False)[0]
+
+        del sana_latent_for_decode, sana_latent_denorm
+        sana_video = ltx2_pipe.video_processor.postprocess_video(sana_decoded, output_type="pil")
+        export_to_video(sana_video[0], save_sana_output, fps=int(frame_rate))
+
+        del sana_decoded, sana_video
+        ltx2_pipe.vae.to("cpu")
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    ltx2_pipe.enable_model_cpu_offload(gpu_id=0)
+
+    # Latent Upsampler (optional)
+    if skip_upsampler:
+        print("Skipping latent upsampler")
+        upscaled_video_latent = video_latent.to(device=device, dtype=dtype)
+    else:
+        latent_upsampler = LTX2LatentUpsamplerModel.from_pretrained(
+            ltx2_model_id, subfolder="latent_upsampler", torch_dtype=dtype
+        )
+        upsample_pipe = LTX2LatentUpsamplePipeline(vae=ltx2_pipe.vae, latent_upsampler=latent_upsampler)
+        upsample_pipe.enable_model_cpu_offload(device=device)
+
+        upscaled_video_latent = upsample_pipe(
+            latents=video_latent.to(device=device, dtype=dtype),
+            latents_normalized=True,
+            height=sana_height,
+            width=sana_width,
+            num_frames=sana_frames,
+            output_type="latent",
+            return_dict=False,
+        )[0]
+
+        latents_mean = ltx2_pipe.vae.latents_mean.view(1, -1, 1, 1, 1).to(
+            upscaled_video_latent.device, upscaled_video_latent.dtype
+        )
+        latents_std = ltx2_pipe.vae.latents_std.view(1, -1, 1, 1, 1).to(
+            upscaled_video_latent.device, upscaled_video_latent.dtype
+        )
+        scaling_factor = ltx2_pipe.vae.config.scaling_factor
+        upscaled_video_latent = (upscaled_video_latent - latents_mean) * scaling_factor / latents_std
+
+        del latent_upsampler, upsample_pipe
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    # Step 3: Manually pack video latent (skip diffusers' normalize, consistent with original code)
+    packed_video_latent = LTX2Pipeline._pack_latents(
+        upscaled_video_latent,
+        patch_size=ltx2_pipe.transformer_spatial_patch_size,
+        patch_size_t=ltx2_pipe.transformer_temporal_patch_size,
+    )
+
+    _, _, latent_num_frames, latent_height, latent_width = upscaled_video_latent.shape
+    pixel_height = latent_height * ltx2_pipe.vae_spatial_compression_ratio
+    pixel_width = latent_width * ltx2_pipe.vae_spatial_compression_ratio
+    pixel_num_frames = (latent_num_frames - 1) * ltx2_pipe.vae_temporal_compression_ratio + 1
+
+    # Step 4: Create audio latent (becomes zero after normalize, consistent with original code)
+    num_frames_pixel = (latent_num_frames - 1) * 8 + 1
+    duration_s = num_frames_pixel / frame_rate
+    audio_num_frames = round(duration_s * 16000 / 160 / 4)
+
+    num_channels_audio, latent_mel_bins = 8, 16
+    audio_latents_mean = ltx2_pipe.audio_vae.latents_mean
+    packed_audio_latent = (
+        audio_latents_mean.unsqueeze(0)
+        .unsqueeze(0)
+        .expand(1, audio_num_frames, num_channels_audio * latent_mel_bins)
+        .to(dtype=dtype, device=device)
+        .contiguous()
+    )
+    audio_latent = (
+        packed_audio_latent.unflatten(2, (num_channels_audio, latent_mel_bins)).permute(0, 2, 1, 3).contiguous()
+    )
+
+    del video_latent, upscaled_video_latent
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    # Step 5: LTX2 Stage-2 Refinement
+    ltx2_pipe.load_lora_weights(
+        ltx2_model_id, adapter_name="stage_2_distilled", weight_name="ltx-2-19b-distilled-lora-384.safetensors"
+    )
+    ltx2_pipe.set_adapters("stage_2_distilled", 1.0)
+    ltx2_pipe.vae.enable_tiling()
+    ltx2_pipe.scheduler = FlowMatchEulerDiscreteScheduler.from_config(
+        ltx2_pipe.scheduler.config,
+        use_dynamic_shifting=False,
+        shift_terminal=None,
+    )
+
+    generator = torch.Generator(device=device).manual_seed(seed)
+    video, audio = ltx2_pipe(
+        latents=packed_video_latent,
+        audio_latents=audio_latent,
+        prompt=prompt,
+        negative_prompt=negative_prompt,
+        height=pixel_height,
+        width=pixel_width,
+        num_frames=pixel_num_frames,
+        num_inference_steps=3,
+        noise_scale=STAGE_2_DISTILLED_SIGMA_VALUES[0],
+        sigmas=STAGE_2_DISTILLED_SIGMA_VALUES,
+        guidance_scale=1.0,
+        frame_rate=frame_rate,
+        generator=generator,
+        output_type="np",
+        return_dict=False,
+    )
+
+    # Step 6: Save output
+    video = (video * 255).round().astype("uint8")
+    video = torch.from_numpy(video)
+    encode_video(
+        video[0],
+        fps=frame_rate,
+        audio=None if skip_audio else audio[0].float().cpu(),
+        audio_sample_rate=None if skip_audio else ltx2_pipe.vocoder.config.output_sampling_rate,
+        output_path=output_path,
+    )
+    print(f"Done! Output saved to: {output_path}")

--- a/asset/docs/sana_video.md
+++ b/asset/docs/sana_video.md
@@ -26,14 +26,14 @@
 
 ## 📽️ About SANA-Video
 
-**SANA-Video** is a small diffusion model designed for **efficient video generation**, capable of synthesizing high-resolution videos (up to $720 \\times 1280$) and **minute-length duration** with strong text-video alignment, while maintaining a remarkably fast speed.It enables low-cost, high-quality video generation and can be deployed efficiently on consumer GPUs like the RTX 5090.
+**SANA-Video** is a small diffusion model designed for **efficient video generation**, capable of synthesizing high-resolution videos (up to 720 x 1280) and **minute-length duration** with strong text-video alignment, while maintaining a remarkably fast speed.It enables low-cost, high-quality video generation and can be deployed efficiently on consumer GPUs like the RTX 5090.
 
 SANA-Video's Core Contributions:
 
 - **Efficient Architecture (Linear DiT)**: Leverages **linear attention** as the core operation, which is significantly more efficient than vanilla attention for video generation due to the large number of tokens processed.
 - **Long-Sequence Capability (Constant-Memory KV Cache)**: Introduces a **Constant-Memory KV cache for Block Linear Attention**. This block-wise autoregressive approach uses a fixed-memory state derived from the cumulative properties of linear attention, which eliminates the need for a traditional KV cache, enabling **efficient minute-long video generation**.
 - **Low Training Cost**: Achieved effective data filters and model training strategies, narrowing the training cost to only **12 days on 64 H100 GPUs**, which is just **1%** of the cost of MovieGen.
-- **State-of-the-Art Speed and Performance**: Achieves competitive performance compared to modern SOTA small diffusion models (e.g., Wan 2.1-1.3B) while being **$16\\times$ faster** in measured latency。Deployment Acceleration: Can be deployed on RTX 5090 GPUs with NVFP4 precision, accelerating the inference speed of generating a 5-second 720p video from 71s to 29s (**$2.4\\times$ speedup**).
+- **State-of-the-Art Speed and Performance**: Achieves competitive performance compared to modern SOTA small diffusion models (e.g., Wan 2.1-1.3B) while being **16x faster** in measured latency。Deployment Acceleration: Can be deployed on RTX 5090 GPUs with NVFP4 precision, accelerating the inference speed of generating a 5-second 720p video from 71s to 29s (**2.4x speedup**).
 
 In summary, SANA-Video enables high-quality video synthesis at an unmatched speed and low operational cost.
 

--- a/configs/sana_video_config/Sana_2000M_720px_ltx2vae_AdamW_fsdp.yaml
+++ b/configs/sana_video_config/Sana_2000M_720px_ltx2vae_AdamW_fsdp.yaml
@@ -1,0 +1,153 @@
+task: t2v
+data:
+  data_dir:
+    video_toy_data: data/video_toy_data
+  external_caption_suffixes: [_Qwen2.5-VL]
+  caption_proportion:
+    prompt: 5
+    _Qwen2_5-VL: 95
+  external_data_filter:
+    video_toy_data:
+      _unimatch: {min: 1.0, max: 30}
+  image_size: 720
+  aspect_ratio_type: ASPECT_RATIO_VIDEO_720_MS_DIV32
+  motion_score_cal_type: average # average, max
+  motion_score_file_thres:
+    _unimatch: null
+  load_text_feat: false
+  load_vae_feat: false
+  transform: default_train_video
+  type: SanaZipDataset
+  num_frames: 81
+  sort_dataset: false
+  resample_fps: false
+  shuffle_dataset: false
+image_data:
+  data_dir:
+    - data/toy_data
+  image_size: 720
+  external_caption_suffixes: []
+  caption_selection_type: proportion
+  caption_proportion:
+    prompt: 1
+  clip_thr_temperature: 0.1
+  clip_thr: 25.0
+  del_img_clip_thr: 22.0
+  load_text_feat: false
+  load_vae_feat: false
+  transform: default_train
+  type: SanaWebDatasetMS
+  aspect_ratio_type: ASPECT_RATIO_VIDEO_720_MS_DIV32
+  sort_dataset: false
+# model config
+model:
+  model: SanaMSVideo_2000M_P1_D20
+  image_size: 720
+  mixed_precision: bf16
+  fp32_attention: true
+  load_from: hf://Efficient-Large-Model/SANA-Video_2B_480p/checkpoints/SANA_Video_2B_480p.pth
+  aspect_ratio_type: ASPECT_RATIO_VIDEO_720_MS_DIV32
+  multi_scale: true
+  attn_type: LiteLAReLURope
+  linear_head_dim: 112
+  ffn_type: GLUMBConvTemp
+  t_kernel_size: 3
+  mlp_acts:
+    - silu
+    - silu
+    -
+  mlp_ratio: 3
+  use_pe: true
+  pos_embed_type: wan_rope
+  qk_norm: true
+  cross_norm: true
+  class_dropout_prob: 0.1
+  # remove_state_dict_keys:
+  #   - x_embedder.proj.weight
+  #   - x_embedder.proj.bias
+  #   - final_layer.linear.weight
+  #   - final_layer.linear.bias
+# VAE setting
+vae:
+  vae_type: LTX2VAE_diffusers
+  vae_pretrained: Lightricks/LTX-2
+  weight_dtype: bfloat16
+  vae_latent_dim: 128
+  vae_downsample_rate: 32
+  vae_stride:
+    - 8
+    - 32
+    - 32
+  if_cache: false
+# text encoder
+text_encoder:
+  text_encoder_name: gemma-2-2b-it
+  y_norm: true
+  y_norm_scale_factor: 0.01
+  model_max_length: 300
+  # CHI
+  chi_prompt:
+    - 'Given a user prompt, generate an "Enhanced prompt" that provides detailed visual descriptions suitable for image generation. Evaluate the level of detail in the user prompt:'
+    - '- If the prompt is simple, focus on adding specifics about colors, shapes, sizes, textures, and spatial relationships to create vivid and concrete scenes.'
+    - '- If the prompt is already detailed, refine and enhance the existing details slightly without overcomplicating.'
+    - 'Here are examples of how to transform or refine prompts:'
+    - '- User Prompt: A cat sleeping -> Enhanced: A small, fluffy white cat curled up in a round shape, sleeping peacefully on a warm sunny windowsill, surrounded by pots of blooming red flowers.'
+    - '- User Prompt: A busy city street -> Enhanced: A bustling city street scene at dusk, featuring glowing street lamps, a diverse crowd of people in colorful clothing, and a double-decker bus passing by towering glass skyscrapers.'
+    - 'Please generate only the enhanced description for the prompt below and avoid including any additional commentary or evaluations:'
+    - 'User Prompt: '
+# Sana schedule Flow
+scheduler:
+  predict_flow_v: true
+  noise_schedule: linear_flow
+  pred_sigma: false
+  flow_shift: 3.0
+  inference_flow_shift: 8.0
+  # logit-normal timestep
+  weighting_scheme: logit_normal
+  logit_mean: 0.0
+  logit_std: 1.0
+  vis_sampler: flow_dpm-solver
+# training setting
+train:
+  use_fsdp: true
+  num_workers: 10
+  seed: 1
+  train_batch_size: 1
+  train_batch_size_image: 4
+  num_epochs: 10
+  gradient_accumulation_steps: 1
+  grad_checkpointing: true
+  gradient_clip: 0.1
+  optimizer:
+    betas:
+      - 0.9
+      - 0.999
+    eps: 1.0e-10
+    lr: 5.0e-5
+    type: AdamW
+    weight_decay: 0.0
+  auto_lr: null
+  lr_schedule: constant
+  lr_schedule_args:
+    num_warmup_steps: 500
+  local_save_vis: true # if save log image locally
+  visualize: true
+  deterministic_validation: false
+  eval_sampling_steps: 500
+  log_interval: 5
+  save_model_epochs: 5
+  save_model_steps: 500
+  work_dir: output/debug
+  online_metric: false
+  eval_metric_step: 2000
+  online_metric_dir: metric_helper
+  validation_prompts:
+    - the opening scene begins with a dynamic view of a bustling cityscape captured in vibrant detail. towering skyscrapers dominate the skyline, while the streets below are alive with motion. people from diverse cultures fill the sidewalks, engaging in daily activities, their vibrant attire adding splashes of color to the scene. vehicles, including cars and buses, weave through the busy roads in a synchronized rhythm. bright billboards in various languages flash advertisements, reflecting the multicultural essence of the city. thecamera smoothly pans upward from the busy streets to focus on a sleek, modern office building. its reflective glass facade shimmers in the sunlight, hinting at its importance as a central location in the story. the atmosphere is energetic and cosmopolitan, setting the stage for an international narrative.
+    - a dark fantasy scene unfolds, captured with a 1980's film grain aesthetic that imbues the frame with a nostalgic, cinematic quality. the shot focuses on a cloaked woman in flowing, pale robes, standing eerily motionless outside a towering, rustic library. the intricate, gothic architecture of the library is illuminated by dim, flickering lanterns, casting dancing shadows across its arched windows and weathered stone fa_ade. the woman's hood obscures her face, her identity hidden, while her presence radiates an aura of magic and mystery. her unnaturally still posture increases the tension, with a single, deliberate gesture - a silent beckoning towards the library - drawing all attention. the surrounding cityscape, cloaked in the inky tones of night, features cobblestone streets and shadowy, weathered buildings, creating a setting that feels both hauntingly lived-in and enchantingly otherworldly.
+    - a large, modern office building dominates the frame, standing tall against a clear blue sky. the str ucture is sleek, with an exterior made primarily of glass and steel that reflects the sunlight in sharp, clean lines. the surrounding area includes a few scattered trees and a wide, open plaza with smooth paving, creating a sense of tranquility and order. the setting is serene and calm, with no people visible, emphasizing the stillness of the moment. the atmosphere feels pristine and meticulously maintained, as the building towers above the peaceful setting.
+    - the image quality is sharp with high dynamic range, capturing the vastness and beauty of the Chilean Andes. a majestic condor soars through the skies, its wide wings cutting across the clear blue expanse. below, a small pudmoves quietly through the thick foliage of a nearby forest. the camera angle gradually rises, expanding the frame to reveal an advanced mining project nestled within the landscape. the mining site, with its technology and industrial activity, contrasts yet integrates with the natural beauty, symbolizing progress and sustainability.
+    - a soft-focus view captures a serene garden, filled with cherry blossom trees in bloom. at the center stands a beautiful japanese woman, portrayed in exquisite detail, wearing a traditional kimono with intricate floral patterns in soft pastel colors. her long, dark hair cascades elegantly down her back, enhancing her gentle, serene expression. pink petals drift down in a light breeze, adding to the garden's ethereal ambiance. sunlight filters through the leafy canopy, casting dappled shadows that dance around her, subtly highlighting her serene posture and the details of her kimono. the atmosphere is tranquil and picturesque, enveloped in a sense of timeless beauty.
+    - the angle is mid-range, focusing on the well-dressed asian male friend sitting comfortably in a modern and stylish cafe. the setting exudes warmth and elegance, with soft music playing in the background to create an inviting atmosphere. the man holds a small gift box in his hand, his face illuminated by a confident smile as he looks around, his expression full of anticipation. his attire, a blend of classic and contemporary style, complements the chic surroundings, enhancing his poised demeanor. the ambient lighting accentuates his features, making the scene lively and intimate.
+    - the setting is a training facility, brightly lit with mirrored walls and sprung wooden floors. the scene starts with the camera panning slowly over the room, capturing the boundless determination in action as a group of korean girls rigorously practice their moves. each one is focused, their expressions marked by the intensity of a long and arduous journey. they are seen rehearsing complex choreography, with synchronized steps and practiced precision. alongside the strenuous physical training, snippets of their vocal lessons are interwoven, illustrating the multifaceted preparation involved. the atmosphere is one of dedication and discipline, reflected in their commitment to rigorous exercise and strict dietary habits. these scenes provide a glimpse into the grueling yet passionate pursuit of their dreams.
+    - astronaut is riding a horse on the moon, wearing a space suit and helmet. the horse is galloping across the lunar surface, leaving behind a trail of moon dust. in the background, earth is visible in the black sky, a beautiful blue and green marble. the astronaut is holding a flag with a logo on it, waving it proudly as they ride. the scene is surreal and whimsical, capturing the imagination of space exploration and adventure.
+  joint_training_interval: 0

--- a/docs/sana_video.md
+++ b/docs/sana_video.md
@@ -26,14 +26,14 @@
 
 ## 📽️ About SANA-Video
 
-**SANA-Video** is a small diffusion model designed for **efficient video generation**, capable of synthesizing high-resolution videos (up to $720 \\times 1280$) and **minute-length duration** with strong text-video alignment, while maintaining a remarkably fast speed.It enables low-cost, high-quality video generation and can be deployed efficiently on consumer GPUs like the RTX 5090.
+**SANA-Video** is a small diffusion model designed for **efficient video generation**, capable of synthesizing high-resolution videos (up to 720 x 1280) and **minute-length duration** with strong text-video alignment, while maintaining a remarkably fast speed.It enables low-cost, high-quality video generation and can be deployed efficiently on consumer GPUs like the RTX 5090.
 
 SANA-Video's Core Contributions:
 
 - **Efficient Architecture (Linear DiT)**: Leverages **linear attention** as the core operation, which is significantly more efficient than vanilla attention for video generation due to the large number of tokens processed.
 - **Long-Sequence Capability (Constant-Memory KV Cache)**: Introduces a **Constant-Memory KV cache for Block Linear Attention**. This block-wise autoregressive approach uses a fixed-memory state derived from the cumulative properties of linear attention, which eliminates the need for a traditional KV cache, enabling **efficient minute-long video generation**.
 - **Low Training Cost**: Achieved effective data filters and model training strategies, narrowing the training cost to only **12 days on 64 H100 GPUs**, which is just **1%** of the cost of MovieGen.
-- **State-of-the-Art Speed and Performance**: Achieves competitive performance compared to modern SOTA small diffusion models (e.g., Wan 2.1-1.3B) while being **$16\\times$ faster** in measured latency。Deployment Acceleration: Can be deployed on RTX 5090 GPUs with NVFP4 precision, accelerating the inference speed of generating a 5-second 720p video from 71s to 29s (**$2.4\\times$ speedup**).
+- **State-of-the-Art Speed and Performance**: Achieves competitive performance compared to modern SOTA small diffusion models (e.g., Wan 2.1-1.3B) while being **16x faster** in measured latency。Deployment Acceleration: Can be deployed on RTX 5090 GPUs with NVFP4 precision, accelerating the inference speed of generating a 5-second 720p video from 71s to 29s (**2.4x speedup**).
 
 In summary, SANA-Video enables high-quality video synthesis at an unmatched speed and low operational cost.
 

--- a/docs/sglang.md
+++ b/docs/sglang.md
@@ -1,0 +1,167 @@
+<p align="center" style="border-radius: 10px">
+  <img src="https://raw.githubusercontent.com/NVlabs/Sana/refs/heads/main/asset/logo.png" width="40%" alt="Sana Logo"/>
+</p>
+
+# 🚀 SGLang: High-Performance Serving for SANA
+
+<div align="center">
+  <a href="https://github.com/sgl-project/sglang"><img src="https://img.shields.io/static/v1?label=Project&message=SGLang&color=blue&logo=github"></a> &ensp;
+  <a href="https://github.com/NVlabs/Sana"><img src="https://img.shields.io/static/v1?label=Project&message=Sana&color=blue&logo=github-pages"></a> &ensp;
+</div>
+
+[SGLang](https://github.com/sgl-project/sglang) is an inference framework for accelerated image/video generation. SANA models are natively supported in SGLang, providing high-performance serving with OpenAI-compatible API, CLI, and Python SDK.
+
+## Supported Models
+
+| Model | HuggingFace ID |
+|-------|----------------|
+| Sana 0.6B (512px) | `Efficient-Large-Model/Sana_600M_512px_diffusers` |
+| Sana 0.6B (1024px) | `Efficient-Large-Model/Sana_600M_1024px_diffusers` |
+| Sana 1.6B (512px) | `Efficient-Large-Model/Sana_1600M_512px_diffusers` |
+| Sana 1.6B (1024px) | `Efficient-Large-Model/Sana_1600M_1024px_diffusers` |
+| SANA-1.5 1.6B (1024px) | `Efficient-Large-Model/SANA1.5_1.6B_1024px_diffusers` |
+| SANA-1.5 4.8B (1024px) | `Efficient-Large-Model/SANA1.5_4.8B_1024px_diffusers` |
+
+______________________________________________________________________
+
+## Installation
+
+```bash
+uv pip install 'sglang[diffusion]' --prerelease=allow
+```
+
+For more installation methods (e.g. Docker, ROCm/AMD), check the [SGLang installation guide](https://github.com/sgl-project/sglang/tree/main/docs/diffusion/installation.md).
+
+______________________________________________________________________
+
+## Quick Start
+
+### 1. CLI
+
+The simplest way to generate an image:
+
+```bash
+sglang generate \
+    --model-path Efficient-Large-Model/SANA1.5_1.6B_1024px_diffusers \
+    --prompt 'a cyberpunk cat with a neon sign that says "Sana"' \
+    --save-output
+```
+
+### 2. Python SDK
+
+```python
+from sglang.multimodal_gen import DiffGenerator
+
+generator = DiffGenerator.from_pretrained(
+    model_path="Efficient-Large-Model/SANA1.5_1.6B_1024px_diffusers",
+    num_gpus=1,
+)
+
+image = generator.generate(
+    sampling_params_kwargs=dict(
+        prompt='a cyberpunk cat with a neon sign that says "Sana"',
+        height=1024,
+        width=1024,
+        num_inference_steps=20,
+        guidance_scale=4.5,
+        seed=42,
+        save_output=True,
+        output_path="outputs/",
+    )
+)
+```
+
+______________________________________________________________________
+
+## Server Mode (OpenAI-Compatible API)
+
+### Launch the Server
+
+```bash
+sglang serve --model-path Efficient-Large-Model/SANA1.5_1.6B_1024px_diffusers \
+    --host 0.0.0.0 --port 30000
+```
+
+### Send Requests
+
+Once the server is running, use the OpenAI-compatible image generation API:
+
+```python
+import requests
+
+response = requests.post(
+    "http://127.0.0.1:30000/v1/images/generations",
+    json={
+        "prompt": 'a cyberpunk cat with a neon sign that says "Sana"',
+        "size": "1024x1024",
+        "num_inference_steps": 20,
+        "guidance_scale": 4.5,
+        "seed": 42,
+        "response_format": "b64_json",
+        "n": 1,
+    },
+)
+
+result = response.json()
+```
+
+______________________________________________________________________
+
+## Memory Optimization
+
+For GPUs with limited VRAM, SGLang provides CPU offloading options:
+
+```bash
+sglang generate \
+    --model-path Efficient-Large-Model/SANA1.5_1.6B_1024px_diffusers \
+    --text-encoder-cpu-offload \
+    --vae-cpu-offload \
+    --pin-cpu-memory \
+    --prompt "A beautiful landscape" \
+    --save-output
+```
+
+| Option | Description |
+|--------|-------------|
+| `--dit-cpu-offload` | Offload DiT model to CPU |
+| `--text-encoder-cpu-offload` | Offload text encoder to CPU |
+| `--vae-cpu-offload` | Offload VAE to CPU |
+| `--pin-cpu-memory` | Pin CPU memory for faster transfer |
+
+______________________________________________________________________
+
+## LoRA Support
+
+Apply LoRA adapters during inference:
+
+```bash
+sglang generate \
+    --model-path Efficient-Large-Model/SANA1.5_1.6B_1024px_diffusers \
+    --lora-path <your-lora-path> \
+    --prompt "A beautiful landscape" \
+    --save-output
+```
+
+______________________________________________________________________
+
+## Related
+
+- [SGLang Diffusion Documentation](https://github.com/sgl-project/sglang/tree/main/docs/diffusion)
+- [Model Zoo](model_zoo.md) - All available Sana models
+- [SANA Inference & Training](sana.md) - Native inference pipeline
+
+______________________________________________________________________
+
+## Citation
+
+```bibtex
+@misc{xie2024sana,
+      title={Sana: Efficient High-Resolution Image Synthesis with Linear Diffusion Transformer},
+      author={Enze Xie and Junsong Chen and Junyu Chen and Han Cai and Haotian Tang and Yujun Lin and Zhekai Zhang and Muyang Li and Ligeng Zhu and Yao Lu and Song Han},
+      year={2024},
+      eprint={2410.10629},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV},
+      url={https://arxiv.org/abs/2410.10629},
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
       - LoRA & DreamBooth: sana_lora_dreambooth.md
   - Integrations:
       - ComfyUI: ComfyUI/comfyui.md
+      - SGLang: sglang.md
   - Evaluation:
       - Metrics Toolkit: metrics_toolkit.md
 extra:


### PR DESCRIPTION
[Add Sana Video Refiner Pipeline and LTX2 VAE Configuration](https://github.com/NVlabs/Sana/pull/361/commits/76b05e67e4e7bbc829b01da09311e979ad81406e) 

- Added a new configuration file for the 720p model using LTX2 VAE.
- Updated documentation to include instructions for inference and training with the new 720p model.
- Enhanced the model builder to support LTX2 VAE integration.
- Minor adjustments in training scripts for better compatibility with FSDP settings.

[Add SGLang integration to documentation](https://github.com/NVlabs/Sana/pull/361/commits/29ec44407598ab21457759abba2ce1091dfdf14b)
- Updated mkdocs.yml to include SGLang in the navigation.
- Enhanced README.md with a new link to SGLang and added a news item about SANA's support in SGLang.