### PR TITLE
fix: replace 30 bare excepts with except Exception

### DIFF
--- a/diffusion/data/datasets/sana_data.py
+++ b/diffusion/data/datasets/sana_data.py
@@ -108,7 +108,7 @@ class SanaImgDataset(Dataset):
             if os.path.exists(caption_json_path):
                 try:
                     caption_json = lru_json_load(caption_json_path)
-                except:
+                except Exception:
                     caption_json = {}
                 if self.key in caption_json:
                     info.update(caption_json[self.key])
@@ -186,7 +186,7 @@ class SanaImgDataset(Dataset):
             if os.path.exists(clipscore_json_path):
                 try:
                     clipscore_json = lru_json_load(clipscore_json_path)
-                except:
+                except Exception:
                     clipscore_json = {}
                 if self.key in clipscore_json:
                     clip_scores = clipscore_json[self.key]
@@ -334,7 +334,7 @@ class SanaWebDataset(Dataset):
             if os.path.exists(caption_json_path):
                 try:
                     caption_json = lru_json_load(caption_json_path)
-                except:
+                except Exception:
                     caption_json = {}
                 if self.key in caption_json:
                     info.update(caption_json[self.key])
@@ -411,7 +411,7 @@ class SanaWebDataset(Dataset):
             if os.path.exists(clipscore_json_path):
                 try:
                     clipscore_json = lru_json_load(clipscore_json_path)
-                except:
+                except Exception:
                     clipscore_json = {}
                 if self.key in clipscore_json:
                     clip_scores = clipscore_json[self.key]

--- a/diffusion/data/datasets/sana_data_multi_scale.py
+++ b/diffusion/data/datasets/sana_data_multi_scale.py
@@ -135,7 +135,7 @@ class SanaWebDatasetMS(SanaWebDataset):
             if os.path.exists(caption_json_path):
                 try:
                     caption_json = lru_json_load(caption_json_path)
-                except:
+                except Exception:
                     caption_json = {}
                 if self.key in caption_json:
                     if self.default_prompt in caption_json[self.key]:

--- a/diffusion/data/datasets/video/sana_video_data.py
+++ b/diffusion/data/datasets/video/sana_video_data.py
@@ -302,7 +302,7 @@ class SanaZipDataset(Dataset):
             if os.path.exists(caption_json_path):
                 try:
                     caption_json = SanaZipDataset.lru_json_load(caption_json_path)
-                except:
+                except Exception:
                     caption_json = {}
                 if self.key in caption_json:
                     external_caption_info = caption_json[self.key]

--- a/diffusion/model/builder.py
+++ b/diffusion/model/builder.py
@@ -229,7 +229,7 @@ def vae_encode(name, vae, images, sample_posterior=True, device="cuda", cache_ke
                         with z_vae_cache.open(key + ".npz", "r") as f:
                             z.append(np.load(f)["z"] if "z" in np.load(f) else np.load(f))
                 z = torch.from_numpy(np.stack(z)).to(device)
-        except:
+        except Exception:
             z = None
         if z is None or len(z) == 0:
             z = ae.encode(images.to(device))
@@ -248,7 +248,7 @@ def vae_encode(name, vae, images, sample_posterior=True, device="cuda", cache_ke
                         np.savez_compressed(f, z=z[i].float().cpu().numpy())  # bf16 not support for cpu
                         try:
                             os.link(f.name, cf)
-                        except:
+                        except Exception:
                             pass
     elif "AutoencoderDC" in name:
         ae = vae
@@ -279,7 +279,7 @@ def vae_encode(name, vae, images, sample_posterior=True, device="cuda", cache_ke
                         with z_vae_cache.open(key + ".npz", "r") as f:
                             z.append(np.load(f)["z"] if "z" in np.load(f) else np.load(f))
                 z = [torch.from_numpy(_z).to(device) for _z in z]
-        except:
+        except Exception:
             z = None
 
         if z is None or len(z) == 0:
@@ -295,7 +295,7 @@ def vae_encode(name, vae, images, sample_posterior=True, device="cuda", cache_ke
                         np.savez_compressed(f, z=z[i].float().cpu().numpy())  # bf16 not support for cpu
                         try:
                             os.link(f.name, cf)
-                        except:
+                        except Exception:
                             pass
 
         z = torch.stack(z, dim=0)

--- a/diffusion/model/dpm_solver.py
+++ b/diffusion/model/dpm_solver.py
@@ -407,7 +407,7 @@ def model_wrapper(
             _, sigma_t = noise_schedule.marginal_alpha(t_continuous), noise_schedule.marginal_std(t_continuous)
             try:
                 noise = (1 - expand_dims(sigma_t, x.ndim - sigma_t.ndim + 1).to(x)) * output + x
-            except:
+            except Exception:
                 noise = (1 - expand_dims(sigma_t, x.ndim - sigma_t.ndim + 1).to(x)) * output[0] + x
 
             return noise
@@ -422,7 +422,7 @@ def model_wrapper(
             _, sigma_t = noise_schedule.marginal_alpha(t_continuous), noise_schedule.marginal_std(t_continuous)
             try:
                 x0 = x - expand_dims(sigma_t, x.ndim - sigma_t.ndim + 1).to(x) * output
-            except:
+            except Exception:
                 x0 = x - expand_dims(sigma_t, x.ndim - sigma_t.ndim + 1).to(x) * output[0]
 
             return {"x0": x0, "model_output": output}
@@ -479,7 +479,7 @@ def model_wrapper(
                     c_in = torch.cat([unconditional_condition, condition])
                 try:
                     noise_uncond, noise = noise_pred_fn(x_in, t_in, cond=c_in).chunk(2)
-                except:
+                except Exception:
                     noise_uncond, noise = noise_pred_fn(x_in, t_in, cond=c_in)[0].chunk(2)
 
                 return noise_uncond + guidance_scale * (noise - noise_uncond)
@@ -506,7 +506,7 @@ def model_wrapper(
 
             try:
                 chunks = noise_pred_fn(x_in, t_in, cond=c_in).chunk(num_inputs)
-            except:
+            except Exception:
                 chunks = noise_pred_fn(x_in, t_in, cond=c_in)[0].chunk(num_inputs)
 
             if guidance_scale == 1.0:
@@ -542,7 +542,7 @@ def model_wrapper(
 
                 try:
                     noise_uncond, noise = noise_pred_fn(x_in, t_in, cond=c_in).chunk(2)
-                except:
+                except Exception:
                     noise_uncond, noise = noise_pred_fn(x_in, t_in, cond=c_in)[0].chunk(num_inputs)
                 return noise_uncond + guidance_scale * (noise - noise_uncond)
             else:
@@ -566,7 +566,7 @@ def model_wrapper(
 
                 try:
                     noise_uncond, noise, noise_perturb = noise_pred_fn(x_in, t_in, cond=c_in).chunk(3)
-                except:
+                except Exception:
                     noise_uncond, noise, noise_perturb = noise_pred_fn(x_in, t_in, cond=c_in)[0].chunk(3)
 
                 for i in pag_applied_layers:
@@ -590,7 +590,7 @@ def model_wrapper(
                 model_output = output["model_output"]
                 try:
                     x0_uncond, x0 = output["x0"].chunk(2)
-                except:
+                except Exception:
                     x0_uncond, x0 = output["x0"][0].chunk(2)
 
                 x0 = apg(x0, x0_uncond)[0]
@@ -606,7 +606,7 @@ def model_wrapper(
 
             try:
                 chunks = noise_pred_fn(x_in, t_in, cond=c_in).chunk(num_inputs)
-            except:
+            except Exception:
                 chunks = noise_pred_fn(x_in, t_in, cond=c_in)[0].chunk(num_inputs)
             for i in stg_applied_layers:
                 if isinstance(model, torch.nn.Module):
@@ -622,7 +622,7 @@ def model_wrapper(
                     model_kwargs["mask"] = mask[x.shape[0] :]
             try:
                 noise_perturb = noise_pred_fn(x, t_continuous, cond=condition[None])
-            except:
+            except Exception:
                 noise_perturb = noise_pred_fn(x, t_continuous, cond=condition[None])[0]
 
             model_kwargs = model_kwargs_ori
@@ -774,7 +774,7 @@ class DPM_Solver:
         if hasattr(self, "progress_fn"):
             try:
                 self.progress_fn(step / total_steps, desc=f"Generating {step}/{total_steps}")
-            except:
+            except Exception:
                 self.progress_fn(step, total_steps)
 
         else:

--- a/diffusion/model/wan/model.py
+++ b/diffusion/model/wan/model.py
@@ -1085,7 +1085,7 @@ class WanModel(ModelMixin, ConfigMixin):
                 try:
                     self.get_parameter(name)
                     exists = True
-                except:
+                except Exception:
                     exists = False
                 if exists:
                     # get device and dtype of the parameter

--- a/diffusion/utils/checkpoint.py
+++ b/diffusion/utils/checkpoint.py
@@ -354,7 +354,7 @@ def load_checkpoint_fsdp(
         # Load metadata to get video_step and image_step
         try:
             metadata = torch.load(os.path.join(checkpoint, "metadata.pth"), map_location="cpu")
-        except:
+        except Exception:
             metadata = {}
 
     if remove_state_dict_keys is None:

--- a/diffusion/utils/data_sampler.py
+++ b/diffusion/utils/data_sampler.py
@@ -74,7 +74,7 @@ class AspectRatioBatchSampler(BatchSampler):
             logger.info(f"Loading cached file for multi-scale training: {cache_file}")
             try:
                 self.cached_idx = json.load(open(cache_file))
-            except:
+            except Exception:
                 logger.info(f"Failed loading: {cache_file}")
                 self.cached_idx = {}
         else:

--- a/train_scripts/train.py
+++ b/train_scripts/train.py
@@ -995,7 +995,7 @@ def main(cfg: SanaConfig) -> None:
         tracker_config = dict(vars(config))
         try:
             accelerator.init_trackers(args.tracker_project_name, tracker_config)
-        except:
+        except Exception:
             accelerator.init_trackers(f"tb_{timestamp}")
 
     start_epoch = 0
@@ -1042,7 +1042,7 @@ def main(cfg: SanaConfig) -> None:
         try:
             start_epoch = int(path.replace(".pth", "").split("_")[1]) - 1
             start_step = int(path.replace(".pth", "").split("_")[3])
-        except:
+        except Exception:
             pass
 
     # 8. Prepare everything

--- a/train_scripts/train_scm_ladd.py
+++ b/train_scripts/train_scm_ladd.py
@@ -1430,7 +1430,7 @@ def main(cfg: SanaConfig) -> None:
         try:
             start_epoch = int(path.replace(".pth", "").split("_")[1]) - 1
             start_step = int(path.replace(".pth", "").split("_")[3])
-        except:
+        except Exception:
             pass
 
     if config.model.teacher_model is not None:

--- a/train_video_scripts/train_video_ivjoint.py
+++ b/train_video_scripts/train_video_ivjoint.py
@@ -1239,7 +1239,7 @@ def main(cfg: SanaVideoConfig) -> None:
         tracker_config = dict(vars(config))
         try:
             accelerator.init_trackers(args.tracker_project_name, tracker_config)
-        except:
+        except Exception:
             accelerator.init_trackers(f"tb_{timestamp}")
 
     start_epoch = 0
@@ -1299,7 +1299,7 @@ def main(cfg: SanaVideoConfig) -> None:
         try:
             start_epoch = int(path.replace(".pth", "").split("_")[1]) - 1
             start_step = int(path.replace(".pth", "").split("_")[3])
-        except:
+        except Exception:
             pass
 
         # Set video_step and image_step based on availability

--- a/train_video_scripts/train_video_ivjoint_chunk.py
+++ b/train_video_scripts/train_video_ivjoint_chunk.py
@@ -1411,7 +1411,7 @@ def main(cfg: SanaVideoConfig) -> None:
         tracker_config = dict(vars(config))
         try:
             accelerator.init_trackers(args.tracker_project_name, tracker_config)
-        except:
+        except Exception:
             accelerator.init_trackers(f"tb_{timestamp}")
 
     start_epoch = 0
@@ -1471,7 +1471,7 @@ def main(cfg: SanaVideoConfig) -> None:
         try:
             start_epoch = int(path.replace(".pth", "").split("_")[1]) - 1
             start_step = int(path.replace(".pth", "").split("_")[3])
-        except:
+        except Exception:
             pass
 
         # Set video_step and image_step based on availability


### PR DESCRIPTION
Replace 30 bare `except:` with `except Exception:` across 12 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors and preventing clean process termination.