### PR TITLE
Add Sol-RL post-training infrastructure

### DIFF
--- a/configs/sol_rl/Sana1.0_1600M_linear.yaml
+++ b/configs/sol_rl/Sana1.0_1600M_linear.yaml
@@ -1,0 +1,106 @@
+data:
+  data_dir: [data/toy_data]
+  image_size: 1024
+  caption_proportion:
+    prompt: 1
+  external_caption_suffixes: ['', _InternVL2-26B, _InternVL2-8B]
+  external_clipscore_suffixes:
+    - _InternVL2-26B_clip_score
+    - _InternVL2-8B_clip_score
+    - _prompt_clip_score
+  clip_thr_temperature: 0.1
+  clip_thr: 25.0
+  load_text_feat: false
+  load_vae_feat: true
+  transform: default_train
+  type: SanaWebDatasetMS
+  sort_dataset: false
+# model config
+model:
+  model: SanaMSLinear_1600M_P1_D20
+  image_size: 1024
+  mixed_precision: bf16
+  fp32_attention: true
+  load_from: sana10_native_linear.pth
+  resume_from:
+  aspect_ratio_type: ASPECT_RATIO_1024
+  multi_scale: true
+  attn_type: linear
+  ffn_type: glumbconv_linear
+  mlp_acts:
+    - silu
+    - silu
+    -
+  mlp_ratio: 2.5
+  use_pe: false
+  qk_norm: false
+  class_dropout_prob: 0.1
+  pag_applied_layers:
+    - 8
+# VAE setting
+vae:
+  vae_type: AutoencoderDC
+  vae_pretrained: mit-han-lab/dc-ae-f32c32-sana-1.1-diffusers
+  scale_factor: 0.41407
+  vae_latent_dim: 32
+  vae_downsample_rate: 32
+  sample_posterior: true
+# text encoder
+text_encoder:
+  text_encoder_name: gemma-2-2b-it
+  y_norm: true
+  y_norm_scale_factor: 0.01
+  model_max_length: 300
+  chi_prompt:
+    - 'Given a user prompt, generate an "Enhanced prompt" that provides detailed visual descriptions suitable for image generation. Evaluate the level of detail in the user prompt:'
+    - '- If the prompt is simple, focus on adding specifics about colors, shapes, sizes, textures, and spatial relationships to create vivid and concrete scenes.'
+    - '- If the prompt is already detailed, refine and enhance the existing details slightly without overcomplicating.'
+    - 'Here are examples of how to transform or refine prompts:'
+    - '- User Prompt: A cat sleeping -> Enhanced: A small, fluffy white cat curled up in a round shape, sleeping peacefully on a warm sunny windowsill, surrounded by pots of blooming red flowers.'
+    - '- User Prompt: A busy city street -> Enhanced: A bustling city street scene at dusk, featuring glowing street lamps, a diverse crowd of people in colorful clothing, and a double-decker bus passing by towering glass skyscrapers.'
+    - 'Please generate only the enhanced description for the prompt below and avoid including any additional commentary or evaluations:'
+    - 'User Prompt: '
+# Sana schedule Flow
+scheduler:
+  predict_flow_v: true
+  noise_schedule: linear_flow
+  pred_sigma: false
+  flow_shift: 3.0
+  weighting_scheme: logit_normal
+  logit_mean: 0.0
+  logit_std: 1.0
+  vis_sampler: flow_dpm-solver
+  timestep_norm_scale_factor: 0.001
+# training setting
+train:
+  num_workers: 10
+  seed: 1
+  train_batch_size: 64
+  num_epochs: 100
+  gradient_accumulation_steps: 1
+  grad_checkpointing: true
+  gradient_clip: 0.1
+  optimizer:
+    betas:
+      - 0.9
+      - 0.999
+      - 0.9999
+    eps:
+      - 1.0e-30
+      - 1.0e-16
+    lr: 0.0001
+    type: CAMEWrapper
+    weight_decay: 0.0
+  lr_schedule: constant
+  lr_schedule_args:
+    num_warmup_steps: 2000
+  local_save_vis: true
+  visualize: true
+  eval_sampling_steps: 500
+  log_interval: 20
+  save_model_epochs: 5
+  save_model_steps: 500
+  work_dir: output/debug
+  online_metric: false
+  eval_metric_step: 2000
+  online_metric_dir: metric_helper

--- a/configs/sol_rl/base.py
+++ b/configs/sol_rl/base.py
@@ -1,0 +1,128 @@
+import ml_collections
+
+
+def get_config():
+    config = ml_collections.ConfigDict()
+
+    ###### General ######
+    # run name for wandb logging and checkpoint saving -- if not provided, will be auto-generated based on the datetime.
+    config.run_name = ""
+    config.debug = False
+    config.sana_config_file = ""
+
+    # random seed for reproducibility.
+    config.seed = 42
+    # top-level logging directory for checkpoint saving.
+    config.logdir = "logs"
+    # number of epochs to train for. each epoch is one round of sampling from the model followed by training on those
+    # samples.
+    config.num_epochs = 100000
+    # number of epochs between saving model checkpoints.
+    config.save_freq = 5
+    config.eval_freq = 20
+    # mixed precision training. options are "fp16", "bf16", and "no". half-precision speeds up training significantly.
+    config.mixed_precision = "bf16"
+    # allow tf32 on Ampere GPUs, which can speed up training.
+    config.allow_tf32 = True
+    # resume training from a checkpoint. either an exact checkpoint directory (e.g. checkpoint_50), or a directory
+    # containing checkpoints, in which case the latest one will be used. `config.use_lora` must be set to the same value
+    # as the run that generated the saved checkpoint.
+    config.resume_from = None
+    config.resume = False
+    # whether or not to use LoRA.
+    config.use_lora = True
+    config.dataset = ""
+    config.resolution = 768
+
+    ###### Pretrained Model ######
+    config.pretrained = pretrained = ml_collections.ConfigDict()
+    # base model to load. either a path to a local directory, or a model name from the HuggingFace model hub.
+    pretrained.model = ""
+
+    ###### Sampling ######
+    config.sample = sample = ml_collections.ConfigDict()
+    # number of sampler inference steps.
+    sample.num_steps = 40
+    sample.eval_num_steps = 40
+    sample.num_image_per_prompt = 24
+    sample.test_batch_size = 1
+    # noise level
+    sample.noise_level = 1.0
+    # number of best of n samples to select from each prompt
+    sample.best_of_n = 24
+
+    ###### Training ######
+    config.train = train = ml_collections.ConfigDict()
+    # batch size (per GPU!) to use for training.
+    train.batch_size = 1
+    # learning rate.
+    train.learning_rate = 3e-4
+    # Adam beta1.
+    train.adam_beta1 = 0.9
+    # Adam beta2.
+    train.adam_beta2 = 0.999
+    # Adam weight decay.
+    train.adam_weight_decay = 1e-4
+    # Adam epsilon.
+    train.adam_epsilon = 1e-8
+    # number of gradient accumulation steps. the effective batch size is `batch_size * num_gpus *
+    # gradient_accumulation_steps`.
+    train.gradient_accumulation_steps = 1
+    # maximum gradient norm for gradient clipping.
+    train.max_grad_norm = 0.002
+    # number of inner epochs per outer epoch. each inner epoch is one iteration through the data collected during one
+    # outer epoch's round of sampling.
+    train.num_inner_epochs = 1
+    # clip advantages to the range [-adv_clip_max, adv_clip_max].
+    train.adv_clip_max = 5
+    # the fraction of timesteps to train on. if set to less than 1.0, the model will be trained on a subset of the
+    # timesteps for each sample. this will speed up training but reduce the accuracy of policy gradient estimates.
+    train.timestep_fraction = 0.6
+    # kl ratio
+    train.beta = 0.0001
+    # pretrained lora path
+    train.lora_path = None
+    # LoRA hyper-parameters; defaults match current train_nft_sana_baseline_bon.py behavior.
+    train.lora_rank = 32
+    train.lora_alpha = 64
+    train.lora_init_weights = True
+    train.lora_target_modules = None
+    train.ema = True
+
+    ###### Prompt Function ######
+    config.prompt_fn = ""
+
+    ###### Reward Function ######
+    # reward function to use. see `rewards.py` for available reward functions.
+    config.reward_fn = ml_collections.ConfigDict()
+    config.save_dir = ""
+
+    ###### Per-Prompt Stat Tracking ######
+    config.per_prompt_stat_tracking = True
+
+    config.global_std = True
+    config.after_adv = False
+
+    ###### Rollout / Eval / Training Guidance ######
+    config.beta = 1.0
+    config.decay_type = 1
+    config.rollout_sample_guidance_scale = 1.0
+    config.train_sample_guidance_scale = 1.0
+    config.eval_sample_guidance_scale = 1.0
+    config.rollout_sample_num_steps = 10
+    config.preview_step = 0
+    config.sequential_decode = True
+
+    ###### Debug Image ######
+    config.enable_debug_image_save = True
+    config.debug_image_every_steps = 10
+    config.debug_image_subset_size = 6
+
+    ###### Inference Model Mode ######
+    config.compile_mode = "max-autotune-no-cudagraphs"
+    config.preview_model = "peft"
+    config.fullrollout_model = "peft"
+    config.nvfp4_skip_modules = []
+    config.nvfp4_min_dim = 0
+
+    return config

--- a/configs/sol_rl/flux1.py
+++ b/configs/sol_rl/flux1.py
@@ -1,0 +1,248 @@
+import imp
+import os
+
+base = imp.load_source("base", os.path.join(os.path.dirname(__file__), "base.py"))
+
+
+def get_config(name):
+    return globals()[name]()
+
+
+def _get_config(n_gpus=8, dataset="pickscore", reward_fn=None):
+    if reward_fn is None:
+        reward_fn = {"pickscore": 1.0}
+
+    config = base.get_config()
+    config.dataset = os.path.join(os.getcwd(), f"dataset/{dataset}")
+    config.pretrained.model = "black-forest-labs/FLUX.1-dev"
+    config.resolution = 512
+
+    config.train.lora_target_modules = ["to_k", "to_q", "to_v", "to_out.0"]
+    config.train.flux_lora_target_modules = config.train.lora_target_modules
+    config.train.lora_init_mode = "gaussian"
+
+    config.sample.num_steps = 10
+    config.sample.eval_num_steps = 28
+    config.sample.noise_level = 0.7
+    config.sample.solver = "dpm2"
+    config.sample.stage1_select_mode = "best_worst"
+    config.sample.stage2_select_mode = "best_worst"
+    config.sample.test_batch_size = 16
+    if n_gpus > 32:
+        config.sample.test_batch_size = max(1, config.sample.test_batch_size // 2)
+
+    config.prompt_fn = "geneval" if dataset == "geneval" else "general_ocr"
+    config.reward_fn = reward_fn
+    config.train.beta = 0.0001
+    config.train.timestep_fraction = 0.4
+    config.decay_type = 1
+    config.beta = 1.0
+    config.train.adv_mode = "all"
+    config.rollout_sample_num_steps = 10
+    config.rollout_sample_guidance_scale = 1.0
+    config.train_sample_guidance_scale = 1.0
+    config.eval_sample_guidance_scale = 1.0
+    config.preview_step = 0
+    config.preview_type = "flow"
+    config.sequential_decode = True
+    config.enable_debug_image_save = True
+    config.debug_image_every_steps = 10
+    config.debug_image_subset_size = 6
+
+    config.compile_mode = "max-autotune-no-cudagraphs"
+    config.nvfp4_skip_modules = ["x_embedder", "context_embedder", "time_text_embed", "norm_out"]
+    config.nvfp4_min_dim = 1000
+
+    config.preview_model = "peft"
+    config.fullrollout_model = "peft"
+    config.train.max_grad_norm = 1.0
+    config.resume = True
+    config.global_std = True
+    config.after_adv = False
+
+    return config
+
+
+def _set_bon_combo(
+    config, reward_name, best_of_n, num_image_per_prompt, n_gpus, grad_steps_per_epoch, rollout_bsz, train_bsz, seed=42
+):
+    config.sample.num_image_per_prompt = int(num_image_per_prompt)
+    config.sample.best_of_n = int(best_of_n)
+    config.sample.full_rollout_num = int(best_of_n)
+
+    num_groups = 48
+    assert num_groups % n_gpus == 0
+    config.sample.per_gpu_to_process_prompts = num_groups // n_gpus
+    config.sample.per_gpu_total_samples_to_train = num_groups * config.sample.best_of_n // n_gpus
+
+    assert config.sample.num_image_per_prompt % rollout_bsz == 0
+    config.sample.rollout_batch_size = rollout_bsz
+    config.sample.per_prompt_iter_num = config.sample.num_image_per_prompt // rollout_bsz
+
+    assert config.sample.per_gpu_total_samples_to_train % train_bsz == 0
+    config.train.batch_size = int(train_bsz)
+    n_batch_per_epoch = config.sample.per_gpu_total_samples_to_train // train_bsz
+    assert n_batch_per_epoch % grad_steps_per_epoch == 0
+    config.train.n_batch_per_epoch = n_batch_per_epoch
+    config.train.gradient_accumulation_steps = n_batch_per_epoch // grad_steps_per_epoch
+
+    config.global_std = True
+    config.after_adv = False
+    config.seed = int(seed)
+    return config
+
+
+def _auto_rollout_bsz(num_image_per_prompt):
+    num_image_per_prompt = int(num_image_per_prompt)
+    max_rollout_bsz = min(24, num_image_per_prompt)
+    for candidate in range(max_rollout_bsz, 0, -1):
+        if num_image_per_prompt % candidate == 0:
+            return int(candidate)
+    return 1
+
+
+def _build_reward(reward_name, best_of_n, num_image_per_prompt):
+    reward_map = {
+        "pickscore": {"pickscore": 1.0},
+        "clipscore": {"clipscore": 1.0},
+        "imagereward": {"imagereward": 1.0},
+        "hpsv2": {"hpsv2": 1.0},
+    }
+    cfg = _get_config(n_gpus=8, dataset="pickscore", reward_fn=reward_map[reward_name])
+    rollout_bsz = _auto_rollout_bsz(num_image_per_prompt)
+    return _set_bon_combo(
+        cfg,
+        reward_name,
+        best_of_n,
+        num_image_per_prompt,
+        n_gpus=8,
+        grad_steps_per_epoch=1,
+        rollout_bsz=rollout_bsz,
+        train_bsz=12,
+        seed=42,
+    )
+
+
+def _set_run(cfg, name):
+    cfg.run_name = name
+    cfg.resume_from = f"logs/nft_slurm/{name}"
+    cfg.save_dir = cfg.resume_from
+    return cfg
+
+
+# ============================================================================
+# DiffusionNFT Baseline: 24-in-24, PEFT inference
+# ============================================================================
+
+
+def flux1_diffusionnft_pickscore():
+    return _set_run(_build_reward("pickscore", 24, 24), "flux1_diffusionnft_pickscore")
+
+
+def flux1_diffusionnft_clipscore():
+    return _set_run(_build_reward("clipscore", 24, 24), "flux1_diffusionnft_clipscore")
+
+
+def flux1_diffusionnft_hpsv2():
+    return _set_run(_build_reward("hpsv2", 24, 24), "flux1_diffusionnft_hpsv2")
+
+
+def flux1_diffusionnft_imagereward():
+    return _set_run(_build_reward("imagereward", 24, 24), "flux1_diffusionnft_imagereward")
+
+
+# ============================================================================
+# Naive Scaling: 24-in-96, BF16 compile model
+# ============================================================================
+
+
+def flux1_naive_scaling_pickscore():
+    cfg = _build_reward("pickscore", 24, 96)
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "flux1_naive_scaling_pickscore")
+
+
+def flux1_naive_scaling_clipscore():
+    cfg = _build_reward("clipscore", 24, 96)
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "flux1_naive_scaling_clipscore")
+
+
+def flux1_naive_scaling_hpsv2():
+    cfg = _build_reward("hpsv2", 24, 96)
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "flux1_naive_scaling_hpsv2")
+
+
+def flux1_naive_scaling_imagereward():
+    cfg = _build_reward("imagereward", 24, 96)
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "flux1_naive_scaling_imagereward")
+
+
+# ============================================================================
+# Naive Quant: 24-in-96, NVFP4 compile model (direct quantized rollout)
+# ============================================================================
+
+
+def flux1_naive_quant_pickscore():
+    cfg = _build_reward("pickscore", 24, 96)
+    cfg.fullrollout_model = "compile_nvfp4"
+    return _set_run(cfg, "flux1_naive_quant_pickscore")
+
+
+def flux1_naive_quant_clipscore():
+    cfg = _build_reward("clipscore", 24, 96)
+    cfg.fullrollout_model = "compile_nvfp4"
+    return _set_run(cfg, "flux1_naive_quant_clipscore")
+
+
+def flux1_naive_quant_hpsv2():
+    cfg = _build_reward("hpsv2", 24, 96)
+    cfg.fullrollout_model = "compile_nvfp4"
+    return _set_run(cfg, "flux1_naive_quant_hpsv2")
+
+
+def flux1_naive_quant_imagereward():
+    cfg = _build_reward("imagereward", 24, 96)
+    cfg.fullrollout_model = "compile_nvfp4"
+    return _set_run(cfg, "flux1_naive_quant_imagereward")
+
+
+# ============================================================================
+# Sol-RL: 24-in-96, Two-stage decoupled framework
+#   Stage 1 (FP4 Exploration): NVFP4 compiled draft model, 6 steps
+#   Stage 2 (BF16 Regeneration): BF16 compiled model, 10 steps
+# ============================================================================
+
+
+def flux1_sol_rl_pickscore():
+    cfg = _build_reward("pickscore", 24, 96)
+    cfg.preview_step = 6
+    cfg.preview_model = "compile_nvfp4"
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "flux1_sol_rl_pickscore")
+
+
+def flux1_sol_rl_clipscore():
+    cfg = _build_reward("clipscore", 24, 96)
+    cfg.preview_step = 6
+    cfg.preview_model = "compile_nvfp4"
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "flux1_sol_rl_clipscore")
+
+
+def flux1_sol_rl_hpsv2():
+    cfg = _build_reward("hpsv2", 24, 96)
+    cfg.preview_step = 6
+    cfg.preview_model = "compile_nvfp4"
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "flux1_sol_rl_hpsv2")
+
+
+def flux1_sol_rl_imagereward():
+    cfg = _build_reward("imagereward", 24, 96)
+    cfg.preview_step = 6
+    cfg.preview_model = "compile_nvfp4"
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "flux1_sol_rl_imagereward")

--- a/configs/sol_rl/sana.py
+++ b/configs/sol_rl/sana.py
@@ -1,0 +1,258 @@
+import imp
+import os
+
+base = imp.load_source("base", os.path.join(os.path.dirname(__file__), "base.py"))
+
+
+def get_config(name):
+    return globals()[name]()
+
+
+def _get_config(n_gpus=8, dataset="pickscore", reward_fn=None):
+    if reward_fn is None:
+        reward_fn = {}
+
+    config = base.get_config()
+    config.dataset = os.path.join(os.getcwd(), f"dataset/{dataset}")
+    config.native_config = "configs/sol_rl/Sana1.0_1600M_linear.yaml"
+    config.resolution = 1024
+    config.train.lora_target_modules = [
+        "attn.qkv",
+        "attn.proj",
+        "cross_attn.q_linear",
+        "cross_attn.kv_linear",
+        "cross_attn.proj",
+    ]
+    config.train.lora_init_mode = "gaussian"
+
+    config.sample.num_steps = 10
+    config.sample.eval_num_steps = 40
+    config.sample.noise_level = 0.0
+    config.sample.deterministic = True
+    config.sample.stage1_select_mode = "best_worst"
+    config.sample.stage2_select_mode = "best_worst"
+    config.sample.test_batch_size = 14 if dataset == "geneval" else 16
+    if n_gpus > 32:
+        config.sample.test_batch_size = max(1, config.sample.test_batch_size // 2)
+
+    config.prompt_fn = "geneval" if dataset == "geneval" else "general_ocr"
+    config.reward_fn = reward_fn
+    config.train.beta = 0.0001
+    config.decay_type = 1
+    config.beta = 1.0
+    config.train.adv_mode = "all"
+    config.rollout_sample_num_steps = 10
+    config.rollout_sample_guidance_scale = 1.0
+    config.eval_sample_guidance_scale = 1.0
+    config.preview_step = 0
+    config.enable_debug_image_save = True
+    config.debug_image_every_steps = 10
+    config.debug_image_subset_size = 6
+
+    config.compile_mode = "max-autotune-no-cudagraphs"
+    config.nvfp4_skip_modules = [
+        "t_embedder",
+        "t_block",
+        "cfg_embedder",
+        "y_embedder",
+        "x_embedder",
+        "final_layer",
+        "logvar_linear",
+        "attn.qkv",
+    ]
+    config.nvfp4_min_dim = 2240
+
+    config.preview_model = "peft"
+    config.fullrollout_model = "peft"
+    config.resume = True
+    config.global_std = True
+    config.after_adv = False
+    config.train.max_grad_norm = 1.0
+
+    return config
+
+
+def _set_bon_combo(
+    config, reward_name, best_of_n, num_image_per_prompt, n_gpus, grad_steps_per_epoch, rollout_bsz, train_bsz, seed=42
+):
+    config.sample.num_image_per_prompt = int(num_image_per_prompt)
+    config.sample.best_of_n = int(best_of_n)
+    config.sample.full_rollout_num = int(best_of_n)
+
+    num_groups = 48
+    assert num_groups % n_gpus == 0
+    config.sample.per_gpu_to_process_prompts = num_groups // n_gpus
+    config.sample.per_gpu_total_samples_to_train = num_groups * config.sample.best_of_n // n_gpus
+
+    assert config.sample.num_image_per_prompt % rollout_bsz == 0
+    config.sample.rollout_batch_size = rollout_bsz
+    config.sample.per_prompt_iter_num = config.sample.num_image_per_prompt // rollout_bsz
+
+    assert config.sample.per_gpu_total_samples_to_train % train_bsz == 0
+    config.train.batch_size = int(train_bsz)
+    n_batch_per_epoch = config.sample.per_gpu_total_samples_to_train // train_bsz
+    assert n_batch_per_epoch % grad_steps_per_epoch == 0
+    config.train.n_batch_per_epoch = n_batch_per_epoch
+    config.train.gradient_accumulation_steps = n_batch_per_epoch // grad_steps_per_epoch
+
+    config.global_std = True
+    config.after_adv = False
+    config.seed = int(seed)
+    return config
+
+
+def _auto_rollout_bsz(num_image_per_prompt):
+    num_image_per_prompt = int(num_image_per_prompt)
+    max_rollout_bsz = min(24, num_image_per_prompt)
+    for candidate in range(max_rollout_bsz, 0, -1):
+        if num_image_per_prompt % candidate == 0:
+            return int(candidate)
+    return 1
+
+
+def _build_reward(reward_name, best_of_n, num_image_per_prompt):
+    reward_map = {
+        "pickscore": {"pickscore": 1.0},
+        "clipscore": {"clipscore": 1.0},
+        "imagereward": {"imagereward": 1.0},
+        "hpsv2": {"hpsv2": 1.0},
+    }
+    cfg = _get_config(n_gpus=8, dataset="pickscore", reward_fn=reward_map[reward_name])
+    rollout_bsz = _auto_rollout_bsz(num_image_per_prompt)
+    return _set_bon_combo(
+        cfg,
+        reward_name,
+        best_of_n,
+        num_image_per_prompt,
+        n_gpus=8,
+        grad_steps_per_epoch=1,
+        rollout_bsz=rollout_bsz,
+        train_bsz=16,
+        seed=42,
+    )
+
+
+def _set_run(cfg, name):
+    cfg.run_name = name
+    cfg.resume_from = f"logs/nft_slurm/{name}"
+    cfg.save_dir = cfg.resume_from
+    return cfg
+
+
+# ============================================================================
+# DiffusionNFT Baseline: 24-in-24, PEFT inference (no compile, no NVFP4)
+# Paper reference: DiffusionNFT [Zheng et al., 2026]
+# ============================================================================
+
+
+def sana_diffusionnft_pickscore():
+    return _set_run(_build_reward("pickscore", 24, 24), "sana_diffusionnft_pickscore")
+
+
+def sana_diffusionnft_clipscore():
+    return _set_run(_build_reward("clipscore", 24, 24), "sana_diffusionnft_clipscore")
+
+
+def sana_diffusionnft_hpsv2():
+    return _set_run(_build_reward("hpsv2", 24, 24), "sana_diffusionnft_hpsv2")
+
+
+def sana_diffusionnft_imagereward():
+    return _set_run(_build_reward("imagereward", 24, 24), "sana_diffusionnft_imagereward")
+
+
+# ============================================================================
+# Naive Scaling: 24-in-96, BF16 compile model (brute-force scaling)
+# ============================================================================
+
+
+def sana_naive_scaling_pickscore():
+    cfg = _build_reward("pickscore", 24, 96)
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "sana_naive_scaling_pickscore")
+
+
+def sana_naive_scaling_clipscore():
+    cfg = _build_reward("clipscore", 24, 96)
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "sana_naive_scaling_clipscore")
+
+
+def sana_naive_scaling_hpsv2():
+    cfg = _build_reward("hpsv2", 24, 96)
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "sana_naive_scaling_hpsv2")
+
+
+def sana_naive_scaling_imagereward():
+    cfg = _build_reward("imagereward", 24, 96)
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "sana_naive_scaling_imagereward")
+
+
+# ============================================================================
+# Naive Quant: 24-in-96, NVFP4 compile model (direct quantized rollout)
+# ============================================================================
+
+
+def sana_naive_quant_pickscore():
+    cfg = _build_reward("pickscore", 24, 96)
+    cfg.fullrollout_model = "compile_nvfp4"
+    return _set_run(cfg, "sana_naive_quant_pickscore")
+
+
+def sana_naive_quant_clipscore():
+    cfg = _build_reward("clipscore", 24, 96)
+    cfg.fullrollout_model = "compile_nvfp4"
+    return _set_run(cfg, "sana_naive_quant_clipscore")
+
+
+def sana_naive_quant_hpsv2():
+    cfg = _build_reward("hpsv2", 24, 96)
+    cfg.fullrollout_model = "compile_nvfp4"
+    return _set_run(cfg, "sana_naive_quant_hpsv2")
+
+
+def sana_naive_quant_imagereward():
+    cfg = _build_reward("imagereward", 24, 96)
+    cfg.fullrollout_model = "compile_nvfp4"
+    return _set_run(cfg, "sana_naive_quant_imagereward")
+
+
+# ============================================================================
+# Sol-RL: 24-in-96, Two-stage decoupled framework
+#   Stage 1 (FP4 Exploration): NVFP4 compiled draft model, 6 steps
+#   Stage 2 (BF16 Regeneration): BF16 compiled model, 10 steps
+# ============================================================================
+
+
+def sana_sol_rl_pickscore():
+    cfg = _build_reward("pickscore", 24, 96)
+    cfg.preview_step = 6
+    cfg.preview_model = "compile_nvfp4"
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "sana_sol_rl_pickscore")
+
+
+def sana_sol_rl_clipscore():
+    cfg = _build_reward("clipscore", 24, 96)
+    cfg.preview_step = 6
+    cfg.preview_model = "compile_nvfp4"
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "sana_sol_rl_clipscore")
+
+
+def sana_sol_rl_hpsv2():
+    cfg = _build_reward("hpsv2", 24, 96)
+    cfg.preview_step = 6
+    cfg.preview_model = "compile_nvfp4"
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "sana_sol_rl_hpsv2")
+
+
+def sana_sol_rl_imagereward():
+    cfg = _build_reward("imagereward", 24, 96)
+    cfg.preview_step = 6
+    cfg.preview_model = "compile_nvfp4"
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "sana_sol_rl_imagereward")

--- a/configs/sol_rl/sd3.py
+++ b/configs/sol_rl/sd3.py
@@ -1,0 +1,259 @@
+import imp
+import os
+
+base = imp.load_source("base", os.path.join(os.path.dirname(__file__), "base.py"))
+
+
+def get_config(name):
+    return globals()[name]()
+
+
+def _get_config(n_gpus=8, dataset="pickscore", reward_fn=None):
+    if reward_fn is None:
+        reward_fn = {}
+
+    config = base.get_config()
+    config.dataset = os.path.join(os.getcwd(), f"dataset/{dataset}")
+    config.pretrained.model = "stabilityai/stable-diffusion-3.5-large"
+    config.resolution = 1024
+    config.train.lora_target_modules = [
+        "attn.add_k_proj",
+        "attn.add_q_proj",
+        "attn.add_v_proj",
+        "attn.to_add_out",
+        "attn.to_k",
+        "attn.to_out.0",
+        "attn.to_q",
+        "attn.to_v",
+    ]
+    config.train.lora_init_mode = "gaussian"
+
+    config.sample.num_steps = 10
+    config.sample.eval_num_steps = 40
+    config.sample.noise_level = 0.7
+    config.sample.solver = "dpm2"
+    config.sample.stage1_select_mode = "best_worst"
+    config.sample.stage2_select_mode = "best_worst"
+    config.sample.test_batch_size = 14 if dataset == "geneval" else 16
+    if n_gpus > 32:
+        config.sample.test_batch_size = max(1, config.sample.test_batch_size // 2)
+
+    config.prompt_fn = "geneval" if dataset == "geneval" else "general_ocr"
+    config.reward_fn = reward_fn
+    config.train.beta = 0.0001
+    config.decay_type = 1
+    config.beta = 1.0
+    config.train.adv_mode = "all"
+    config.rollout_sample_num_steps = 10
+    config.rollout_sample_guidance_scale = 1.0
+    config.train_sample_guidance_scale = 1.0
+    config.eval_sample_guidance_scale = 1.0
+    config.preview_step = 0
+    config.sequential_decode = True
+    config.enable_debug_image_save = True
+    config.debug_image_every_steps = 10
+    config.debug_image_subset_size = 6
+
+    config.compile_mode = "max-autotune-no-cudagraphs"
+    config.nvfp4_skip_modules = [
+        "pos_embed",
+        "context_embedder",
+        "time_text_embed",
+        "norm_out",
+        "norm1",
+        "ff_context",
+    ]
+    config.nvfp4_min_dim = 2432
+
+    config.preview_model = "peft"
+    config.fullrollout_model = "peft"
+    config.resume = True
+    config.global_std = True
+    config.after_adv = False
+
+    return config
+
+
+def _set_bon_combo(
+    config, reward_name, best_of_n, num_image_per_prompt, n_gpus, grad_steps_per_epoch, rollout_bsz, train_bsz, seed=42
+):
+    config.sample.num_image_per_prompt = int(num_image_per_prompt)
+    config.sample.best_of_n = int(best_of_n)
+    config.sample.full_rollout_num = int(best_of_n)
+
+    num_groups = 48
+    assert num_groups % n_gpus == 0
+    config.sample.per_gpu_to_process_prompts = num_groups // n_gpus
+    config.sample.per_gpu_total_samples_to_train = num_groups * config.sample.best_of_n // n_gpus
+
+    assert config.sample.num_image_per_prompt % rollout_bsz == 0
+    config.sample.rollout_batch_size = rollout_bsz
+    config.sample.per_prompt_iter_num = config.sample.num_image_per_prompt // rollout_bsz
+
+    assert config.sample.per_gpu_total_samples_to_train % train_bsz == 0
+    config.train.batch_size = int(train_bsz)
+    n_batch_per_epoch = config.sample.per_gpu_total_samples_to_train // train_bsz
+    assert n_batch_per_epoch % grad_steps_per_epoch == 0
+    config.train.n_batch_per_epoch = n_batch_per_epoch
+    config.train.gradient_accumulation_steps = n_batch_per_epoch // grad_steps_per_epoch
+
+    config.global_std = True
+    config.after_adv = False
+    config.seed = int(seed)
+    return config
+
+
+def _auto_rollout_bsz(num_image_per_prompt):
+    num_image_per_prompt = int(num_image_per_prompt)
+    max_rollout_bsz = min(24, num_image_per_prompt)
+    for candidate in range(max_rollout_bsz, 0, -1):
+        if num_image_per_prompt % candidate == 0:
+            return int(candidate)
+    return 1
+
+
+def _build_reward(reward_name, best_of_n, num_image_per_prompt):
+    reward_map = {
+        "pickscore": {"pickscore": 1.0},
+        "clipscore": {"clipscore": 1.0},
+        "imagereward": {"imagereward": 1.0},
+        "hpsv2": {"hpsv2": 1.0},
+    }
+    cfg = _get_config(n_gpus=8, dataset="pickscore", reward_fn=reward_map[reward_name])
+    rollout_bsz = _auto_rollout_bsz(num_image_per_prompt)
+    return _set_bon_combo(
+        cfg,
+        reward_name,
+        best_of_n,
+        num_image_per_prompt,
+        n_gpus=8,
+        grad_steps_per_epoch=1,
+        rollout_bsz=rollout_bsz,
+        train_bsz=4,
+        seed=42,
+    )
+
+
+def _set_run(cfg, name):
+    cfg.run_name = name
+    cfg.resume_from = f"logs/nft_slurm/{name}"
+    cfg.save_dir = cfg.resume_from
+    return cfg
+
+
+# ============================================================================
+# DiffusionNFT Baseline: 24-in-24, PEFT inference
+# ============================================================================
+
+
+def sd3_diffusionnft_pickscore():
+    return _set_run(_build_reward("pickscore", 24, 24), "sd3_diffusionnft_pickscore")
+
+
+def sd3_diffusionnft_clipscore():
+    return _set_run(_build_reward("clipscore", 24, 24), "sd3_diffusionnft_clipscore")
+
+
+def sd3_diffusionnft_hpsv2():
+    return _set_run(_build_reward("hpsv2", 24, 24), "sd3_diffusionnft_hpsv2")
+
+
+def sd3_diffusionnft_imagereward():
+    return _set_run(_build_reward("imagereward", 24, 24), "sd3_diffusionnft_imagereward")
+
+
+# ============================================================================
+# Naive Scaling: 24-in-96, BF16 compile model
+# ============================================================================
+
+
+def sd3_naive_scaling_pickscore():
+    cfg = _build_reward("pickscore", 24, 96)
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "sd3_naive_scaling_pickscore")
+
+
+def sd3_naive_scaling_clipscore():
+    cfg = _build_reward("clipscore", 24, 96)
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "sd3_naive_scaling_clipscore")
+
+
+def sd3_naive_scaling_hpsv2():
+    cfg = _build_reward("hpsv2", 24, 96)
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "sd3_naive_scaling_hpsv2")
+
+
+def sd3_naive_scaling_imagereward():
+    cfg = _build_reward("imagereward", 24, 96)
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "sd3_naive_scaling_imagereward")
+
+
+# ============================================================================
+# Naive Quant: 24-in-96, NVFP4 compile model (direct quantized rollout)
+# ============================================================================
+
+
+def sd3_naive_quant_pickscore():
+    cfg = _build_reward("pickscore", 24, 96)
+    cfg.fullrollout_model = "compile_nvfp4"
+    return _set_run(cfg, "sd3_naive_quant_pickscore")
+
+
+def sd3_naive_quant_clipscore():
+    cfg = _build_reward("clipscore", 24, 96)
+    cfg.fullrollout_model = "compile_nvfp4"
+    return _set_run(cfg, "sd3_naive_quant_clipscore")
+
+
+def sd3_naive_quant_hpsv2():
+    cfg = _build_reward("hpsv2", 24, 96)
+    cfg.fullrollout_model = "compile_nvfp4"
+    return _set_run(cfg, "sd3_naive_quant_hpsv2")
+
+
+def sd3_naive_quant_imagereward():
+    cfg = _build_reward("imagereward", 24, 96)
+    cfg.fullrollout_model = "compile_nvfp4"
+    return _set_run(cfg, "sd3_naive_quant_imagereward")
+
+
+# ============================================================================
+# Sol-RL: 24-in-96, Two-stage decoupled framework
+#   Stage 1 (FP4 Exploration): NVFP4 compiled draft model, 6 steps
+#   Stage 2 (BF16 Regeneration): BF16 compiled model, 10 steps
+# ============================================================================
+
+
+def sd3_sol_rl_pickscore():
+    cfg = _build_reward("pickscore", 24, 96)
+    cfg.preview_step = 6
+    cfg.preview_model = "compile_nvfp4"
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "sd3_sol_rl_pickscore")
+
+
+def sd3_sol_rl_clipscore():
+    cfg = _build_reward("clipscore", 24, 96)
+    cfg.preview_step = 6
+    cfg.preview_model = "compile_nvfp4"
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "sd3_sol_rl_clipscore")
+
+
+def sd3_sol_rl_hpsv2():
+    cfg = _build_reward("hpsv2", 24, 96)
+    cfg.preview_step = 6
+    cfg.preview_model = "compile_nvfp4"
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "sd3_sol_rl_hpsv2")
+
+
+def sd3_sol_rl_imagereward():
+    cfg = _build_reward("imagereward", 24, 96)
+    cfg.preview_step = 6
+    cfg.preview_model = "compile_nvfp4"
+    cfg.fullrollout_model = "compile"
+    return _set_run(cfg, "sd3_sol_rl_imagereward")

--- a/diffusion/flow_grpo/aesthetic_scorer.py
+++ b/diffusion/flow_grpo/aesthetic_scorer.py
@@ -1,0 +1,69 @@
+# Based on https://github.com/christophschuhmann/improved-aesthetic-predictor/blob/fe88a163f4661b4ddabba0751ff645e2e620746e/simple_inference.py
+
+import os
+
+import numpy as np
+import torch
+import torch.nn as nn
+from PIL import Image
+from transformers import CLIPModel, CLIPProcessor
+
+from diffusion.flow_grpo.reward_ckpt_path import CKPT_PATH
+
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.Sequential(
+            nn.Linear(768, 1024),
+            nn.Dropout(0.2),
+            nn.Linear(1024, 128),
+            nn.Dropout(0.2),
+            nn.Linear(128, 64),
+            nn.Dropout(0.1),
+            nn.Linear(64, 16),
+            nn.Linear(16, 1),
+        )
+
+    @torch.no_grad()
+    def forward(self, embed):
+        return self.layers(embed)
+
+
+class AestheticScorer(torch.nn.Module):
+    def __init__(self, dtype, device):
+        super().__init__()
+        self.clip = CLIPModel.from_pretrained("openai/clip-vit-large-patch14").to(device)
+        self.processor = CLIPProcessor.from_pretrained("openai/clip-vit-large-patch14")
+        self.mlp = MLP().to(device)
+        state_dict = torch.load(os.path.join(CKPT_PATH, "sac+logos+ava1-l14-linearMSE.pth"), map_location="cpu")
+        self.mlp.load_state_dict(state_dict)
+        self.dtype = dtype
+        self.device = device
+        self.eval()
+
+    @torch.no_grad()
+    def __call__(self, images):
+        inputs = self.processor(images=images, return_tensors="pt")
+        inputs = {k: v.to(self.dtype).to(self.device) for k, v in inputs.items()}
+        embed = self.clip.get_image_features(**inputs)
+        # normalize embedding
+        embed = embed / torch.linalg.vector_norm(embed, dim=-1, keepdim=True)
+        return self.mlp(embed).squeeze(1)
+
+
+# Usage example
+def main():
+    scorer = AestheticScorer(device="cuda", dtype=torch.float32)
+
+    images = [
+        "test_cases/nasa.jpg",
+    ]
+    pil_images = np.stack([np.array(Image.open(img)) for img in images])
+    images = pil_images.transpose(0, 3, 1, 2)  # NHWC -> NCHW
+    images = torch.tensor(images, dtype=torch.uint8)
+    print(scorer(images))
+
+
+if __name__ == "__main__":
+    main()

--- a/diffusion/flow_grpo/clip_scorer.py
+++ b/diffusion/flow_grpo/clip_scorer.py
@@ -1,0 +1,73 @@
+# Based on https://github.com/RE-N-Y/imscore/blob/main/src/imscore/preference/model.py
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torchvision.transforms as T
+from PIL import Image
+from transformers import AutoImageProcessor, CLIPModel, CLIPProcessor
+
+
+def get_size(size):
+    if isinstance(size, int):
+        return (size, size)
+    elif "height" in size and "width" in size:
+        return (size["height"], size["width"])
+    elif "shortest_edge" in size:
+        return size["shortest_edge"]
+    else:
+        raise ValueError(f"Invalid size: {size}")
+
+
+def get_image_transform(processor: AutoImageProcessor):
+    config = processor.to_dict()
+    resize = T.Resize(get_size(config.get("size"))) if config.get("do_resize") else nn.Identity()
+    crop = T.CenterCrop(get_size(config.get("crop_size"))) if config.get("do_center_crop") else nn.Identity()
+    normalise = (
+        T.Normalize(mean=processor.image_mean, std=processor.image_std) if config.get("do_normalize") else nn.Identity()
+    )
+
+    return T.Compose([resize, crop, normalise])
+
+
+class ClipScorer(torch.nn.Module):
+    def __init__(self, device):
+        super().__init__()
+        self.device = device
+        self.model = CLIPModel.from_pretrained("openai/clip-vit-large-patch14").to(device)
+        self.processor = CLIPProcessor.from_pretrained("openai/clip-vit-large-patch14")
+        self.tform = get_image_transform(self.processor.image_processor)
+        self.eval()
+
+    def _process(self, pixels):
+        dtype = pixels.dtype
+        pixels = self.tform(pixels)
+        pixels = pixels.to(dtype=dtype)
+
+        return pixels
+
+    @torch.no_grad()
+    def __call__(self, pixels, prompts, return_img_embedding=False):
+        texts = self.processor(text=prompts, padding="max_length", truncation=True, return_tensors="pt").to(self.device)
+        pixels = self._process(pixels).to(self.device)
+        outputs = self.model(pixel_values=pixels, **texts)
+        if return_img_embedding:
+            return outputs.logits_per_image.diagonal() / 100, outputs.image_embeds
+        return outputs.logits_per_image.diagonal() / 100
+
+
+def main():
+    scorer = ClipScorer(device="cuda")
+
+    images = ["test_cases/cat.jpg", "test_cases/cat.jpg"]
+    pil_images = [Image.open(img) for img in images]
+    prompts = ["an image of cat", "not an image of cat"]
+    images = [np.array(img) for img in pil_images]
+    images = np.array(images)
+    images = images.transpose(0, 3, 1, 2)  # NHWC -> NCHW
+    images = torch.tensor(images, dtype=torch.uint8) / 255.0
+    print(scorer(images, prompts))
+
+
+if __name__ == "__main__":
+    main()

--- a/diffusion/flow_grpo/diffusers_patch/pipeline_with_logprob.py
+++ b/diffusion/flow_grpo/diffusers_patch/pipeline_with_logprob.py
@@ -1,0 +1,285 @@
+# Copied from https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py
+# with the following modifications:
+# - It uses the patched version of `sde_step_with_logprob` from `sd3_sde_with_logprob.py`.
+# - It returns all the intermediate latents of the denoising process as well as the log probs of each denoising step.
+from typing import Any, Dict, List, Optional, Union
+
+import numpy as np
+import torch
+from diffusers.pipelines.stable_diffusion_3.pipeline_stable_diffusion_3 import retrieve_timesteps
+
+from .solver import run_sampling
+
+
+def calculate_shift(
+    image_seq_len,
+    base_seq_len: int = 256,
+    max_seq_len: int = 4096,
+    base_shift: float = 0.5,
+    max_shift: float = 1.15,
+):
+    m = (max_shift - base_shift) / (max_seq_len - base_seq_len)
+    b = base_shift - m * base_seq_len
+    mu = image_seq_len * m + b
+    return mu
+
+
+@torch.no_grad()
+def pipeline_with_logprob(
+    self,
+    prompt: Union[str, List[str]] = None,
+    prompt_2: Optional[Union[str, List[str]]] = None,
+    prompt_3: Optional[Union[str, List[str]]] = None,
+    height: Optional[int] = None,
+    width: Optional[int] = None,
+    num_inference_steps: int = 28,
+    guidance_scale: float = 7.0,
+    negative_prompt: Optional[Union[str, List[str]]] = None,
+    negative_prompt_2: Optional[Union[str, List[str]]] = None,
+    negative_prompt_3: Optional[Union[str, List[str]]] = None,
+    num_images_per_prompt: Optional[int] = 1,
+    generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
+    latents: Optional[torch.FloatTensor] = None,
+    prompt_embeds: Optional[torch.FloatTensor] = None,
+    negative_prompt_embeds: Optional[torch.FloatTensor] = None,
+    pooled_prompt_embeds: Optional[torch.FloatTensor] = None,
+    negative_pooled_prompt_embeds: Optional[torch.FloatTensor] = None,
+    output_type: Optional[str] = "pil",
+    joint_attention_kwargs: Optional[Dict[str, Any]] = None,
+    callback_on_step_end_tensor_inputs: List[str] = ["latents"],
+    max_sequence_length: int = 256,
+    noise_level: float = 0.7,
+    deterministic: bool = False,
+    solver: str = "flow",
+    model_type: str = "sd3",
+    sequential_decode: bool = False,
+):
+    height = height or self.default_sample_size * self.vae_scale_factor
+    width = width or self.default_sample_size * self.vae_scale_factor
+
+    assert model_type in ["sd3", "flux"]
+    flux = model_type == "flux"
+    # 1. Check inputs. Raise error if not correct
+    if not flux:
+        self.check_inputs(
+            prompt,
+            prompt_2,
+            prompt_3,
+            height,
+            width,
+            negative_prompt=negative_prompt,
+            negative_prompt_2=negative_prompt_2,
+            negative_prompt_3=negative_prompt_3,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            pooled_prompt_embeds=pooled_prompt_embeds,
+            negative_pooled_prompt_embeds=negative_pooled_prompt_embeds,
+            callback_on_step_end_tensor_inputs=callback_on_step_end_tensor_inputs,
+            max_sequence_length=max_sequence_length,
+        )
+    else:
+        self.check_inputs(
+            prompt,
+            prompt_2,
+            height,
+            width,
+            negative_prompt=negative_prompt,
+            negative_prompt_2=negative_prompt_2,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            pooled_prompt_embeds=pooled_prompt_embeds,
+            negative_pooled_prompt_embeds=negative_pooled_prompt_embeds,
+            callback_on_step_end_tensor_inputs=callback_on_step_end_tensor_inputs,
+            max_sequence_length=max_sequence_length,
+        )
+
+    self._guidance_scale = guidance_scale
+    self._joint_attention_kwargs = joint_attention_kwargs
+    self._current_timestep = None
+    self._interrupt = False
+
+    # 2. Define call parameters
+    if prompt is not None and isinstance(prompt, str):
+        batch_size = 1
+    elif prompt is not None and isinstance(prompt, list):
+        batch_size = len(prompt)
+    else:
+        batch_size = prompt_embeds.shape[0]
+
+    device = self._execution_device
+
+    lora_scale = self.joint_attention_kwargs.get("scale", None) if self.joint_attention_kwargs is not None else None
+    if not flux:
+        (
+            prompt_embeds,
+            negative_prompt_embeds,
+            pooled_prompt_embeds,
+            negative_pooled_prompt_embeds,
+        ) = self.encode_prompt(
+            prompt=prompt,
+            prompt_2=prompt_2,
+            prompt_3=prompt_3,
+            negative_prompt=negative_prompt,
+            negative_prompt_2=negative_prompt_2,
+            negative_prompt_3=negative_prompt_3,
+            do_classifier_free_guidance=self.do_classifier_free_guidance,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            pooled_prompt_embeds=pooled_prompt_embeds,
+            negative_pooled_prompt_embeds=negative_pooled_prompt_embeds,
+            device=device,
+            num_images_per_prompt=num_images_per_prompt,
+            max_sequence_length=max_sequence_length,
+            lora_scale=lora_scale,
+        )
+        if self.do_classifier_free_guidance:
+            prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
+            pooled_prompt_embeds = torch.cat([negative_pooled_prompt_embeds, pooled_prompt_embeds], dim=0)
+    else:
+        (
+            prompt_embeds,
+            pooled_prompt_embeds,
+            text_ids,
+        ) = self.encode_prompt(
+            prompt=prompt,
+            prompt_2=prompt_2,
+            prompt_embeds=prompt_embeds,
+            pooled_prompt_embeds=pooled_prompt_embeds,
+            device=device,
+            num_images_per_prompt=num_images_per_prompt,
+            max_sequence_length=max_sequence_length,
+            lora_scale=lora_scale,
+        )
+
+    # 4. Prepare latent variables
+    if not flux:
+        num_channels_latents = self.transformer.config.in_channels
+        if latents is None:
+            latents = self.prepare_latents(
+                batch_size * num_images_per_prompt,
+                num_channels_latents,
+                height,
+                width,
+                prompt_embeds.dtype,
+                device,
+                generator,
+                latents,
+            )
+        else:
+            latents = latents.to(device)
+    else:
+        num_channels_latents = self.transformer.config.in_channels // 4
+        if latents is None:
+            latents, latent_image_ids = self.prepare_latents(
+                batch_size * num_images_per_prompt,
+                num_channels_latents,
+                height,
+                width,
+                prompt_embeds.dtype,
+                device,
+                generator,
+                latents,
+            )
+        else:
+            latents = latents.to(device)
+
+    # 5. Prepare timesteps
+    if not flux:
+        timesteps, num_inference_steps = retrieve_timesteps(
+            self.scheduler,
+            num_inference_steps,
+            device,
+            sigmas=None,
+        )
+        self._num_timesteps = len(timesteps)
+    else:
+        sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps)
+        if hasattr(self.scheduler.config, "use_flow_sigmas") and self.scheduler.config.use_flow_sigmas:
+            sigmas = None
+        image_seq_len = latents.shape[1]
+        mu = calculate_shift(
+            image_seq_len,
+            self.scheduler.config.get("base_image_seq_len", 256),
+            self.scheduler.config.get("max_image_seq_len", 4096),
+            self.scheduler.config.get("base_shift", 0.5),
+            self.scheduler.config.get("max_shift", 1.15),
+        )
+        timesteps, num_inference_steps = retrieve_timesteps(
+            self.scheduler,
+            num_inference_steps,
+            device,
+            sigmas=sigmas,
+            mu=mu,
+        )
+        self._num_timesteps = len(timesteps)
+
+    sigmas = self.scheduler.sigmas.float()
+
+    def v_pred_fn(z, sigma):
+        if not flux:
+            latent_model_input = torch.cat([z] * 2) if self.do_classifier_free_guidance else z
+            # broadcast to batch dimension in a way that's compatible with ONNX/Core ML
+            timesteps = torch.full([latent_model_input.shape[0]], sigma * 1000, device=z.device, dtype=torch.long)
+            noise_pred = self.transformer(
+                hidden_states=latent_model_input,
+                timestep=timesteps,
+                encoder_hidden_states=prompt_embeds,
+                pooled_projections=pooled_prompt_embeds,
+                joint_attention_kwargs=self.joint_attention_kwargs,
+                return_dict=False,
+            )[0]
+            noise_pred = noise_pred.to(prompt_embeds.dtype)
+            # perform guidance
+            if self.do_classifier_free_guidance:
+                # default run this branch
+                noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+                noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
+        else:
+            latent_model_input = z
+            # handle guidance
+            if self.transformer.config.guidance_embeds:
+                guidance = torch.full([1], guidance_scale, device=device, dtype=torch.float32)
+                guidance = guidance.expand(latent_model_input.shape[0])
+            else:
+                guidance = None
+            timesteps = torch.full([latent_model_input.shape[0]], sigma, device=z.device, dtype=torch.long)
+            noise_pred = self.transformer(
+                hidden_states=latent_model_input,
+                timestep=timesteps,
+                guidance=guidance,
+                pooled_projections=pooled_prompt_embeds,
+                encoder_hidden_states=prompt_embeds,
+                txt_ids=text_ids,
+                img_ids=latent_image_ids,
+                joint_attention_kwargs=self.joint_attention_kwargs,
+                return_dict=False,
+            )[0]
+        return noise_pred
+
+    # 6. Prepare image embeddings
+    all_latents = [latents]
+    all_log_probs = []
+
+    # 7. Denoising loop
+    latents, all_latents, all_log_probs = run_sampling(v_pred_fn, latents, sigmas, solver, deterministic, noise_level)
+
+    if flux:
+        latents = self._unpack_latents(latents, height, width, self.vae_scale_factor)
+    latents = (latents / self.vae.config.scaling_factor) + self.vae.config.shift_factor
+    latents = latents.to(dtype=self.vae.dtype)
+    if sequential_decode and latents.shape[0] > 1:
+        decoded_batches = []
+        for idx in range(latents.shape[0]):
+            decoded_batches.append(self.vae.decode(latents[idx : idx + 1], return_dict=False)[0])
+        image = torch.cat(decoded_batches, dim=0)
+    else:
+        image = self.vae.decode(latents, return_dict=False)[0]
+    image = self.image_processor.postprocess(image, output_type=output_type)
+
+    # Offload all models
+    self.maybe_free_model_hooks()
+
+    if not flux:
+        return image, all_latents, all_log_probs
+    else:
+        return image, all_latents, latent_image_ids, text_ids, all_log_probs

--- a/diffusion/flow_grpo/diffusers_patch/solver.py
+++ b/diffusion/flow_grpo/diffusers_patch/solver.py
@@ -1,0 +1,357 @@
+import math
+from dataclasses import dataclass
+from functools import partial
+from typing import List, Optional
+
+import torch
+import torch.distributed as dist
+import tqdm
+from diffusers.utils.torch_utils import randn_tensor
+
+tqdm = partial(tqdm.tqdm, dynamic_ncols=True)
+
+
+# Modified from MixGRPO
+def run_sampling(
+    v_pred_fn,
+    z,
+    sigma_schedule,
+    solver="flow",
+    determistic=False,
+    eta=0.7,
+):
+    assert solver in ["flow", "dance", "ddim", "dpm1", "dpm2"]
+    dtype = z.dtype
+    all_latents = [z]
+    all_log_probs = []
+
+    if "dpm" in solver:
+        order = int(solver[-1])
+        dpm_state = DPMState(order=order)
+    for i in tqdm(
+        range(len(sigma_schedule) - 1),
+        desc="Sampling Progress",
+        disable=not dist.is_initialized() or dist.get_rank() != 0,
+    ):
+        sigma = sigma_schedule[i]
+
+        pred = v_pred_fn(z.to(dtype), sigma)
+        if solver == "flow":
+            z, pred_original, log_prob = flow_grpo_step(
+                model_output=pred.float(),
+                latents=z.float(),
+                eta=eta if not determistic else 0,
+                sigmas=sigma_schedule,
+                index=i,
+                prev_sample=None,
+            )
+        elif solver == "dance":
+            z, pred_original, log_prob = dance_grpo_step(
+                pred.float(), z.float(), eta if not determistic else 0, sigmas=sigma_schedule, index=i, prev_sample=None
+            )
+        elif solver == "ddim":
+            z, pred_original, log_prob = ddim_step(
+                pred.float(), z.float(), eta if not determistic else 0, sigmas=sigma_schedule, index=i, prev_sample=None
+            )
+        elif "dpm" in solver:
+            assert determistic
+            z, pred_original, log_prob = dpm_step(
+                order,
+                model_output=pred.float(),
+                sample=z.float(),
+                step_index=i,
+                timesteps=sigma_schedule[:-1],
+                sigmas=sigma_schedule,
+                dpm_state=dpm_state,
+            )
+        else:
+            assert False
+        z = z.to(dtype)
+        all_latents.append(z)
+        all_log_probs.append(log_prob)
+
+    latents = z.to(dtype)
+    # all_latents = torch.stack(all_latents, dim=1)  # (batch_size, num_steps + 1, 4, 64, 64)
+    # all_log_probs = torch.stack(all_log_probs, dim=1)  # (batch_size, num_steps, 1)
+    return latents, all_latents, all_log_probs
+
+
+def flow_grpo_step(
+    model_output: torch.Tensor,
+    latents: torch.Tensor,
+    eta: float,
+    sigmas: torch.Tensor,
+    index: int,
+    prev_sample: torch.Tensor,
+    generator: Optional[torch.Generator] = None,
+):
+    device = model_output.device
+    sigma = sigmas[index].to(device)
+    sigma_prev = sigmas[index + 1].to(device)
+    sigma_max = sigmas[1].item()
+    dt = sigma_prev - sigma  # neg dt
+
+    pred_original_sample = latents - sigma * model_output
+
+    std_dev_t = torch.sqrt(sigma / (1 - torch.where(sigma == 1, sigma_max, sigma))) * eta
+
+    if prev_sample is not None and generator is not None:
+        raise ValueError(
+            "Cannot pass both generator and prev_sample. Please make sure that either `generator` or"
+            " `prev_sample` stays `None`."
+        )
+
+    prev_sample_mean = (
+        latents * (1 + std_dev_t**2 / (2 * sigma) * dt)
+        + model_output * (1 + std_dev_t**2 * (1 - sigma) / (2 * sigma)) * dt
+    )
+
+    if prev_sample is None:
+        variance_noise = randn_tensor(model_output.shape, generator=generator, device=device, dtype=model_output.dtype)
+        prev_sample = prev_sample_mean + std_dev_t * torch.sqrt(-1 * dt) * variance_noise
+
+    log_prob = (
+        -((prev_sample.detach() - prev_sample_mean) ** 2) / (2 * ((std_dev_t * torch.sqrt(-1 * dt)) ** 2))
+        - torch.log(std_dev_t * torch.sqrt(-1 * dt))
+        - torch.log(torch.sqrt(2 * torch.as_tensor(math.pi)))
+    )
+
+    # mean along all but batch dimension
+    log_prob = log_prob.mean(dim=tuple(range(1, log_prob.ndim)))
+
+    return prev_sample, pred_original_sample, log_prob
+
+
+def dance_grpo_step(
+    model_output: torch.Tensor,
+    latents: torch.Tensor,
+    eta: float,
+    sigmas: torch.Tensor,
+    index: int,
+    prev_sample: torch.Tensor,
+):
+    sigma = sigmas[index]
+    dsigma = sigmas[index + 1] - sigma  # neg dt
+    prev_sample_mean = latents + dsigma * model_output
+
+    pred_original_sample = latents - sigma * model_output
+
+    delta_t = sigma - sigmas[index + 1]  # pos -dt
+    std_dev_t = eta * math.sqrt(delta_t)
+
+    score_estimate = -(latents - pred_original_sample * (1 - sigma)) / sigma**2
+    log_term = -0.5 * eta**2 * score_estimate
+    prev_sample_mean = prev_sample_mean + log_term * dsigma
+
+    if prev_sample is None:
+        prev_sample = prev_sample_mean + torch.randn_like(prev_sample_mean) * std_dev_t
+
+    # log prob of prev_sample given prev_sample_mean and std_dev_t
+    log_prob = -((prev_sample.detach().to(torch.float32) - prev_sample_mean.to(torch.float32)) ** 2) / (
+        2 * (std_dev_t**2)
+    )
+    -math.log(std_dev_t) - torch.log(torch.sqrt(2 * torch.as_tensor(math.pi)))
+
+    # mean along all but batch dimension
+    log_prob = log_prob.mean(dim=tuple(range(1, log_prob.ndim)))
+    return prev_sample, pred_original_sample, log_prob
+
+
+def ddim_step(
+    model_output: torch.Tensor,
+    latents: torch.Tensor,
+    eta: float,
+    sigmas: torch.Tensor,
+    index: int,
+    prev_sample: torch.Tensor,
+):
+    model_output = convert_model_output(model_output, latents, sigmas, step_index=index)
+    prev_sample, prev_sample_mean, std_dev_t, dt_sqrt = ddim_update(
+        model_output,
+        sigmas.to(torch.float64),
+        index,
+        latents,
+        eta=eta,
+    )
+
+    # Compute log_prob
+    log_prob = (
+        -((prev_sample.detach() - prev_sample_mean) ** 2) / (2 * ((std_dev_t * dt_sqrt) ** 2))
+        - torch.log(std_dev_t * dt_sqrt)
+        - torch.log(torch.sqrt(2 * torch.as_tensor(math.pi)))
+    )
+
+    # mean along all but batch dimension
+    log_prob = log_prob.mean(dim=tuple(range(1, log_prob.ndim)))
+    return prev_sample, model_output, log_prob
+
+
+@dataclass
+class DPMState:
+    order: int
+    model_outputs: List[torch.Tensor] = None
+    lower_order_nums = 0
+
+    def __post_init__(self):
+        self.model_outputs = [None] * self.order
+
+    def update(self, model_output: torch.Tensor):
+        for i in range(self.order - 1):
+            self.model_outputs[i] = self.model_outputs[i + 1]
+        self.model_outputs[-1] = model_output
+
+    def update_lower_order(self):
+        if self.lower_order_nums < self.order:
+            self.lower_order_nums += 1
+
+
+def dpm_step(
+    order,
+    model_output: torch.Tensor,
+    sample: torch.Tensor,
+    step_index: int,
+    timesteps: list,
+    sigmas: torch.Tensor,
+    dpm_state: DPMState = None,
+) -> torch.Tensor:
+
+    # Improve numerical stability for small number of steps
+    lower_order_final = step_index == len(timesteps) - 1
+    lower_order_second = (step_index == len(timesteps) - 2) and len(timesteps) < 15
+
+    model_output = convert_model_output(model_output, sample, sigmas, step_index=step_index)
+
+    assert dpm_state is not None
+    dpm_state.update(model_output)
+
+    # Upcast to avoid precision issues when computing prev_sample
+    sample = sample.to(torch.float32)
+
+    if order == 1 or dpm_state.lower_order_nums < 1 or lower_order_final:
+        if step_index == 0 or lower_order_final:
+            prev_sample, _, _, _ = ddim_update(
+                model_output,
+                sigmas.to(torch.float64),
+                step_index,
+                sample,
+                eta=0.0,
+            )
+        else:
+            prev_sample = dpm_solver_first_order_update(
+                model_output,
+                sigmas.to(torch.float64),
+                step_index,
+                sample,
+            )
+    elif order == 2 or dpm_state.lower_order_nums < 2 or lower_order_second:
+        prev_sample = multistep_dpm_solver_second_order_update(
+            dpm_state.model_outputs,
+            sigmas.to(torch.float64),
+            step_index,
+            sample,
+        )
+    else:
+        assert False
+
+    dpm_state.update_lower_order()
+
+    # Cast sample back to expected dtype
+    prev_sample = prev_sample.to(model_output.dtype)
+
+    return prev_sample, model_output, None
+
+
+def convert_model_output(
+    model_output,
+    sample,
+    sigmas,
+    step_index,
+) -> torch.Tensor:
+    sigma_t = sigmas[step_index]
+    x0_pred = sample - sigma_t * model_output
+
+    return x0_pred
+
+
+def ddim_update(
+    model_output: torch.Tensor,
+    sigmas,
+    step_index,
+    sample: torch.Tensor = None,
+    noise: Optional[torch.Tensor] = None,
+    eta: float = 1.0,
+) -> torch.Tensor:
+
+    t, s = sigmas[step_index + 1], sigmas[step_index]
+
+    std_dev_t = eta * t
+    dt_sqrt = torch.sqrt(1.0 - t**2 * (1 - s) ** 2 / (s**2 * (1 - t) ** 2))
+    rho_t = std_dev_t * dt_sqrt
+    noise_pred = (sample - (1 - s) * model_output) / s
+    if noise is None:
+        noise = torch.randn_like(model_output)
+    prev_mean = (1 - t) * model_output + torch.sqrt(t**2 - rho_t**2) * noise_pred
+    x_t = prev_mean + rho_t * noise
+
+    return x_t, prev_mean, std_dev_t, dt_sqrt
+
+
+def dpm_solver_first_order_update(
+    model_output: torch.Tensor,
+    sigmas,
+    step_index,
+    sample: torch.Tensor = None,
+) -> torch.Tensor:
+
+    sigma_t, sigma_s = sigmas[step_index + 1], sigmas[step_index]
+    alpha_t, sigma_t = _sigma_to_alpha_sigma_t(sigma_t)
+    alpha_s, sigma_s = _sigma_to_alpha_sigma_t(sigma_s)
+    lambda_t = torch.log(alpha_t) - torch.log(sigma_t)
+    lambda_s = torch.log(alpha_s) - torch.log(sigma_s)
+
+    h = lambda_t - lambda_s
+    x_t = (sigma_t / sigma_s) * sample - (alpha_t * (torch.exp(-h) - 1.0)) * model_output
+
+    return x_t
+
+
+def multistep_dpm_solver_second_order_update(
+    model_output_list: List[torch.Tensor],
+    sigmas,
+    step_index,
+    sample: torch.Tensor = None,
+) -> torch.Tensor:
+
+    sigma_t, sigma_s0, sigma_s1 = (
+        sigmas[step_index + 1],
+        sigmas[step_index],
+        sigmas[step_index - 1],
+    )
+
+    alpha_t, sigma_t = _sigma_to_alpha_sigma_t(sigma_t)
+    alpha_s0, sigma_s0 = _sigma_to_alpha_sigma_t(sigma_s0)
+    alpha_s1, sigma_s1 = _sigma_to_alpha_sigma_t(sigma_s1)
+
+    lambda_t = torch.log(alpha_t) - torch.log(sigma_t)
+    lambda_s0 = torch.log(alpha_s0) - torch.log(sigma_s0)
+    lambda_s1 = torch.log(alpha_s1) - torch.log(sigma_s1)
+
+    m0, m1 = model_output_list[-1], model_output_list[-2]
+
+    h, h_0 = lambda_t - lambda_s0, lambda_s0 - lambda_s1
+    r0 = h_0 / h
+    D0, D1 = m0, (1.0 / r0) * (m0 - m1)
+
+    x_t = (
+        (sigma_t / sigma_s0) * sample
+        - (alpha_t * (torch.exp(-h) - 1.0)) * D0
+        - 0.5 * (alpha_t * (torch.exp(-h) - 1.0)) * D1
+    )
+
+    return x_t
+
+
+def _sigma_to_alpha_sigma_t(sigma):
+    alpha_t = 1 - sigma
+    sigma_t = sigma
+    return alpha_t, sigma_t

--- a/diffusion/flow_grpo/diffusers_patch/train_dreambooth_lora_sd3.py
+++ b/diffusion/flow_grpo/diffusers_patch/train_dreambooth_lora_sd3.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import torch
+
+
+def _encode_prompt_with_t5(
+    text_encoder,
+    tokenizer,
+    max_sequence_length,
+    prompt=None,
+    num_images_per_prompt=1,
+    device=None,
+    text_input_ids=None,
+):
+    prompt = [prompt] if isinstance(prompt, str) else prompt
+    batch_size = len(prompt)
+
+    if tokenizer is not None:
+        text_inputs = tokenizer(
+            prompt,
+            padding="max_length",
+            max_length=max_sequence_length,
+            truncation=True,
+            add_special_tokens=True,
+            return_tensors="pt",
+        )
+        text_input_ids = text_inputs.input_ids
+    else:
+        if text_input_ids is None:
+            raise ValueError("text_input_ids must be provided when the tokenizer is not specified")
+
+    prompt_embeds = text_encoder(text_input_ids.to(device))[0]
+
+    dtype = text_encoder.dtype
+    prompt_embeds = prompt_embeds.to(dtype=dtype, device=device)
+
+    _, seq_len, _ = prompt_embeds.shape
+
+    # duplicate text embeddings and attention mask for each generation per prompt, using mps friendly method
+    prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
+    prompt_embeds = prompt_embeds.view(batch_size * num_images_per_prompt, seq_len, -1)
+
+    return prompt_embeds
+
+
+def _encode_prompt_with_clip(
+    text_encoder,
+    tokenizer,
+    prompt: str,
+    device=None,
+    text_input_ids=None,
+    num_images_per_prompt: int = 1,
+):
+    prompt = [prompt] if isinstance(prompt, str) else prompt
+    batch_size = len(prompt)
+
+    if tokenizer is not None:
+        text_inputs = tokenizer(
+            prompt,
+            padding="max_length",
+            max_length=77,
+            truncation=True,
+            return_tensors="pt",
+        )
+
+        text_input_ids = text_inputs.input_ids
+    else:
+        if text_input_ids is None:
+            raise ValueError("text_input_ids must be provided when the tokenizer is not specified")
+
+    prompt_embeds = text_encoder(text_input_ids.to(device), output_hidden_states=True)
+
+    pooled_prompt_embeds = prompt_embeds[0]
+    prompt_embeds = prompt_embeds.hidden_states[-2]
+    prompt_embeds = prompt_embeds.to(dtype=text_encoder.dtype, device=device)
+
+    _, seq_len, _ = prompt_embeds.shape
+    # duplicate text embeddings for each generation per prompt, using mps friendly method
+    prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
+    prompt_embeds = prompt_embeds.view(batch_size * num_images_per_prompt, seq_len, -1)
+
+    return prompt_embeds, pooled_prompt_embeds
+
+
+def encode_prompt(
+    text_encoders,
+    tokenizers,
+    prompt: str,
+    max_sequence_length,
+    device=None,
+    num_images_per_prompt: int = 1,
+    text_input_ids_list=None,
+):
+    prompt = [prompt] if isinstance(prompt, str) else prompt
+
+    clip_tokenizers = tokenizers[:2]
+    clip_text_encoders = text_encoders[:2]
+
+    clip_prompt_embeds_list = []
+    clip_pooled_prompt_embeds_list = []
+    for i, (tokenizer, text_encoder) in enumerate(zip(clip_tokenizers, clip_text_encoders)):
+        prompt_embeds, pooled_prompt_embeds = _encode_prompt_with_clip(
+            text_encoder=text_encoder,
+            tokenizer=tokenizer,
+            prompt=prompt,
+            device=device if device is not None else text_encoder.device,
+            num_images_per_prompt=num_images_per_prompt,
+            text_input_ids=text_input_ids_list[i] if text_input_ids_list else None,
+        )
+        clip_prompt_embeds_list.append(prompt_embeds)
+        clip_pooled_prompt_embeds_list.append(pooled_prompt_embeds)
+
+    clip_prompt_embeds = torch.cat(clip_prompt_embeds_list, dim=-1)
+    pooled_prompt_embeds = torch.cat(clip_pooled_prompt_embeds_list, dim=-1)
+
+    t5_prompt_embed = _encode_prompt_with_t5(
+        text_encoders[-1],
+        tokenizers[-1],
+        max_sequence_length,
+        prompt=prompt,
+        num_images_per_prompt=num_images_per_prompt,
+        text_input_ids=text_input_ids_list[-1] if text_input_ids_list else None,
+        device=device if device is not None else text_encoders[-1].device,
+    )
+
+    clip_prompt_embeds = torch.nn.functional.pad(
+        clip_prompt_embeds, (0, t5_prompt_embed.shape[-1] - clip_prompt_embeds.shape[-1])
+    )
+    prompt_embeds = torch.cat([clip_prompt_embeds, t5_prompt_embed], dim=-2)
+
+    return prompt_embeds, pooled_prompt_embeds

--- a/diffusion/flow_grpo/ema.py
+++ b/diffusion/flow_grpo/ema.py
@@ -1,0 +1,91 @@
+# Copied from another repo, but I can't remember exactly which one.
+
+from collections.abc import Iterable
+
+import torch
+
+
+class EMAModuleWrapper:
+    def __init__(
+        self,
+        parameters: Iterable[torch.nn.Parameter],
+        decay: float = 0.9999,
+        update_step_interval: int = 1,
+        device: torch.device | None = None,
+    ):
+        parameters = list(parameters)
+        self.ema_parameters = [p.clone().detach().to(device) for p in parameters]
+
+        self.temp_stored_parameters = None
+
+        self.decay = decay
+        self.update_step_interval = update_step_interval
+        self.device = device
+
+    def get_current_decay(self, optimization_step) -> float:
+        return min((1 + optimization_step) / (10 + optimization_step), self.decay)
+
+    @torch.no_grad()
+    def step(self, parameters: Iterable[torch.nn.Parameter], optimization_step):
+        parameters = list(parameters)
+
+        one_minus_decay = 1 - self.get_current_decay(optimization_step)
+
+        if (optimization_step + 1) % self.update_step_interval == 0:
+            for ema_parameter, parameter in zip(self.ema_parameters, parameters, strict=True):
+                if parameter.requires_grad:
+                    if ema_parameter.device == parameter.device:
+                        ema_parameter.add_(one_minus_decay * (parameter - ema_parameter))
+                    else:
+                        # in place calculations to save memory
+                        parameter_copy = parameter.detach().to(ema_parameter.device)
+                        parameter_copy.sub_(ema_parameter)
+                        parameter_copy.mul_(one_minus_decay)
+                        ema_parameter.add_(parameter_copy)
+                        del parameter_copy
+
+    def to(self, device: torch.device = None, dtype: torch.dtype = None) -> None:
+        self.device = device
+        self.ema_parameters = [
+            p.to(device=device, dtype=dtype) if p.is_floating_point() else p.to(device=device)
+            for p in self.ema_parameters
+        ]
+
+    @torch.no_grad()
+    def sync_with_model(self, parameters: Iterable[torch.nn.Parameter]) -> None:
+        """
+        Force the EMA parameters to be a direct copy of the given model parameters.
+        This is used to create a snapshot for the rollout policy.
+        """
+        parameters = list(parameters)
+        for ema_parameter, parameter in zip(self.ema_parameters, parameters, strict=True):
+            ema_parameter.data.copy_(parameter.detach().data)
+
+    def copy_ema_to(self, parameters: Iterable[torch.nn.Parameter], store_temp: bool = True, grad=False) -> None:
+        if store_temp:
+            if grad:
+                self.temp_stored_parameters = [parameter.data.clone() for parameter in parameters]
+            else:
+                self.temp_stored_parameters = [parameter.detach().cpu() for parameter in parameters]
+
+        parameters = list(parameters)
+        for ema_parameter, parameter in zip(self.ema_parameters, parameters, strict=True):
+            parameter.data.copy_(ema_parameter.to(parameter.device).data)
+
+    def copy_temp_to(self, parameters: Iterable[torch.nn.Parameter]) -> None:
+        for temp_parameter, parameter in zip(self.temp_stored_parameters, parameters, strict=True):
+            # Ensure the temp parameter is on the right device
+            parameter.data.copy_(temp_parameter.to(parameter.device))
+
+        self.temp_stored_parameters = None
+
+    def load_state_dict(self, state_dict: dict) -> None:
+        self.decay = self.decay if self.decay else state_dict.get("decay", self.decay)
+        self.ema_parameters = state_dict.get("ema_parameters")
+        self.to(self.device)
+
+    def state_dict(self) -> dict:
+        return {
+            "decay": self.decay,
+            "ema_parameters": self.ema_parameters,
+        }

--- a/diffusion/flow_grpo/gen_eval.py
+++ b/diffusion/flow_grpo/gen_eval.py
@@ -1,0 +1,409 @@
+import json
+import os
+import sys
+import time
+import warnings
+
+warnings.filterwarnings("ignore")
+
+from collections import defaultdict
+
+import mmdet
+import numpy as np
+import open_clip
+import torch
+from clip_benchmark.metrics import zeroshot_classification as zsc
+from mmdet.apis import inference_detector, init_detector
+from PIL import Image, ImageOps
+
+zsc.tqdm = lambda it, *args, **kwargs: it
+
+
+def load_geneval(DEVICE):
+    def timed(fn):
+        def wrapper(*args, **kwargs):
+            startt = time.time()
+            result = fn(*args, **kwargs)
+            endt = time.time()
+            print(
+                f"Function {fn.__name__!r} executed in {endt - startt:.3f}s",
+                file=sys.stderr,
+            )
+            return result
+
+        return wrapper
+
+    # Load models
+
+    @timed
+    def load_models():
+        CONFIG_PATH = os.path.join(
+            os.path.dirname(os.path.dirname(mmdet.__file__)),
+            "configs/mask2former/mask2former_swin-s-p4-w7-224_lsj_8x2_50e_coco.py",
+        )
+        OBJECT_DETECTOR = "mask2former_swin-s-p4-w7-224_lsj_8x2_50e_coco_20220504_001756-743b7d99"
+        from flow_grpo.reward_ckpt_path import CKPT_PATH
+
+        _CKPT_PATH = os.path.join(CKPT_PATH, f"{OBJECT_DETECTOR}.pth")
+        object_detector = init_detector(CONFIG_PATH, _CKPT_PATH, device=DEVICE)
+
+        clip_arch = "ViT-L-14"
+        clip_model, _, transform = open_clip.create_model_and_transforms(clip_arch, pretrained="openai", device=DEVICE)
+        tokenizer = open_clip.get_tokenizer(clip_arch)
+
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets/object_names.txt")) as cls_file:
+            classnames = [line.strip() for line in cls_file]
+
+        return object_detector, (clip_model, transform, tokenizer), classnames
+
+    COLORS = [
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "blue",
+        "purple",
+        "pink",
+        "brown",
+        "black",
+        "white",
+    ]
+    COLOR_CLASSIFIERS = {}
+
+    # Evaluation parts
+
+    class ImageCrops(torch.utils.data.Dataset):
+        def __init__(self, image: Image.Image, objects):
+            self._image = image.convert("RGB")
+            bgcolor = "#999"
+            if bgcolor == "original":
+                self._blank = self._image.copy()
+            else:
+                self._blank = Image.new("RGB", image.size, color=bgcolor)
+            self._objects = objects
+
+        def __len__(self):
+            return len(self._objects)
+
+        def __getitem__(self, index):
+            box, mask = self._objects[index]
+            if mask is not None:
+                assert tuple(self._image.size[::-1]) == tuple(mask.shape), (
+                    index,
+                    self._image.size[::-1],
+                    mask.shape,
+                )
+                image = Image.composite(self._image, self._blank, Image.fromarray(mask))
+            else:
+                image = self._image
+            image = image.crop(box[:4])
+            return (transform(image), 0)
+
+    def color_classification(image, bboxes, classname):
+        if classname not in COLOR_CLASSIFIERS:
+            COLOR_CLASSIFIERS[classname] = zsc.zero_shot_classifier(
+                clip_model,
+                tokenizer,
+                COLORS,
+                [
+                    f"a photo of a {{c}} {classname}",
+                    f"a photo of a {{c}}-colored {classname}",
+                    f"a photo of a {{c}} object",
+                ],
+                str(DEVICE),
+            )
+        clf = COLOR_CLASSIFIERS[classname]
+        dataloader = torch.utils.data.DataLoader(ImageCrops(image, bboxes), batch_size=16, num_workers=4)
+        with torch.no_grad():
+            pred, _ = zsc.run_classification(clip_model, clf, dataloader, str(DEVICE))
+            return [COLORS[index.item()] for index in pred.argmax(1)]
+
+    def compute_iou(box_a, box_b):
+        area_fn = lambda box: max(box[2] - box[0] + 1, 0) * max(box[3] - box[1] + 1, 0)
+        i_area = area_fn(
+            [
+                max(box_a[0], box_b[0]),
+                max(box_a[1], box_b[1]),
+                min(box_a[2], box_b[2]),
+                min(box_a[3], box_b[3]),
+            ]
+        )
+        u_area = area_fn(box_a) + area_fn(box_b) - i_area
+        return i_area / u_area if u_area else 0
+
+    def relative_position(obj_a, obj_b):
+        """Give position of A relative to B, factoring in object dimensions"""
+        boxes = np.array([obj_a[0], obj_b[0]])[:, :4].reshape(2, 2, 2)
+        center_a, center_b = boxes.mean(axis=-2)
+        dim_a, dim_b = np.abs(np.diff(boxes, axis=-2))[..., 0, :]
+        offset = center_a - center_b
+        #
+        revised_offset = np.maximum(np.abs(offset) - POSITION_THRESHOLD * (dim_a + dim_b), 0) * np.sign(offset)
+        if np.all(np.abs(revised_offset) < 1e-3):
+            return set()
+        #
+        dx, dy = revised_offset / np.linalg.norm(offset)
+        relations = set()
+        if dx < -0.5:
+            relations.add("left of")
+        if dx > 0.5:
+            relations.add("right of")
+        if dy < -0.5:
+            relations.add("above")
+        if dy > 0.5:
+            relations.add("below")
+        return relations
+
+    def evaluate(image, objects, metadata):
+        """
+        Evaluate given image using detected objects on the global metadata specifications.
+        Assumptions:
+        * Metadata combines 'include' clauses with AND, and 'exclude' clauses with OR
+        * All clauses are independent, i.e., duplicating a clause has no effect on the correctness
+        * CHANGED: Color and position will only be evaluated on the most confidently predicted objects;
+            therefore, objects are expected to appear in sorted order
+        """
+        correct = True
+        reason = []
+        matched_groups = []
+        # Check for expected objects
+        for req in metadata.get("include", []):
+            classname = req["class"]
+            matched = True
+            found_objects = objects.get(classname, [])[: req["count"]]
+            if len(found_objects) < req["count"]:
+                correct = matched = False
+                reason.append(f"expected {classname}>={req['count']}, found {len(found_objects)}")
+            else:
+                if "color" in req:
+                    # Color check
+                    colors = color_classification(image, found_objects, classname)
+                    if colors.count(req["color"]) < req["count"]:
+                        correct = matched = False
+                        reason.append(
+                            f"expected {req['color']} {classname}>={req['count']}, found "
+                            + f"{colors.count(req['color'])} {req['color']}; and "
+                            + ", ".join(f"{colors.count(c)} {c}" for c in COLORS if c in colors)
+                        )
+                if "position" in req and matched:
+                    # Relative position check
+                    expected_rel, target_group = req["position"]
+                    if matched_groups[target_group] is None:
+                        correct = matched = False
+                        reason.append(f"no target for {classname} to be {expected_rel}")
+                    else:
+                        for obj in found_objects:
+                            for target_obj in matched_groups[target_group]:
+                                true_rels = relative_position(obj, target_obj)
+                                if expected_rel not in true_rels:
+                                    correct = matched = False
+                                    reason.append(
+                                        f"expected {classname} {expected_rel} target, found "
+                                        + f"{' and '.join(true_rels)} target"
+                                    )
+                                    break
+                            if not matched:
+                                break
+            if matched:
+                matched_groups.append(found_objects)
+            else:
+                matched_groups.append(None)
+        # Check for non-expected objects
+        for req in metadata.get("exclude", []):
+            classname = req["class"]
+            if len(objects.get(classname, [])) >= req["count"]:
+                correct = False
+                reason.append(f"expected {classname}<{req['count']}, found {len(objects[classname])}")
+        return correct, "\n".join(reason)
+
+    def evaluate_reward(image, objects, metadata):
+        """
+        Evaluate given image using detected objects on the global metadata specifications.
+        Assumptions:
+        * Metadata combines 'include' clauses with AND, and 'exclude' clauses with OR
+        * All clauses are independent, i.e., duplicating a clause has no effect on the correctness
+        * CHANGED: Color and position will only be evaluated on the most confidently predicted objects;
+            therefore, objects are expected to appear in sorted order
+        """
+        correct = True
+        reason = []
+        rewards = []
+        matched_groups = []
+        # Check for expected objects
+        for req in metadata.get("include", []):
+            classname = req["class"]
+            matched = True
+            found_objects = objects.get(classname, [])
+            rewards.append(1 - abs(req["count"] - len(found_objects)) / req["count"])
+            if len(found_objects) != req["count"]:
+                correct = matched = False
+                reason.append(f"expected {classname}=={req['count']}, found {len(found_objects)}")
+                if "color" in req or "position" in req:
+                    rewards.append(0.0)
+            else:
+                if "color" in req:
+                    # Color check
+                    colors = color_classification(image, found_objects, classname)
+                    rewards.append(1 - abs(req["count"] - colors.count(req["color"])) / req["count"])
+                    if colors.count(req["color"]) != req["count"]:
+                        correct = matched = False
+                        reason.append(
+                            f"expected {req['color']} {classname}>={req['count']}, found "
+                            + f"{colors.count(req['color'])} {req['color']}; and "
+                            + ", ".join(f"{colors.count(c)} {c}" for c in COLORS if c in colors)
+                        )
+                if "position" in req and matched:
+                    # Relative position check
+                    expected_rel, target_group = req["position"]
+                    if matched_groups[target_group] is None:
+                        correct = matched = False
+                        reason.append(f"no target for {classname} to be {expected_rel}")
+                        rewards.append(0.0)
+                    else:
+                        for obj in found_objects:
+                            for target_obj in matched_groups[target_group]:
+                                true_rels = relative_position(obj, target_obj)
+                                if expected_rel not in true_rels:
+                                    correct = matched = False
+                                    reason.append(
+                                        f"expected {classname} {expected_rel} target, found "
+                                        + f"{' and '.join(true_rels)} target"
+                                    )
+                                    rewards.append(0.0)
+                                    break
+                            if not matched:
+                                break
+                        rewards.append(1.0)
+            if matched:
+                matched_groups.append(found_objects)
+            else:
+                matched_groups.append(None)
+        reward = sum(rewards) / len(rewards) if rewards else 0
+        return correct, reward, "\n".join(reason)
+
+    def evaluate_image(image_pils, metadatas, only_strict):
+        results = inference_detector(object_detector, [np.array(image_pil) for image_pil in image_pils])
+        ret = []
+        for result, image_pil, metadata in zip(results, image_pils, metadatas):
+            bbox = result[0] if isinstance(result, tuple) else result
+            segm = result[1] if isinstance(result, tuple) and len(result) > 1 else None
+            image = ImageOps.exif_transpose(image_pil)
+            detected = {}
+            # Determine bounding boxes to keep
+            confidence_threshold = THRESHOLD if metadata["tag"] != "counting" else COUNTING_THRESHOLD
+            for index, classname in enumerate(classnames):
+                ordering = np.argsort(bbox[index][:, 4])[::-1]
+                ordering = ordering[bbox[index][ordering, 4] > confidence_threshold]  # Threshold
+                ordering = ordering[:MAX_OBJECTS].tolist()  # Limit number of detected objects per class
+                detected[classname] = []
+                while ordering:
+                    max_obj = ordering.pop(0)
+                    detected[classname].append(
+                        (
+                            bbox[index][max_obj],
+                            None if segm is None else segm[index][max_obj],
+                        )
+                    )
+                    ordering = [
+                        obj
+                        for obj in ordering
+                        if NMS_THRESHOLD == 1 or compute_iou(bbox[index][max_obj], bbox[index][obj]) < NMS_THRESHOLD
+                    ]
+                if not detected[classname]:
+                    del detected[classname]
+            # Evaluate
+            is_strict_correct, score, reason = evaluate_reward(image, detected, metadata)
+            if only_strict:
+                is_correct = False
+            else:
+                is_correct, _ = evaluate(image, detected, metadata)
+            ret.append(
+                {
+                    "tag": metadata["tag"],
+                    "prompt": metadata["prompt"],
+                    "correct": is_correct,
+                    "strict_correct": is_strict_correct,
+                    "score": score,
+                    "reason": reason,
+                    "metadata": json.dumps(metadata),
+                    "details": json.dumps({key: [box.tolist() for box, _ in value] for key, value in detected.items()}),
+                }
+            )
+        return ret
+
+    object_detector, (clip_model, transform, tokenizer), classnames = load_models()
+    THRESHOLD = 0.3
+    COUNTING_THRESHOLD = 0.9
+    MAX_OBJECTS = 16
+    NMS_THRESHOLD = 1.0
+    POSITION_THRESHOLD = 0.1
+
+    @torch.no_grad()
+    def compute_geneval(images, metadatas, only_strict=False):
+        required_keys = [
+            "single_object",
+            "two_object",
+            "counting",
+            "colors",
+            "position",
+            "color_attr",
+        ]
+        scores = []
+        strict_rewards = []
+        grouped_strict_rewards = defaultdict(list)
+        rewards = []
+        grouped_rewards = defaultdict(list)
+        results = evaluate_image(images, metadatas, only_strict=only_strict)
+        # print(results)
+        for result in results:
+            strict_rewards.append(1.0 if result["strict_correct"] else 0.0)
+            scores.append(result["score"])
+            rewards.append(1.0 if result["correct"] else 0.0)
+            tag = result["tag"]
+            for key in required_keys:
+                if key != tag:
+                    grouped_strict_rewards[key].append(-10.0)
+                    grouped_rewards[key].append(-10.0)
+                else:
+                    grouped_strict_rewards[tag].append(1.0 if result["strict_correct"] else 0.0)
+                    grouped_rewards[tag].append(1.0 if result["correct"] else 0.0)
+        return (
+            scores,
+            rewards,
+            strict_rewards,
+            dict(grouped_rewards),
+            dict(grouped_strict_rewards),
+        )
+
+    return compute_geneval
+
+
+if __name__ == "__main__":
+    data = {
+        "images": [
+            Image.open(
+                os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)),
+                    "test_cases/a photo of a brown giraffe and a white stop sign.png",
+                )
+            )
+        ],
+        "metadatas": [
+            {
+                "tag": "color_attr",
+                "include": [
+                    {"class": "giraffe", "count": 1, "color": "red"},
+                    {"class": "stop sign", "count": 1, "color": "white"},
+                ],
+                "prompt": "a photo of a brown giraffe and a white stop sign",
+            }
+        ],
+        "only_strict": False,
+    }
+    compute_geneval = load_geneval("cuda")
+    scores, rewards, strict_rewards, group_rewards, group_strict_rewards = compute_geneval(**data)
+    print(f"Score: {scores}")
+    print(f"Reward: {rewards}")
+    print(f"Strict reward: {strict_rewards}")
+    print(f"Group reward: {group_rewards}")
+    print(f"Group strict reward: {group_strict_rewards}")

--- a/diffusion/flow_grpo/hpsv2_scorer.py
+++ b/diffusion/flow_grpo/hpsv2_scorer.py
@@ -1,0 +1,155 @@
+import os
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torchvision.transforms.functional as F
+from hpsv2.src.open_clip import create_model, get_tokenizer
+from PIL import Image
+from torchvision.transforms import Compose, InterpolationMode, Normalize, ToTensor
+
+from diffusion.flow_grpo.reward_ckpt_path import CKPT_PATH
+
+OPENAI_DATASET_MEAN = (0.48145466, 0.4578275, 0.40821073)
+OPENAI_DATASET_STD = (0.26862954, 0.26130258, 0.27577711)
+
+
+class ResizeMaxSize(nn.Module):
+    def __init__(self, max_size, interpolation=InterpolationMode.BICUBIC, fn="max", fill=0):
+        super().__init__()
+        if not isinstance(max_size, int):
+            raise TypeError(f"Size should be int. Got {type(max_size)}")
+        self.max_size = max_size
+        self.interpolation = interpolation
+        self.fn = min if fn == "min" else min  # Note: both 'min' and 'max' map to min
+        self.fill = fill
+
+    def forward(self, img):
+        if isinstance(img, torch.Tensor):
+            # Assuming NCHW, get H and W from the last two dimensions
+            height, width = img.shape[-2:]
+        else:
+            width, height = img.size
+        scale = self.max_size / float(max(height, width))
+        if scale != 1.0:
+            new_size = tuple(round(dim * scale) for dim in (height, width))
+            img = F.resize(img, new_size, self.interpolation)
+            pad_h = self.max_size - new_size[0]
+            pad_w = self.max_size - new_size[1]
+            img = F.pad(img, padding=[pad_w // 2, pad_h // 2, pad_w - pad_w // 2, pad_h - pad_h // 2], fill=self.fill)
+        return img
+
+
+class MaskAwareNormalize(nn.Module):
+    def __init__(self, mean, std):
+        super().__init__()
+        self.normalize = Normalize(mean=mean, std=std)
+
+    def forward(self, tensor):
+        # Assuming NCHW, check the channel dimension
+        if tensor.shape[1] == 4:
+            # Process each image in the batch
+            normalized_parts = []
+            for i in range(tensor.shape[0]):
+                img_slice = tensor[i]
+                normalized_rgb = self.normalize(img_slice[:3])
+                alpha_channel = img_slice[3:]
+                normalized_parts.append(torch.cat([normalized_rgb, alpha_channel], dim=0))
+            return torch.stack(normalized_parts, dim=0)
+        else:
+            return self.normalize(tensor)
+
+
+def image_transform_tensor(
+    image_size: int,
+    mean: tuple = None,
+    std: tuple = None,
+    fill_color: int = 0,
+):
+    mean = mean or OPENAI_DATASET_MEAN
+    std = std or OPENAI_DATASET_STD
+
+    if not isinstance(mean, (list, tuple)):
+        mean = (mean,) * 3
+    if not isinstance(std, (list, tuple)):
+        std = (std,) * 3
+
+    normalize = MaskAwareNormalize(mean=mean, std=std)
+
+    transforms = [
+        ResizeMaxSize(image_size, fill=fill_color),
+        normalize,
+    ]
+    return Compose(transforms)
+
+
+class HPSv2Scorer(nn.Module):
+    def __init__(self, dtype, device):
+        super().__init__()
+        self.dtype = dtype
+        self.device = device
+        model = create_model(
+            "ViT-H-14",
+            os.path.join(CKPT_PATH, "open_clip_pytorch_model.bin"),
+            precision="amp",
+            device=device,
+            jit=False,
+            force_quick_gelu=False,
+            force_custom_text=False,
+            force_patch_dropout=False,
+            force_image_size=None,
+            pretrained_image=False,
+            output_dict=True,
+        )
+
+        image_mean = getattr(model.visual, "image_mean", None)
+        image_std = getattr(model.visual, "image_std", None)
+        image_size = model.visual.image_size
+        if isinstance(image_size, tuple):
+            image_size = image_size[0]
+        preprocess_val = image_transform_tensor(
+            image_size,
+            mean=image_mean,
+            std=image_std,
+        )
+
+        self.model = model.to(device)
+        self.preprocess_val = preprocess_val
+        checkpoint = torch.load(os.path.join(CKPT_PATH, "HPS_v2.1_compressed.pt"), map_location="cpu")
+        self.model.load_state_dict(checkpoint["state_dict"])
+        self.processor = get_tokenizer("ViT-H-14")
+        self.eval()
+
+    @torch.no_grad()
+    def __call__(self, images, prompts):
+        image = self.preprocess_val(images.to(self.dtype).to(device=self.device, non_blocking=True))
+        # Process the prompt
+        text = self.processor(prompts).to(device=self.device, non_blocking=True)
+        outputs = self.model(image, text)
+        image_features, text_features = outputs["image_features"], outputs["text_features"]
+        logits_per_image = image_features @ text_features.T
+        hps_score = torch.diagonal(logits_per_image, 0)
+        return hps_score.contiguous()
+
+
+def main():
+    scorer = HPSv2Scorer(dtype=torch.float32, device="cuda")
+
+    images = [
+        "test_cases/nasa.jpg",
+        "test_cases/hello world.jpg",
+    ]
+    pil_images = [Image.open(img) for img in images]
+    prompts = [
+        'An astronaut’s glove floating in zero-g with "NASA 2049" on the wrist',
+        'New York Skyline with "Hello World" written with fireworks on the sky',
+    ]
+    images = [np.array(img) for img in pil_images]
+    images = np.array(images)
+    images = images.transpose(0, 3, 1, 2)  # NHWC -> NCHW
+    images = torch.tensor(images, dtype=torch.uint8) / 255.0
+    print(scorer(images, prompts))
+
+
+if __name__ == "__main__":
+    main()

--- a/diffusion/flow_grpo/imagereward_scorer.py
+++ b/diffusion/flow_grpo/imagereward_scorer.py
@@ -1,0 +1,128 @@
+import os
+
+import torch
+
+# ---------------------------------------------------------------------------
+# Compatibility shim: ImageReward's vendored BLIP imports three helpers that
+# were removed from transformers >= 5.0.  Inject them back before the import.
+# ---------------------------------------------------------------------------
+import transformers.modeling_utils as _mu
+from PIL import Image
+
+if not hasattr(_mu, "apply_chunking_to_forward"):
+
+    def _apply_chunking_to_forward(forward_fn, chunk_size, chunk_dim, *input_tensors):
+        if chunk_size > 0:
+            num_chunks = input_tensors[0].shape[chunk_dim] // chunk_size
+            input_chunks = tuple(t.chunk(num_chunks, dim=chunk_dim) for t in input_tensors)
+            output_chunks = tuple(forward_fn(*chunk) for chunk in zip(*input_chunks))
+            return torch.cat(output_chunks, dim=chunk_dim)
+        return forward_fn(*input_tensors)
+
+    _mu.apply_chunking_to_forward = _apply_chunking_to_forward
+
+if not hasattr(_mu, "find_pruneable_heads_and_indices"):
+
+    def _find_pruneable_heads_and_indices(heads, n_heads, head_size, already_pruned_heads):
+        mask = torch.ones(n_heads, head_size)
+        heads = set(heads) - already_pruned_heads
+        for head in heads:
+            head -= sum(1 if h < head else 0 for h in already_pruned_heads)
+            mask[head] = 0
+        return heads, mask.view(-1).contiguous().eq(1).nonzero().squeeze()
+
+    _mu.find_pruneable_heads_and_indices = _find_pruneable_heads_and_indices
+
+if not hasattr(_mu, "prune_linear_layer"):
+
+    def _prune_linear_layer(layer, index, dim=0):
+        W = layer.weight.index_select(dim, index.to(layer.weight.device)).clone().detach()
+        if layer.bias is not None:
+            if dim == 1:
+                b = layer.bias.clone().detach()
+            else:
+                b = layer.bias[index].clone().detach()
+        new_size = list(layer.weight.size())
+        new_size[dim] = len(index)
+        new_layer = torch.nn.Linear(new_size[1], new_size[0], bias=layer.bias is not None).to(layer.weight.device)
+        new_layer.weight.requires_grad_(False)
+        new_layer.weight.copy_(W)
+        new_layer.weight.requires_grad_(True)
+        if layer.bias is not None:
+            new_layer.bias.requires_grad_(False)
+            new_layer.bias.copy_(b)
+            new_layer.bias.requires_grad_(True)
+        return new_layer
+
+    _mu.prune_linear_layer = _prune_linear_layer
+# ---------------------------------------------------------------------------
+
+import ImageReward as RM
+
+# Replace BLIP's init_tokenizer to avoid additional_special_tokens_ids
+# (removed in transformers 5.x) and patch all_tied_weights_keys.
+import ImageReward.models.BLIP.blip_pretrain as _blip_pt
+
+
+def _patched_init_tokenizer():
+    from transformers import BertTokenizer
+
+    tokenizer = BertTokenizer.from_pretrained("bert-base-uncased")
+    tokenizer.add_special_tokens({"bos_token": "[DEC]"})
+    tokenizer.add_special_tokens({"additional_special_tokens": ["[ENC]"]})
+    tokenizer.enc_token_id = tokenizer.convert_tokens_to_ids("[ENC]")
+    return tokenizer
+
+
+_blip_pt.init_tokenizer = _patched_init_tokenizer
+
+# Patch PreTrainedModel to add all_tied_weights_keys if missing
+# (renamed to _tied_weights_keys in transformers 5.x)
+from transformers import PreTrainedModel as _PTM
+
+if not hasattr(_PTM, "all_tied_weights_keys"):
+    _PTM.all_tied_weights_keys = property(lambda self: getattr(self, "_tied_weights_keys", []))
+# ---------------------------------------------------------------------------
+
+
+class ImageRewardScorer(torch.nn.Module):
+    def __init__(self, device="cuda", dtype=torch.float32):
+        super().__init__()
+        self.device = device
+        self.dtype = dtype
+        self.model = (
+            RM.load(
+                "ImageReward-v1.0",
+                device=device,
+                download_root=os.path.join(os.environ.get("HF_HOME", "~/.cache/"), "ImageReward"),
+            )
+            .eval()
+            .to(dtype=dtype)
+        )
+        self.model.requires_grad_(False)
+
+    @torch.no_grad()
+    def __call__(self, prompts, images):
+        _, rewards = self.model.inference_rank(prompts, images)
+        rewards = torch.diagonal(torch.Tensor(rewards).to(self.device).reshape(len(prompts), len(prompts)), 0)
+        return rewards.contiguous()
+
+
+# Usage example
+def main():
+    scorer = ImageRewardScorer(device="cuda", dtype=torch.float32)
+
+    images = [
+        "test_cases/nasa.jpg",
+        "test_cases/hello world.jpg",
+    ]
+    pil_images = [Image.open(img) for img in images]
+    prompts = [
+        'An astronaut\'s glove floating in zero-g with "NASA 2049" on the wrist',
+        'New York Skyline with "Hello World" written with fireworks on the sky',
+    ]
+    print(scorer(prompts, pil_images))
+
+
+if __name__ == "__main__":
+    main()

--- a/diffusion/flow_grpo/ocr.py
+++ b/diffusion/flow_grpo/ocr.py
@@ -1,0 +1,74 @@
+from typing import List, Union
+
+import numpy as np
+import torch
+from Levenshtein import distance
+from paddleocr import PaddleOCR
+from PIL import Image
+
+
+class OcrScorer:
+    def __init__(self, use_gpu: bool = False):
+        """
+        OCR reward calculator
+        :param use_gpu: Whether to use GPU acceleration for PaddleOCR
+        """
+        self.ocr = PaddleOCR(
+            use_angle_cls=False, lang="en", use_gpu=use_gpu, show_log=False  # Disable unnecessary log output
+        )
+
+    @torch.no_grad()
+    def __call__(self, images: Union[List[Image.Image], List[np.ndarray]], prompts: List[str]) -> torch.Tensor:
+        """
+        Calculate OCR reward
+        :param images: List of input images (PIL or numpy format)
+        :param prompts: Corresponding target text list
+        :return: Reward tensor (CPU)
+        """
+        prompts = [prompt.split('"')[1] for prompt in prompts]
+        rewards = []
+        # Ensure input lengths are consistent
+        assert len(images) == len(prompts), "Images and prompts must have the same length"
+        for img, prompt in zip(images, prompts):
+            # Convert image format
+            if isinstance(img, Image.Image):
+                img = np.array(img)
+
+            try:
+                # OCR recognition
+                result = self.ocr.ocr(img, cls=False)
+                # Extract recognized text (handle possible multi-line results)
+                recognized_text = (
+                    "".join([res[1][0] if res[1][1] > 0 else "" for res in result[0]]) if result[0] else ""
+                )
+
+                recognized_text = recognized_text.replace(" ", "").lower()
+                prompt = prompt.replace(" ", "").lower()
+                if prompt in recognized_text:
+                    dist = 0
+                else:
+                    dist = distance(recognized_text, prompt)
+                # Recognized many unrelated characters, only add one character penalty
+                if dist > len(prompt):
+                    dist = len(prompt)
+
+            except Exception as e:
+                # Error handling (e.g., OCR parsing failure)
+                print(f"OCR processing failed: {str(e)}")
+                dist = len(prompt)  # Maximum penalty
+            reward = 1 - dist / (len(prompt))
+            rewards.append(reward)
+
+        return rewards
+
+
+if __name__ == "__main__":
+    example_image_path = "test_cases/hello world.jpg"
+    example_image = Image.open(example_image_path)
+    example_prompt = 'New York Skyline with "Hello World" written with fireworks on the sky'
+    # Instantiate scorer
+    scorer = OcrScorer(use_gpu=False)
+
+    # Call scorer and print result
+    reward = scorer([example_image], [example_prompt])
+    print(f"OCR Reward: {reward}")

--- a/diffusion/flow_grpo/pickscore_scorer.py
+++ b/diffusion/flow_grpo/pickscore_scorer.py
@@ -1,0 +1,85 @@
+import torch
+from PIL import Image
+from transformers import AutoModel, AutoProcessor
+
+
+class PickScoreScorer(torch.nn.Module):
+    def __init__(self, device="cuda", dtype=torch.float32):
+        super().__init__()
+        processor_path = "laion/CLIP-ViT-H-14-laion2B-s32B-b79K"
+        model_path = "yuvalkirstain/PickScore_v1"
+        self.device = device
+        self.dtype = dtype
+        self.processor = AutoProcessor.from_pretrained(processor_path)
+        self.model = AutoModel.from_pretrained(model_path).eval().to(device)
+        self.model = self.model.to(dtype=dtype)
+
+    @staticmethod
+    def _as_embedding(features):
+        """Convert model output to [B, C] embedding tensor."""
+        if torch.is_tensor(features):
+            return features
+
+        # transformers BaseModelOutputWithPooling
+        if hasattr(features, "pooler_output") and features.pooler_output is not None:
+            return features.pooler_output
+        if hasattr(features, "last_hidden_state") and features.last_hidden_state is not None:
+            hidden = features.last_hidden_state
+            if hidden.ndim == 3:
+                return hidden.mean(dim=1)
+            return hidden
+
+        raise TypeError(f"Unsupported model output type: {type(features)}")
+
+    @torch.no_grad()
+    def __call__(self, prompt, images):
+        # Preprocess images
+        image_inputs = self.processor(
+            images=images,
+            padding=True,
+            truncation=True,
+            max_length=77,
+            return_tensors="pt",
+        )
+        image_inputs = {k: v.to(device=self.device) for k, v in image_inputs.items()}
+        # Preprocess text
+        text_inputs = self.processor(
+            text=prompt,
+            padding=True,
+            truncation=True,
+            max_length=77,
+            return_tensors="pt",
+        )
+        text_inputs = {k: v.to(device=self.device) for k, v in text_inputs.items()}
+
+        # Get embeddings
+        image_embs = self._as_embedding(self.model.get_image_features(**image_inputs))
+        image_embs = image_embs / image_embs.norm(p=2, dim=-1, keepdim=True)
+
+        text_embs = self._as_embedding(self.model.get_text_features(**text_inputs))
+        text_embs = text_embs / text_embs.norm(p=2, dim=-1, keepdim=True)
+
+        # Calculate scores
+        logit_scale = self.model.logit_scale.exp()
+        scores = logit_scale * (text_embs @ image_embs.T)
+        scores = scores.diag()
+        # norm到0-1
+        scores = scores / 26
+        return scores
+
+
+# Usage example
+def main():
+    scorer = PickScoreScorer(device="cuda", dtype=torch.float32)
+    images = [
+        "test_cases/nasa.jpg",
+    ]
+    pil_images = [Image.open(img) for img in images]
+    prompts = [
+        'An astronaut’s glove floating in zero-g with "NASA 2049" on the wrist',
+    ]
+    print(scorer(prompts, pil_images))
+
+
+if __name__ == "__main__":
+    main()

--- a/diffusion/flow_grpo/prompt_dataset.py
+++ b/diffusion/flow_grpo/prompt_dataset.py
@@ -1,0 +1,86 @@
+import json
+import os
+
+import torch
+from torch.utils.data import Dataset, Sampler
+
+
+class TextPromptDataset(Dataset):
+    def __init__(self, dataset, split="train"):
+        self.file_path = os.path.join(dataset, f"{split}.txt")
+        with open(self.file_path) as f:
+            self.prompts = [line.strip() for line in f.readlines()]
+        # if split == "test":
+        #     self.prompts = self.prompts
+        #     self.prompts = self.prompts[:1024]
+
+    def __len__(self):
+        return len(self.prompts)
+
+    def __getitem__(self, idx):
+        return {"prompt": self.prompts[idx], "metadata": {}}
+
+    @staticmethod
+    def collate_fn(examples):
+        prompts = [example["prompt"] for example in examples]
+        metadatas = [example["metadata"] for example in examples]
+        return prompts, metadatas
+
+
+class GenevalPromptDataset(Dataset):
+    def __init__(self, dataset, split="train"):
+        self.file_path = os.path.join(dataset, f"{split}_metadata.jsonl")
+        with open(self.file_path, encoding="utf-8") as f:
+            self.metadatas = [json.loads(line) for line in f]
+            self.prompts = [item["prompt"] for item in self.metadatas]
+        # if split == "test":
+        #     self.prompts = self.prompts[:256]
+
+    def __len__(self):
+        return len(self.prompts)
+
+    def __getitem__(self, idx):
+        return {"prompt": self.prompts[idx], "metadata": self.metadatas[idx]}
+
+    @staticmethod
+    def collate_fn(examples):
+        prompts = [example["prompt"] for example in examples]
+        metadatas = [example["metadata"] for example in examples]
+        return prompts, metadatas
+
+
+class DistributedKRepeatSampler(Sampler):
+    def __init__(self, dataset, batch_size, k, num_replicas, rank, seed=0):
+        self.dataset = dataset
+        self.batch_size = batch_size
+        self.k = k
+        self.num_replicas = num_replicas
+        self.rank = rank
+        self.seed = seed
+
+        self.total_samples = self.num_replicas * self.batch_size
+        assert (
+            self.total_samples % self.k == 0
+        ), f" total {self.total_samples} {self.k} k can not div n*b, k{k}-num_replicas{num_replicas}-batch_size{batch_size}"
+        self.m = self.total_samples // self.k
+        self.epoch = 0
+
+    def __iter__(self):
+        while True:
+            g = torch.Generator()
+            g.manual_seed(self.seed + self.epoch)
+            indices = torch.randperm(len(self.dataset), generator=g)[: self.m].tolist()
+            repeated_indices = [idx for idx in indices for _ in range(self.k)]
+
+            shuffled_indices = torch.randperm(len(repeated_indices), generator=g).tolist()
+            shuffled_samples = [repeated_indices[i] for i in shuffled_indices]
+
+            per_card_samples = []
+            for i in range(self.num_replicas):
+                start = i * self.batch_size
+                end = start + self.batch_size
+                per_card_samples.append(shuffled_samples[start:end])
+            yield per_card_samples[self.rank]
+
+    def set_epoch(self, epoch):
+        self.epoch = epoch

--- a/diffusion/flow_grpo/remote_hpsv2.py
+++ b/diffusion/flow_grpo/remote_hpsv2.py
@@ -1,0 +1,8 @@
+from diffusion.flow_grpo.remote_reward_base import RemoteImageRewardScorer
+
+
+class RemoteHPSv2Scorer(RemoteImageRewardScorer):
+    """Remote HPSv2 wrapper with strict request/response contract."""
+
+    def __init__(self):
+        super().__init__(reward_name="hpsv2", response_key="hpsv2")

--- a/diffusion/flow_grpo/remote_hpsv3.py
+++ b/diffusion/flow_grpo/remote_hpsv3.py
@@ -1,0 +1,8 @@
+from diffusion.flow_grpo.remote_reward_base import RemoteImageRewardScorer
+
+
+class RemoteHPSv3Scorer(RemoteImageRewardScorer):
+    """Remote HPSv3 wrapper with strict request/response contract."""
+
+    def __init__(self):
+        super().__init__(reward_name="hpsv3", response_key="hpsv3")

--- a/diffusion/flow_grpo/remote_image_reward.py
+++ b/diffusion/flow_grpo/remote_image_reward.py
@@ -1,0 +1,8 @@
+from diffusion.flow_grpo.remote_reward_base import RemoteImageRewardScorer
+
+
+class RemoteImageRewardServerScorer(RemoteImageRewardScorer):
+    """Remote ImageReward wrapper with strict request/response contract."""
+
+    def __init__(self):
+        super().__init__(reward_name="image_reward", response_key="image_reward")

--- a/diffusion/flow_grpo/remote_ocr.py
+++ b/diffusion/flow_grpo/remote_ocr.py
@@ -1,0 +1,25 @@
+from diffusion.flow_grpo.remote_reward_base import RemoteImageRewardScorer
+
+
+class RemoteOCRScorer(RemoteImageRewardScorer):
+    """Remote OCR wrapper with strict request/response contract."""
+
+    def __init__(self):
+        # OCR response key from remote service is "ocr_reward".
+        super().__init__(
+            reward_name="ocr",
+            response_key="ocr_reward",
+            extra_data={"ocr_use_gpu": True},
+        )
+
+    def build_request_prompts(self, prompts):
+        # Align to OCR examples that use a double-quoted target phrase.
+        normalized = []
+        for p in prompts:
+            if isinstance(p, str) and '"' not in p and p.count("'") >= 2:
+                first = p.find("'")
+                last = p.rfind("'")
+                if 0 <= first < last:
+                    p = p[:first] + '"' + p[first + 1 : last] + '"' + p[last + 1 :]
+            normalized.append(p)
+        return normalized

--- a/diffusion/flow_grpo/remote_pickscore.py
+++ b/diffusion/flow_grpo/remote_pickscore.py
@@ -1,0 +1,8 @@
+from diffusion.flow_grpo.remote_reward_base import RemoteImageRewardScorer
+
+
+class RemotePickScoreScorer(RemoteImageRewardScorer):
+    """Remote PickScore wrapper with strict request/response contract."""
+
+    def __init__(self):
+        super().__init__(reward_name="pickscore", response_key="pickscore")

--- a/diffusion/flow_grpo/remote_reward_base.py
+++ b/diffusion/flow_grpo/remote_reward_base.py
@@ -1,0 +1,133 @@
+import os
+import time
+from typing import Any, Dict, Optional, Sequence
+
+import numpy as np
+import torch
+
+from diffusion.flow_grpo.reward_client import CosmosImageRewardClient
+
+
+class RemoteImageRewardScorer:
+    """Adapter to use remote image reward server in training-style scorer API.
+
+    Subclasses should override at least:
+      - ``build_request_prompts`` when prompt format differs
+      - ``build_extra_data`` when request json needs extra fields
+      - ``extract_scores`` when response key/shape differs
+    """
+
+    def __init__(
+        self,
+        reward_name: str,
+        response_key: Optional[str] = None,
+        host: Optional[str] = None,
+        token: Optional[str] = None,
+        extra_data: Optional[Dict[str, Any]] = None,
+        poll_interval: float = 1.0,
+        max_wait_seconds: float = 120.0,
+        wait_before_fetch: Optional[float] = None,
+    ):
+        self.reward_name = reward_name
+        self.response_key = response_key or reward_name
+        self.extra_data = extra_data or {}
+        self.poll_interval = float(poll_interval)
+        self.max_wait_seconds = float(max_wait_seconds)
+        # Match reward_client.py behavior: wait before first pull.
+        default_wait = float(os.environ.get("REMOTE_REWARD_WAIT_BEFORE_FETCH", "20.0"))
+        self.wait_before_fetch = float(default_wait if wait_before_fetch is None else wait_before_fetch)
+        self.client = CosmosImageRewardClient(
+            host=(host or os.environ.get("REMOTE_REWARD_HOST") or "https://cosmos-reward-image.dgxc-lepton.nvidia.com"),
+            token=(token if token is not None else os.environ.get("REMOTE_REWARD_TOKEN")),
+            reward_fn={reward_name: 1.0},
+            name=reward_name,
+        )
+
+    def build_request_prompts(self, prompts: Sequence[str]) -> list[str]:
+        """Build prompt list sent to remote server."""
+        return list(prompts)
+
+    def build_extra_data(self) -> Dict[str, Any]:
+        """Build extra request fields sent to remote server."""
+        return dict(self.extra_data)
+
+    def extract_scores(self, result: Dict[str, Any], batch_size: int) -> np.ndarray:
+        """Extract reward vector from remote response."""
+        score_dict = result.get("scores", {})
+        if self.response_key not in score_dict:
+            raise RuntimeError(
+                f"[{self.reward_name}] response missing expected key '{self.response_key}'. "
+                f"Available keys: {list(score_dict.keys())}. Raw response: {result}"
+            )
+        return self._normalize_length(score_dict[self.response_key], batch_size)
+
+    @staticmethod
+    def _to_uint8_nhwc(images: Any) -> np.ndarray:
+        if isinstance(images, torch.Tensor):
+            # NCHW float [0,1] -> NHWC uint8
+            arr = (images * 255.0).round().clamp(0, 255).to(torch.uint8).detach().cpu().numpy()
+            if arr.ndim != 4:
+                raise ValueError(f"Expected 4D tensor images, got shape {arr.shape}")
+            return arr.transpose(0, 2, 3, 1)
+        arr = np.asarray(images)
+        if arr.ndim != 4:
+            raise ValueError(f"Expected 4D images, got shape {arr.shape}")
+        # Accept NHWC uint8 directly.
+        if arr.shape[-1] == 3:
+            if arr.dtype != np.uint8:
+                arr = np.clip(arr, 0, 255).astype(np.uint8)
+            return arr
+        # Accept NCHW.
+        if arr.shape[1] == 3:
+            if arr.dtype != np.uint8:
+                arr = np.clip(arr, 0, 255).astype(np.uint8)
+            return arr.transpose(0, 2, 3, 1)
+        raise ValueError(f"Unsupported image shape {arr.shape}. Need NHWC or NCHW with 3 channels.")
+
+    @staticmethod
+    def _normalize_length(scores: Sequence[float], batch_size: int) -> np.ndarray:
+        arr = np.asarray(scores, dtype=np.float32).reshape(-1)
+        if arr.shape[0] == batch_size:
+            return arr
+        raise RuntimeError(f"Remote reward result length mismatch: got {arr.shape[0]}, expected {batch_size}.")
+
+    def __call__(self, images: Any, prompts: Sequence[str]) -> np.ndarray:
+        images_np = self._to_uint8_nhwc(images)
+        prompts = self.build_request_prompts(prompts)
+        batch_size = images_np.shape[0]
+        if len(prompts) != batch_size:
+            raise ValueError(f"Prompt count ({len(prompts)}) != image batch size ({batch_size})")
+
+        try:
+            task = self.client.submit_task(prompts, images_np, extra_data=self.build_extra_data())
+        except Exception as e:
+            raise RuntimeError(
+                f"[{self.reward_name}] submit_task failed. "
+                f"host={self.client.host}, token_set={self.client.token is not None}. "
+                f"Original error: {e}"
+            ) from e
+
+        if self.wait_before_fetch > 0:
+            time.sleep(self.wait_before_fetch)
+
+        deadline = time.time() + self.max_wait_seconds
+        reward_type = task["reward_types"][0]
+        while time.time() < deadline:
+            try:
+                result = self.client.check_results(task["uuid"], reward_type, replica_id=task["replica_id"])
+            except Exception as e:
+                raise RuntimeError(
+                    f"[{self.reward_name}] check_results failed for uuid={task['uuid']}, "
+                    f"reward_type={reward_type}. Original error: {e}"
+                ) from e
+
+            if result is None:
+                time.sleep(self.poll_interval)
+                continue
+
+            return self.extract_scores(result, batch_size)
+
+        raise TimeoutError(
+            f"[{self.reward_name}] timed out waiting for reward result after {self.max_wait_seconds}s. "
+            f"uuid={task['uuid']}, reward_type={reward_type}"
+        )

--- a/diffusion/flow_grpo/reward_ckpt_path.py
+++ b/diffusion/flow_grpo/reward_ckpt_path.py
@@ -1,0 +1,3 @@
+import os
+
+CKPT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../reward_ckpts")

--- a/diffusion/flow_grpo/reward_client.py
+++ b/diffusion/flow_grpo/reward_client.py
@@ -1,0 +1,482 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import json
+import time
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Dict, List, Optional
+
+import numpy as np
+import requests
+import torch
+
+
+def log(msg: str) -> None:
+    ts = time.strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[{ts}] {msg}", flush=True)
+
+
+class CosmosImageRewardClient:
+    """Client for the Cosmos image reward service.
+
+    Supports HPSv2, ImageReward, OCR, and GenEval reward functions.
+    Accepts raw RGB images (numpy uint8) instead of encoded latents.
+    """
+
+    def __init__(
+        self,
+        host: str = "http://localhost:8080",
+        token: Optional[str] = None,
+        reward_fn: Optional[Dict[str, float]] = None,
+        name: str = "hpsv2",
+    ):
+        self.host = host.rstrip("/")
+        self.token = token
+        self.reward_fn = reward_fn or {"hpsv2": 1.0}
+        self.name = name
+        self.batch_size_dict: Dict[str, int] = {}
+
+    def _make_headers(self, replica_id: Optional[str] = None, extra: Optional[dict] = None) -> dict:
+        headers: dict = {}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        if replica_id:
+            headers["X-Lepton-Replica-Target"] = replica_id
+        if extra:
+            headers.update(extra)
+        return headers
+
+    def ping(self) -> dict:
+        """Check server availability."""
+        resp = requests.post(
+            f"{self.host}/api/reward/ping",
+            data={"info_data": json.dumps({"reward_fn": self.reward_fn})},
+            headers=self._make_headers(),
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def submit_task(
+        self,
+        prompts: List[str],
+        images: np.ndarray,
+        reward_fn: Optional[Dict[str, float]] = None,
+        extra_data: Optional[dict] = None,
+    ) -> dict:
+        """Submit images for reward calculation.
+
+        Args:
+            prompts: list of text prompts, one per image.
+            images: uint8 numpy array of shape [B, H, W, 3].
+            reward_fn: override reward function weights (defaults to self.reward_fn).
+            extra_data: additional fields merged into the request JSON
+                        (e.g. ocr_use_gpu, tag, include for GenEval).
+
+        Returns:
+            dict with "uuid", "replica_id", and reward type keys.
+        """
+        assert images.ndim == 4 and images.shape[-1] == 3, f"Expected images shape [B, H, W, 3], got {images.shape}"
+        assert images.dtype == np.uint8, f"Expected uint8 images, got {images.dtype}"
+        assert len(prompts) == images.shape[0], f"Prompt count ({len(prompts)}) != image count ({images.shape[0]})"
+
+        self.batch_size_dict["uuid"] = images.shape[0]
+
+        buf = io.BytesIO()
+        np.save(buf, images, allow_pickle=False)
+        npy_bytes = buf.getvalue()
+
+        rw = reward_fn or self.reward_fn
+        data = {
+            "media_type": "image",
+            "prompts": prompts,
+            "reward_fn": rw,
+        }
+        if extra_data:
+            data.update(extra_data)
+        payload = json.dumps(data).encode("utf-8") + b"\n" + npy_bytes
+
+        resp = requests.post(
+            f"{self.host}/api/reward/enqueue",
+            data=payload,
+            headers=self._make_headers(extra={"Content-Type": "application/octet-stream"}),
+            timeout=120,
+        )
+        if resp.status_code != 200:
+            raise RuntimeError(f"Enqueue failed ({resp.status_code}): {resp.text}")
+
+        result = resp.json()
+        uuid = result["uuid"]
+        replica_id = result.get("replica_id")
+        reward_types = list(rw.keys())
+        log(f"Task submitted. UUID: {uuid}, replica: {replica_id}")
+        return {"uuid": uuid, "replica_id": replica_id, "reward_types": reward_types}
+
+    def check_results(
+        self,
+        uuid: str,
+        reward_type: str,
+        replica_id: Optional[str] = None,
+    ) -> Optional[dict]:
+        """Single poll for results. Returns scores dict or None if still pending."""
+        resp = requests.post(
+            f"{self.host}/api/reward/pull",
+            data={"uuid": uuid, "type": reward_type},
+            headers=self._make_headers(replica_id=replica_id),
+            timeout=20,
+        )
+        if resp.status_code == 200:
+            return resp.json()
+        elif resp.status_code == 400:
+            return None
+        else:
+            raise RuntimeError(f"Pull failed ({resp.status_code}): {resp.text}")
+
+    def check_results_until_get(
+        self,
+        uuid: str,
+        reward_type: str,
+        target_device: torch.device,
+        replica_id: Optional[str] = None,
+        poll_interval: float = 1.0,
+    ) -> tuple:
+        """Block until results are available, returns (processed_rewards, success_flag)."""
+        while True:
+            resp = requests.post(
+                f"{self.host}/api/reward/pull",
+                data={"uuid": uuid, "type": reward_type},
+                headers=self._make_headers(replica_id=replica_id),
+                timeout=20,
+            )
+            if resp.status_code == 200:
+                return self.process_results(resp.json()["scores"], target_device), 1
+            elif resp.status_code == 400:
+                time.sleep(poll_interval)
+            else:
+                log(f"Pull error ({resp.status_code}): {resp.text}, returning zeros")
+                return self.get_zero_rewards(self.batch_size_dict.get("uuid", 1), target_device), 0
+
+    def get_zero_rewards(self, batch_size: int, target_device: torch.device) -> dict:
+        weighted_rewards = torch.zeros(batch_size, dtype=torch.float32, device=target_device)
+        return {
+            self.name: weighted_rewards,
+            "avg": [weighted_rewards[i] for i in range(batch_size)],
+        }
+
+    def process_results(self, scores: dict, target_device: torch.device) -> dict:
+        rewards = {k: torch.as_tensor(v, device=target_device, dtype=torch.float32) for k, v in scores.items()}
+        weighted = sum(rewards[k] * w for k, w in self.reward_fn.items() if k in rewards)
+        if isinstance(weighted, int) and weighted == 0:
+            batch_size = self.batch_size_dict.get("uuid", 1)
+            weighted = torch.zeros(batch_size, dtype=torch.float32, device=target_device)
+        return {
+            self.name: weighted,
+            "avg": [weighted[i] for i in range(weighted.shape[0])],
+        }
+
+    # ---- async wrappers (ThreadPoolExecutor) ----
+
+    def submit_task_async(
+        self,
+        executor: ThreadPoolExecutor,
+        prompts: List[str],
+        images: np.ndarray,
+        reward_fn: Optional[Dict[str, float]] = None,
+        extra_data: Optional[dict] = None,
+    ) -> Future:
+        """Non-blocking submit. Returns a Future that resolves to the task dict."""
+        return executor.submit(self.submit_task, prompts, images, reward_fn, extra_data)
+
+    def fetch_results_async(
+        self,
+        executor: ThreadPoolExecutor,
+        uuid: str,
+        reward_type: str,
+        target_device: torch.device,
+        replica_id: Optional[str] = None,
+        poll_interval: float = 1.0,
+    ) -> Future:
+        """Non-blocking fetch. Returns a Future that resolves to (rewards, flag)."""
+        return executor.submit(
+            self.check_results_until_get,
+            uuid,
+            reward_type,
+            target_device,
+            replica_id,
+            poll_interval,
+        )
+
+
+# ---------- helpers ----------
+
+
+def load_images_from_folder(folder_path: str) -> np.ndarray:
+    """Load all images from a folder as a [B, H, W, 3] uint8 numpy array."""
+    import os
+
+    from PIL import Image
+
+    imgs = []
+    for name in sorted(os.listdir(folder_path)):
+        path = os.path.join(folder_path, name)
+        img = np.array(Image.open(path).convert("RGB"), dtype=np.uint8)
+        imgs.append(img)
+    return np.stack(imgs, axis=0)
+
+
+def make_fake_images(batch_size: int = 2, h: int = 512, w: int = 512) -> np.ndarray:
+    """Generate random fake images for testing. Returns [B, H, W, 3] uint8."""
+    return (np.random.rand(batch_size, h, w, 3) * 255.0).clip(0, 255).astype(np.uint8)
+
+
+# ---------- main ----------
+
+
+BATCH_SIZE = 8
+WAIT_BEFORE_FETCH = 20.0
+
+
+def _run_test(client: CosmosImageRewardClient, prompts, images, extra_data=None):
+    """Submit a task, wait, then poll. Reports submit + fetch time (excluding wait)."""
+    log(f"Images shape: {images.shape}, dtype: {images.dtype}")
+
+    t0 = time.perf_counter()
+    task = client.submit_task(prompts, images, extra_data=extra_data)
+    submit_time = time.perf_counter() - t0
+    log(f"UUID: {task['uuid']}, replica: {task['replica_id']}")
+    log(f"Submit time: {submit_time:.3f}s")
+
+    log(f"Waiting {WAIT_BEFORE_FETCH}s before fetching...")
+    time.sleep(WAIT_BEFORE_FETCH)
+
+    fetch_time = 0.0
+    for rtype in task["reward_types"]:
+        log(f"Polling results for reward type: {rtype} ...")
+        while True:
+            t1 = time.perf_counter()
+            result = client.check_results(task["uuid"], rtype, replica_id=task["replica_id"])
+            fetch_time += time.perf_counter() - t1
+            if result is not None:
+                log(f"Results ready: {result}")
+                break
+            time.sleep(1)
+
+    log(f"Fetch time:  {fetch_time:.3f}s")
+    log(f"Total time (submit + fetch, excluding wait): {submit_time + fetch_time:.3f}s")
+
+
+def _simulate_gpu_work(duration: float, label: str = "GPU work"):
+    """Simulate local GPU computation with a matmul workload."""
+    log(f"[{label}] Starting (target ~{duration:.1f}s) ...")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    t0 = time.perf_counter()
+    while time.perf_counter() - t0 < duration:
+        a = torch.randn(1024, 1024, device=device)
+        b = torch.randn(1024, 1024, device=device)
+        _ = a @ b
+        if device.type == "cuda":
+            torch.cuda.synchronize()
+    elapsed = time.perf_counter() - t0
+    log(f"[{label}] Done in {elapsed:.3f}s")
+    return elapsed
+
+
+def _run_async_demo(client: CosmosImageRewardClient, prompts, images, extra_data=None):
+    """Demo: submit & fetch run in background threads while GPU keeps working."""
+    executor = ThreadPoolExecutor(max_workers=2)
+    gpu_work_time = 3.0
+
+    log("=" * 60)
+    log("SYNC baseline: submit -> wait -> fetch -> GPU work")
+    log("=" * 60)
+    t_sync_start = time.perf_counter()
+
+    t0 = time.perf_counter()
+    task = client.submit_task(prompts, images, extra_data=extra_data)
+    sync_submit = time.perf_counter() - t0
+    log(f"Submit: {sync_submit:.3f}s")
+
+    time.sleep(WAIT_BEFORE_FETCH)
+
+    t0 = time.perf_counter()
+    for rtype in task["reward_types"]:
+        while True:
+            result = client.check_results(task["uuid"], rtype, replica_id=task["replica_id"])
+            if result is not None:
+                log(f"[{rtype}] got result")
+                break
+            time.sleep(1)
+    sync_fetch = time.perf_counter() - t0
+    log(f"Fetch: {sync_fetch:.3f}s")
+
+    _simulate_gpu_work(gpu_work_time, "GPU work (sync)")
+
+    sync_total = time.perf_counter() - t_sync_start
+    log(f"SYNC total wall time: {sync_total:.3f}s")
+
+    log("")
+    log("=" * 60)
+    log("ASYNC: submit overlaps GPU work, fetch overlaps GPU work")
+    log("=" * 60)
+    t_async_start = time.perf_counter()
+
+    submit_future = client.submit_task_async(executor, prompts, images, extra_data=extra_data)
+    _simulate_gpu_work(gpu_work_time, "GPU work during submit")
+
+    task = submit_future.result()
+    log(f"Submit finished (overlapped with GPU work)")
+
+    time.sleep(WAIT_BEFORE_FETCH)
+
+    fetch_future = client.fetch_results_async(
+        executor,
+        task["uuid"],
+        task["reward_types"][0],
+        torch.device("cuda" if torch.cuda.is_available() else "cpu"),
+        replica_id=task["replica_id"],
+    )
+    _simulate_gpu_work(gpu_work_time, "GPU work during fetch")
+
+    rewards, flag = fetch_future.result()
+    log(f"Fetch finished (overlapped with GPU work), success={flag}")
+
+    async_total = time.perf_counter() - t_async_start
+    log(f"ASYNC total wall time: {async_total:.3f}s")
+
+    log("")
+    log("=" * 60)
+    log(f"SYNC  wall time: {sync_total:.3f}s")
+    log(f"ASYNC wall time: {async_total:.3f}s")
+    log(f"Saved: {sync_total - async_total:.3f}s ({(sync_total - async_total) / sync_total * 100:.1f}%)")
+    log("=" * 60)
+
+    executor.shutdown(wait=False)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    REWARD_CHOICES = ["hpsv2", "hpsv3", "pickscore", "image_reward", "ocr", "gen_eval", "async_demo"]
+    # ocr pickscore hpsv2 hpsv3 image_reward
+
+    parser = argparse.ArgumentParser(description="Test CosmosImageRewardClient")
+    parser.add_argument(
+        "reward_type",
+        choices=REWARD_CHOICES,
+        help=f"Reward type to test: {REWARD_CHOICES}",
+    )
+    parser.add_argument("--host", default="https://cosmos-reward-image.dgxc-lepton.nvidia.com")
+    parser.add_argument("--token", default="YySuTH0PWzNIpDh4tWCXEvWSGYVCr8j4")
+    args = parser.parse_args()
+
+    rtype = args.reward_type
+    log(f"=== Testing reward type: {rtype} ===")
+
+    # ---- hpsv2 (+ image_reward combo) ----
+    if rtype == "hpsv2":
+        client = CosmosImageRewardClient(
+            host=args.host,
+            token=args.token,
+            reward_fn={"hpsv2": 1.0, "image_reward": 1.0},
+        )
+        prompts = ["a photo of a cat", "a beautiful sunset"] * 4
+        images = make_fake_images(batch_size=BATCH_SIZE)
+        _run_test(client, prompts, images)
+
+    # ---- hpsv3 ----
+    elif rtype == "hpsv3":
+        client = CosmosImageRewardClient(
+            host=args.host,
+            token=args.token,
+            reward_fn={"hpsv3": 1.0},
+        )
+        prompts = [
+            "cute chibi anime cartoon fox, smiling wagging tail " "with a small cartoon heart above sticker",
+        ] * BATCH_SIZE
+        images = make_fake_images(batch_size=BATCH_SIZE)
+        _run_test(client, prompts, images)
+
+    # ---- pickscore ----
+    elif rtype == "pickscore":
+        client = CosmosImageRewardClient(
+            host=args.host,
+            token=args.token,
+            reward_fn={"pickscore": 1.0},
+        )
+        prompts = [
+            "An astronaut's glove floating in zero-g " 'with "NASA 2049" on the wrist',
+        ] * BATCH_SIZE
+        images = make_fake_images(batch_size=BATCH_SIZE)
+        _run_test(client, prompts, images)
+
+    # ---- image_reward ----
+    elif rtype == "image_reward":
+        client = CosmosImageRewardClient(
+            host=args.host,
+            token=args.token,
+            reward_fn={"image_reward": 1.0},
+        )
+        prompts = ["a photo of a cat", "a beautiful sunset"] * 4
+        images = make_fake_images(batch_size=BATCH_SIZE)
+        _run_test(client, prompts, images)
+
+    # ---- ocr ----
+    elif rtype == "ocr":
+        client = CosmosImageRewardClient(
+            host=args.host,
+            token=args.token,
+            reward_fn={"ocr": 1.0},
+        )
+        prompts = [
+            'New York Skyline with "Hello World" written with fireworks',
+        ] * BATCH_SIZE
+        images = make_fake_images(batch_size=BATCH_SIZE)
+        _run_test(client, prompts, images, extra_data={"ocr_use_gpu": True})
+
+    # ---- gen_eval ----
+    elif rtype == "gen_eval":
+        client = CosmosImageRewardClient(
+            host=args.host,
+            token=args.token,
+            reward_fn={"gen_eval": 1.0},
+        )
+        prompts = [
+            "a photo of a brown giraffe and a white stop sign",
+        ] * BATCH_SIZE
+        images = make_fake_images(batch_size=BATCH_SIZE)
+        _run_test(
+            client,
+            prompts,
+            images,
+            extra_data={
+                "tag": "single_object",
+                "include": [
+                    {"class": "giraffe", "count": 1, "color": "brown"},
+                    {"class": "stop sign", "count": 1, "color": "black"},
+                ],
+            },
+        )
+
+    # ---- async_demo: sync vs async comparison ----
+    elif rtype == "async_demo":
+        client = CosmosImageRewardClient(
+            host=args.host,
+            token=args.token,
+            reward_fn={"hpsv2": 1.0},
+        )
+        prompts = ["a photo of a cat", "a beautiful sunset"] * 4
+        images = make_fake_images(batch_size=BATCH_SIZE)
+        _run_async_demo(client, prompts, images)

--- a/diffusion/flow_grpo/rewards.py
+++ b/diffusion/flow_grpo/rewards.py
@@ -1,0 +1,425 @@
+import io
+from collections import defaultdict
+
+import numpy as np
+import torch
+from PIL import Image
+
+
+def jpeg_incompressibility():
+    def _fn(images, prompts, metadata):
+        if isinstance(images, torch.Tensor):
+            images = (images * 255).round().clamp(0, 255).to(torch.uint8).cpu().numpy()
+            images = images.transpose(0, 2, 3, 1)  # NCHW -> NHWC
+        images = [Image.fromarray(image) for image in images]
+        buffers = [io.BytesIO() for _ in images]
+        for image, buffer in zip(images, buffers):
+            image.save(buffer, format="JPEG", quality=95)
+        sizes = [buffer.tell() / 1000 for buffer in buffers]
+        return np.array(sizes), {}
+
+    return _fn
+
+
+def jpeg_compressibility():
+    jpeg_fn = jpeg_incompressibility()
+
+    def _fn(images, prompts, metadata):
+        rew, meta = jpeg_fn(images, prompts, metadata)
+        return -rew / 500, meta
+
+    return _fn
+
+
+def aesthetic_score(device):
+    from diffusion.flow_grpo.aesthetic_scorer import AestheticScorer
+
+    scorer = AestheticScorer(dtype=torch.float32, device=device)
+
+    def _fn(images, prompts, metadata):
+        if isinstance(images, torch.Tensor):
+            images = (images * 255).round().clamp(0, 255).to(torch.uint8)
+        else:
+            images = images.transpose(0, 3, 1, 2)  # NHWC -> NCHW
+            images = torch.tensor(images, dtype=torch.uint8)
+        scores = scorer(images)
+        return scores, {}
+
+    return _fn
+
+
+def clip_score(device):
+    from diffusion.flow_grpo.clip_scorer import ClipScorer
+
+    scorer = ClipScorer(device=device)
+
+    def _fn(images, prompts, metadata):
+        if not isinstance(images, torch.Tensor):
+            images = images.transpose(0, 3, 1, 2)  # NHWC -> NCHW
+            images = torch.tensor(images, dtype=torch.uint8) / 255.0
+        scores = scorer(images, prompts)
+        return scores, {}
+
+    return _fn
+
+
+def hpsv2_score(device):
+    from diffusion.flow_grpo.hpsv2_scorer import HPSv2Scorer
+
+    scorer = HPSv2Scorer(dtype=torch.float32, device=device)
+
+    def _fn(images, prompts, metadata):
+        if not isinstance(images, torch.Tensor):
+            images = images.transpose(0, 3, 1, 2)  # NHWC -> NCHW
+            images = torch.tensor(images, dtype=torch.uint8) / 255.0
+        scores = scorer(images, prompts)
+        return scores, {}
+
+    return _fn
+
+
+def pickscore_score(device):
+    from diffusion.flow_grpo.pickscore_scorer import PickScoreScorer
+
+    scorer = PickScoreScorer(dtype=torch.float32, device=device)
+
+    def _fn(images, prompts, metadata):
+        if isinstance(images, torch.Tensor):
+            images = (images * 255).round().clamp(0, 255).to(torch.uint8).cpu().numpy()
+            images = images.transpose(0, 2, 3, 1)  # NCHW -> NHWC
+            images = [Image.fromarray(image) for image in images]
+        scores = scorer(prompts, images)
+        return scores, {}
+
+    return _fn
+
+
+def imagereward_score(device):
+    from diffusion.flow_grpo.imagereward_scorer import ImageRewardScorer
+
+    scorer = ImageRewardScorer(dtype=torch.float32, device=device)
+
+    def _fn(images, prompts, metadata):
+        if isinstance(images, torch.Tensor):
+            images = (images * 255).round().clamp(0, 255).to(torch.uint8).cpu().numpy()
+            images = images.transpose(0, 2, 3, 1)  # NCHW -> NHWC
+            images = [Image.fromarray(image) for image in images]
+        prompts = [prompt for prompt in prompts]
+        scores = scorer(prompts, images)
+        return scores, {}
+
+    return _fn
+
+
+def geneval_score(device):
+    from diffusion.flow_grpo.gen_eval import load_geneval
+
+    batch_size = 64
+    compute_geneval = load_geneval(device)
+
+    def _fn(images, prompts, metadatas, only_strict):
+        del prompts
+        if isinstance(images, torch.Tensor):
+            images = (images * 255).round().clamp(0, 255).to(torch.uint8).cpu().numpy()
+            images = images.transpose(0, 2, 3, 1)  # NCHW -> NHWC
+        images_batched = np.array_split(images, np.ceil(len(images) / batch_size))
+        metadatas_batched = np.array_split(metadatas, np.ceil(len(metadatas) / batch_size))
+        all_scores = []
+        all_rewards = []
+        all_strict_rewards = []
+        all_group_strict_rewards = []
+        all_group_rewards = []
+        for image_batch, metadata_batched in zip(images_batched, metadatas_batched):
+            pil_images = [Image.fromarray(image) for image in image_batch]
+
+            data = {
+                "images": pil_images,
+                "metadatas": list(metadata_batched),
+                "only_strict": only_strict,
+            }
+            scores, rewards, strict_rewards, group_rewards, group_strict_rewards = compute_geneval(**data)
+
+            all_scores += scores
+            all_rewards += rewards
+            all_strict_rewards += strict_rewards
+            all_group_strict_rewards.append(group_strict_rewards)
+            all_group_rewards.append(group_rewards)
+        all_group_strict_rewards_dict = defaultdict(list)
+        all_group_rewards_dict = defaultdict(list)
+        for current_dict in all_group_strict_rewards:
+            for key, value in current_dict.items():
+                all_group_strict_rewards_dict[key].extend(value)
+        all_group_strict_rewards_dict = dict(all_group_strict_rewards_dict)
+
+        for current_dict in all_group_rewards:
+            for key, value in current_dict.items():
+                all_group_rewards_dict[key].extend(value)
+        all_group_rewards_dict = dict(all_group_rewards_dict)
+
+        return all_scores, all_rewards, all_strict_rewards, all_group_rewards_dict, all_group_strict_rewards_dict
+
+    return _fn
+
+
+def ocr_score(device):
+    from diffusion.flow_grpo.ocr import OcrScorer
+
+    scorer = OcrScorer()
+
+    def _fn(images, prompts, metadata):
+        if isinstance(images, torch.Tensor):
+            images = (images * 255).round().clamp(0, 255).to(torch.uint8).cpu().numpy()
+            images = images.transpose(0, 2, 3, 1)  # NCHW -> NHWC
+        scores = scorer(images, prompts)
+        # change tensor to list
+        return scores, {}
+
+    return _fn
+
+
+def remote_hpsv2_score(device):
+    from diffusion.flow_grpo.remote_hpsv2 import RemoteHPSv2Scorer
+
+    del device
+    scorer = RemoteHPSv2Scorer()
+
+    def _fn(images, prompts, metadata):
+        del metadata
+        scores = scorer(images, prompts)
+        return scores, {}
+
+    return _fn
+
+
+def remote_hpsv3_score(device):
+    from diffusion.flow_grpo.remote_hpsv3 import RemoteHPSv3Scorer
+
+    del device
+    scorer = RemoteHPSv3Scorer()
+
+    def _fn(images, prompts, metadata):
+        del metadata
+        scores = scorer(images, prompts)
+        return scores, {}
+
+    return _fn
+
+
+def remote_pickscore_score(device):
+    from diffusion.flow_grpo.remote_pickscore import RemotePickScoreScorer
+
+    del device
+    scorer = RemotePickScoreScorer()
+
+    def _fn(images, prompts, metadata):
+        del metadata
+        scores = scorer(images, prompts)
+        return scores, {}
+
+    return _fn
+
+
+def remote_image_reward_score(device):
+    from diffusion.flow_grpo.remote_image_reward import RemoteImageRewardServerScorer
+
+    del device
+    scorer = RemoteImageRewardServerScorer()
+
+    def _fn(images, prompts, metadata):
+        del metadata
+        scores = scorer(images, prompts)
+        return scores, {}
+
+    return _fn
+
+
+def remote_ocr_score(device):
+    from diffusion.flow_grpo.remote_ocr import RemoteOCRScorer
+
+    del device
+    scorer = RemoteOCRScorer()
+
+    def _fn(images, prompts, metadata):
+        del metadata
+        scores = scorer(images, prompts)
+        return scores, {}
+
+    return _fn
+
+
+def dryrun_score():
+    def _fn(images, prompts, metadata):
+        del prompts, metadata
+        batch_size = int(images.shape[0]) if hasattr(images, "shape") else len(images)
+        scores = np.random.random(batch_size).astype(np.float32)
+        return scores, {}
+
+    return _fn
+
+
+def unifiedreward_score_sglang(device):
+    import asyncio
+    import base64
+    import re
+    from io import BytesIO
+
+    from openai import AsyncOpenAI
+
+    def pil_image_to_base64(image):
+        buffered = BytesIO()
+        image.save(buffered, format="PNG")
+        encoded_image_text = base64.b64encode(buffered.getvalue()).decode("utf-8")
+        base64_qwen = f"data:image;base64,{encoded_image_text}"
+        return base64_qwen
+
+    def _extract_scores(text_outputs):
+        scores = []
+        pattern = r"Final Score:\s*([1-5](?:\.\d+)?)"
+        for text in text_outputs:
+            match = re.search(pattern, text)
+            if match:
+                try:
+                    scores.append(float(match.group(1)))
+                except ValueError:
+                    scores.append(0.0)
+            else:
+                scores.append(0.0)
+        return scores
+
+    client = AsyncOpenAI(base_url="http://127.0.0.1:17140/v1", api_key="flowgrpo")
+
+    async def evaluate_image(prompt, image):
+        question = f"<image>\nYou are given a text caption and a generated image based on that caption. Your task is to evaluate this image based on two key criteria:\n1. Alignment with the Caption: Assess how well this image aligns with the provided caption. Consider the accuracy of depicted objects, their relationships, and attributes as described in the caption.\n2. Overall Image Quality: Examine the visual quality of this image, including clarity, detail preservation, color accuracy, and overall aesthetic appeal.\nBased on the above criteria, assign a score from 1 to 5 after 'Final Score:'.\nYour task is provided as follows:\nText Caption: [{prompt}]"
+        images_base64 = pil_image_to_base64(image)
+        response = await client.chat.completions.create(
+            model="UnifiedReward-7b-v1.5",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": images_base64},
+                        },
+                        {
+                            "type": "text",
+                            "text": question,
+                        },
+                    ],
+                },
+            ],
+            temperature=0,
+        )
+        return response.choices[0].message.content
+
+    async def evaluate_batch_image(images, prompts):
+        tasks = [evaluate_image(prompt, img) for prompt, img in zip(prompts, images)]
+        results = await asyncio.gather(*tasks)
+        return results
+
+    def _fn(images, prompts, metadata):
+        # 处理Tensor类型转换
+        if isinstance(images, torch.Tensor):
+            images = (images * 255).round().clamp(0, 255).to(torch.uint8).cpu().numpy()
+            images = images.transpose(0, 2, 3, 1)  # NCHW -> NHWC
+
+        # 转换为PIL Image并调整尺寸
+        images = [Image.fromarray(image).resize((512, 512)) for image in images]
+
+        # 执行异步批量评估
+        text_outputs = asyncio.run(evaluate_batch_image(images, prompts))
+        score = _extract_scores(text_outputs)
+        score = [sc / 5.0 for sc in score]
+        return score, {}
+
+    return _fn
+
+
+def multi_score(device, score_dict):
+    score_functions = {
+        "ocr": ocr_score,
+        "remote_ocr": remote_ocr_score,
+        "dryrun": dryrun_score,
+        "imagereward": imagereward_score,
+        "remote_image_reward": remote_image_reward_score,
+        "pickscore": pickscore_score,
+        "remote_pickscore": remote_pickscore_score,
+        "aesthetic": aesthetic_score,
+        "jpeg_compressibility": jpeg_compressibility,
+        "unifiedreward": unifiedreward_score_sglang,
+        "geneval": geneval_score,
+        "clipscore": clip_score,
+        "hpsv2": hpsv2_score,
+        "remote_hpsv2": remote_hpsv2_score,
+        "remote_hpsv3": remote_hpsv3_score,
+    }
+    score_fns = {}
+    for score_name, weight in score_dict.items():
+        score_fns[score_name] = (
+            score_functions[score_name](device)
+            if "device" in score_functions[score_name].__code__.co_varnames
+            else score_functions[score_name]()
+        )
+
+    # only_strict is only for geneval. During training, only the strict reward is needed, and non-strict rewards don't need to be computed, reducing reward calculation time.
+    def _fn(images, prompts, metadata, only_strict=True):
+        total_scores = []
+        score_details = {}
+
+        for score_name, weight in score_dict.items():
+            if score_name == "geneval":
+                scores, rewards, strict_rewards, group_rewards, group_strict_rewards = score_fns[score_name](
+                    images, prompts, metadata, only_strict
+                )
+                score_details["accuracy"] = rewards
+                score_details["strict_accuracy"] = strict_rewards
+                for key, value in group_strict_rewards.items():
+                    score_details[f"{key}_strict_accuracy"] = value
+                for key, value in group_rewards.items():
+                    score_details[f"{key}_accuracy"] = value
+            else:
+                scores, rewards = score_fns[score_name](images, prompts, metadata)
+            score_details[score_name] = scores
+            weighted_scores = [weight * score for score in scores]
+
+            if not total_scores:
+                total_scores = weighted_scores
+            else:
+                total_scores = [total + weighted for total, weighted in zip(total_scores, weighted_scores)]
+
+        score_details["avg"] = total_scores
+        return score_details, {}
+
+    return _fn
+
+
+def main():
+    import torchvision.transforms as transforms
+
+    image_paths = [
+        "test_cases/nasa.jpg",
+    ]
+
+    transform = transforms.Compose(
+        [
+            transforms.ToTensor(),  # Convert to tensor
+        ]
+    )
+
+    images = torch.stack([transform(Image.open(image_path).convert("RGB")) for image_path in image_paths])
+    prompts = [
+        'A astronaut’s glove floating in zero-g with "NASA 2049" on the wrist',
+    ]
+    metadata = {}  # Example metadata
+    score_dict = {"unifiedreward": 1.0}
+    # Initialize the multi_score function with a device and score_dict
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    scoring_fn = multi_score(device, score_dict)
+    # Get the scores
+    scores, _ = scoring_fn(images, prompts, metadata)
+    # Print the scores
+    print("Scores:", scores)
+
+
+if __name__ == "__main__":
+    main()

--- a/diffusion/flow_grpo/stat_tracking.py
+++ b/diffusion/flow_grpo/stat_tracking.py
@@ -1,0 +1,160 @@
+import numpy as np
+import torch
+
+
+class PerPromptStatTracker:
+    def __init__(self, global_std=False):
+        self.global_std = global_std
+        self.stats = {}
+        self.history_prompts = set()
+
+    # exp reward is for rwr
+    def update(self, prompts, rewards, exp=False):
+        prompts = np.array(prompts)
+        rewards = np.array(rewards, dtype=np.float64)
+        unique = np.unique(prompts)
+        advantages = np.empty_like(rewards) * 0.0
+
+        for prompt in unique:
+            prompt_rewards = rewards[prompts == prompt]
+            if prompt not in self.stats:
+                self.stats[prompt] = []
+            self.stats[prompt].extend(prompt_rewards)
+            self.history_prompts.add(hash(prompt))  # Add hash of prompt to history_prompts
+        for prompt in unique:
+            self.stats[prompt] = np.stack(self.stats[prompt])
+            prompt_rewards = rewards[prompts == prompt]  # Fix: Recalculate prompt_rewards for each prompt
+            mean = np.mean(self.stats[prompt], axis=0, keepdims=True)
+            if self.global_std:
+                std = np.std(rewards, axis=0, keepdims=True) + 1e-4  # Use global std of all rewards
+            else:
+                std = np.std(self.stats[prompt], axis=0, keepdims=True) + 1e-4
+            advantages[prompts == prompt] = (prompt_rewards - mean) / std
+        return advantages
+
+    def get_stats(self):
+        avg_group_size = sum(len(v) for v in self.stats.values()) / len(self.stats) if self.stats else 0
+        history_prompts = len(self.history_prompts)
+        return avg_group_size, history_prompts
+
+    def clear(self):
+        self.stats = {}
+
+    def get_mean_of_top_rewards(self, top_percentage):
+        if not self.stats:
+            return 0.0
+
+        assert 0 <= top_percentage <= 100
+
+        per_prompt_top_means = []
+        for prompt_rewards in self.stats.values():
+            if isinstance(prompt_rewards, list):
+                rewards = np.array(prompt_rewards)
+            else:
+                rewards = prompt_rewards
+
+            if rewards.size == 0:
+                continue
+
+            if top_percentage == 100:
+                per_prompt_top_means.append(np.mean(rewards))
+                continue
+
+            lower_bound_percentile = 100 - top_percentage
+            threshold = np.percentile(rewards, lower_bound_percentile)
+
+            top_rewards = rewards[rewards >= threshold]
+
+            if top_rewards.size > 0:
+                per_prompt_top_means.append(np.mean(top_rewards))
+
+        if not per_prompt_top_means:
+            return 0.0
+
+        return np.mean(per_prompt_top_means)
+
+
+def filter_top_bottom_k_gpu(data, unique_num, num_in_group, k=2):
+    prompts = data["prompt_ids"]  # [N, L]
+    advs = data["advantages"][:, 0]  # [N]
+
+    # 1. 纯 GPU 分组
+    # unique 能够识别 [N, 300] 中唯一的行
+    # inverse_indices: 形状 [N]，内容是 0~num_groups-1，表示每一行属于第几个 unique group
+    unique_prompts, inverse_indices = torch.unique(prompts, dim=0, return_inverse=True)
+
+    num_groups = unique_prompts.shape[0]
+    keep_indices = []
+
+    print(f"unique_num: {unique_num}, num_groups: {num_groups}")
+    assert unique_num == num_groups, f"unique_num: {unique_num}, num_groups: {num_groups}"
+
+    # 2. 遍历每个组 (因为 group 数量很少，比如 6 个，Python 循环也没关系)
+    for group_idx in range(num_groups):
+        # 创建 mask：当前组的位置
+        group_mask = inverse_indices == group_idx
+
+        # 获取当前组的全局索引
+        # nonzero 返回 [m, 1]，squeeze 变成 [m]
+        global_indices = torch.nonzero(group_mask).squeeze(1)
+
+        current_count = global_indices.numel()
+
+        assert current_count == num_in_group, f"current_count: {current_count}, num_in_group: {num_in_group}"
+
+        # 获取对应的 advantages
+        group_advs = advs[global_indices]
+
+        # 检查数量是否足够
+        if group_advs.shape[0] < 2 * k:
+            # 如果不够，可以根据策略选择跳过或报错，这里演示跳过
+            assert False, f"group_advs.shape[0]: {group_advs.shape[0]}, k: {k}"
+
+        # 3. 排序选 Top/Bottom
+        # argsort 得到的是组内相对索引
+        sorted_relative_indices = torch.argsort(group_advs)
+
+        # 映射回全局索引
+        sorted_global_indices = global_indices[sorted_relative_indices]
+
+        # 选最小 k 个 (Bottom)
+        keep_indices.append(sorted_global_indices[:k])
+        # 选最大 k 个 (Top)
+        keep_indices.append(sorted_global_indices[-k:])
+
+    # 4. 拼接索引并切片
+    if len(keep_indices) > 0:
+        final_indices = torch.cat(keep_indices)
+        # 可选：保持原来的 batch 顺序
+        final_indices, _ = torch.sort(final_indices)
+    else:
+        # 极端情况：没有任何组满足条件
+        final_indices = torch.tensor([], device=prompts.device, dtype=torch.long)
+
+    # 5. 重构字典
+    new_dict = {}
+    n_total = prompts.shape[0]
+    for key, val in data.items():
+        if torch.is_tensor(val) and val.shape[0] == n_total:
+            new_dict[key] = val[final_indices]
+        else:
+            new_dict[key] = val
+
+    return new_dict
+
+
+def main():
+    tracker = PerPromptStatTracker()
+    prompts = ["a", "b", "a", "c", "b", "a"]
+    rewards = [1, 2, 3, 4, 5, 6]
+    advantages = tracker.update(prompts, rewards)
+    print("Advantages:", advantages)
+    avg_group_size, history_prompts = tracker.get_stats()
+    print("Average Group Size:", avg_group_size)
+    print("History Prompts:", history_prompts)
+    tracker.clear()
+    print("Stats after clear:", tracker.stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/diffusion/model/nets/basic_modules_linear.py
+++ b/diffusion/model/nets/basic_modules_linear.py
@@ -1,0 +1,333 @@
+# Copyright 2024 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GLUMBConv with 1x1 Conv replaced by Linear layers for better efficiency.
+The 1x1 Conv2d is mathematically equivalent to Linear layer.
+"""
+
+
+import torch
+import torch.nn as nn
+from timm.models.vision_transformer import Mlp
+
+from diffusion.model.act import build_act, get_act_name
+from diffusion.model.norms import build_norm, get_norm_name
+from diffusion.model.utils import get_same_padding, val2tuple
+
+
+class LinearLayer(nn.Module):
+    """Linear layer with optional normalization and activation."""
+
+    def __init__(
+        self,
+        in_dim: int,
+        out_dim: int,
+        use_bias=True,
+        norm=None,
+        act=None,
+    ):
+        super().__init__()
+        self.in_dim = in_dim
+        self.out_dim = out_dim
+        self.use_bias = use_bias
+
+        self.linear = nn.Linear(in_dim, out_dim, bias=use_bias)
+        self.norm = build_norm(norm, num_features=out_dim)
+        self.act = build_act(act)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.linear(x)
+        if self.norm:
+            x = self.norm(x)
+        if self.act:
+            x = self.act(x)
+        return x
+
+
+class ConvLayer(nn.Module):
+    """Conv layer for depthwise convolution (kernel_size > 1)."""
+
+    def __init__(
+        self,
+        in_dim: int,
+        out_dim: int,
+        kernel_size=3,
+        stride=1,
+        dilation=1,
+        groups=1,
+        padding: int or None = None,
+        use_bias=False,
+        dropout=0.0,
+        conv_type="2d",
+        norm="bn2d",
+        act="relu",
+    ):
+        super().__init__()
+        if padding is None:
+            padding = get_same_padding(kernel_size)
+            padding *= dilation
+
+        self.in_dim = in_dim
+        self.out_dim = out_dim
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.dilation = dilation
+        self.groups = groups
+        self.padding = padding
+        self.use_bias = use_bias
+
+        self.dropout = nn.Dropout2d(dropout, inplace=False) if dropout > 0 else None
+        if conv_type == "2d":
+            self.conv = nn.Conv2d(
+                in_dim,
+                out_dim,
+                kernel_size=(kernel_size, kernel_size),
+                stride=(stride, stride),
+                padding=padding,
+                dilation=(dilation, dilation),
+                groups=groups,
+                bias=use_bias,
+            )
+        elif conv_type == "3d":
+            self.conv = nn.Conv3d(
+                in_dim,
+                out_dim,
+                kernel_size=(kernel_size, kernel_size, kernel_size),
+                stride=(stride, stride, stride),
+                padding=padding,
+                dilation=(dilation, dilation, dilation),
+                groups=groups,
+                bias=use_bias,
+            )
+        else:
+            self.conv = None
+
+        self.norm = build_norm(norm, num_features=out_dim)
+        self.act = build_act(act)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.dropout is not None:
+            x = self.dropout(x)
+        x = self.conv(x)
+        if self.norm:
+            x = self.norm(x)
+        if self.act:
+            x = self.act(x)
+        return x
+
+
+class GLUMBConvLinear(nn.Module):
+    """
+    GLUMBConv with 1x1 Conv replaced by Linear layers.
+
+    Original GLUMBConv structure:
+    - inverted_conv: Conv2d(in_features, hidden_features*2, kernel=1x1) -> replaced with Linear
+    - depth_conv: Conv2d(hidden_features*2, hidden_features*2, kernel=3x3, groups=hidden_features*2) -> keep Conv
+    - point_conv: Conv2d(hidden_features, out_features, kernel=1x1) -> replaced with Linear
+
+    Weight mapping (for checkpoint conversion):
+    - inverted_conv.conv.weight: [out, in, 1, 1] -> inverted_conv.linear.weight: [out, in]
+    - inverted_conv.conv.bias: [out] -> inverted_conv.linear.bias: [out]
+    - point_conv.conv.weight: [out, in, 1, 1] -> point_conv.linear.weight: [out, in]
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features: int,
+        out_feature=None,
+        kernel_size=3,
+        stride=1,
+        padding: int or None = None,
+        use_bias=False,
+        norm=(None, None, None),
+        act=("silu", "silu", None),
+        dilation=1,
+    ):
+        out_feature = out_feature or in_features
+        super().__init__()
+        use_bias = val2tuple(use_bias, 3)
+        norm = val2tuple(norm, 3)
+        act = val2tuple(act, 3)
+
+        self.hidden_features = hidden_features
+        self.out_feature = out_feature
+
+        self.glu_act = build_act(act[1], inplace=False)
+
+        # Replace 1x1 conv with Linear
+        self.inverted_conv = LinearLayer(
+            in_features,
+            hidden_features * 2,
+            use_bias=use_bias[0],
+            norm=norm[0],
+            act=act[0],
+        )
+
+        # Keep depthwise conv (kernel_size=3)
+        self.depth_conv = ConvLayer(
+            hidden_features * 2,
+            hidden_features * 2,
+            kernel_size,
+            stride=stride,
+            groups=hidden_features * 2,
+            padding=padding,
+            use_bias=use_bias[1],
+            norm=norm[1],
+            act=None,
+            dilation=dilation,
+        )
+
+        # Replace 1x1 conv with Linear
+        self.point_conv = LinearLayer(
+            hidden_features,
+            out_feature,
+            use_bias=use_bias[2],
+            norm=norm[2],
+            act=act[2],
+        )
+
+    def forward(self, x: torch.Tensor, HW=None) -> torch.Tensor:
+        B, N, C = x.shape
+        if HW is None:
+            H = W = int(N**0.5)
+        elif len(HW) == 2:
+            H, W = HW
+        elif len(HW) == 3:
+            T, H, W = HW
+
+        # inverted_conv: Linear on sequence dimension (B, N, C) -> (B, N, hidden*2)
+        x = self.inverted_conv(x)
+
+        # Reshape for depthwise conv: (B, N, hidden*2) -> (B*T or B, hidden*2, H, W)
+        if HW is not None and len(HW) == 3:
+            x = x.reshape(B * T, H, W, -1).permute(0, 3, 1, 2)
+        else:
+            x = x.reshape(B, H, W, -1).permute(0, 3, 1, 2)
+
+        # depth_conv: keep as Conv2d (depthwise 3x3)
+        x = self.depth_conv(x)
+
+        # GLU activation
+        x, gate = torch.chunk(x, 2, dim=1)
+        gate = self.glu_act(gate)
+        x = x * gate
+
+        # Reshape back to sequence for point_conv: (B*T or B, hidden, H, W) -> (B, N, hidden)
+        if HW is not None and len(HW) == 3:
+            x = x.reshape(B * T, self.hidden_features, H * W).permute(0, 2, 1)
+            x = x.reshape(B, N, self.hidden_features)
+        else:
+            x = x.reshape(B, self.hidden_features, N).permute(0, 2, 1)
+
+        # point_conv: Linear on sequence dimension (B, N, hidden) -> (B, N, out)
+        x = self.point_conv(x)
+
+        return x
+
+
+class GLUMBConvLinearTemp(GLUMBConvLinear):
+    """GLUMBConvLinear with temporal convolution support."""
+
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features: int,
+        out_feature=None,
+        kernel_size=3,
+        stride=1,
+        padding: int or None = None,
+        use_bias=False,
+        norm=(None, None, None),
+        act=("silu", "silu", None),
+        t_kernel_size=3,
+    ):
+        super().__init__(
+            in_features=in_features,
+            hidden_features=hidden_features,
+            out_feature=out_feature,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            use_bias=use_bias,
+            norm=norm,
+            act=act,
+        )
+
+        out_feature = out_feature or in_features
+        t_padding = t_kernel_size // 2
+        self.t_conv = nn.Conv2d(
+            out_feature,
+            out_feature,
+            kernel_size=(t_kernel_size, 1),
+            stride=1,
+            padding=(t_padding, 0),
+            bias=False,
+        )
+
+        nn.init.zeros_(self.t_conv.weight)
+
+    def forward(self, x: torch.Tensor, HW=None, **kwargs) -> torch.Tensor:
+        B, N, C = x.shape
+
+        assert len(HW) == 3, "HW must be a tuple of (T, H, W)"
+        T, H, W = HW
+
+        # inverted_conv: Linear (B, N, C) -> (B, N, hidden*2)
+        x = self.inverted_conv(x)
+
+        # Reshape for depth_conv: (B, T*H*W, hidden*2) -> (B*T, hidden*2, H, W)
+        x = x.reshape(B * T, H, W, -1).permute(0, 3, 1, 2)
+        x = self.depth_conv(x)
+
+        # Space aggregation (GLU)
+        x, gate = torch.chunk(x, 2, dim=1)
+        gate = self.glu_act(gate)
+        x = x * gate
+
+        # Reshape for point_conv: (B*T, hidden, H, W) -> (B*T, H*W, hidden)
+        x = x.reshape(B * T, self.hidden_features, H * W).permute(0, 2, 1)
+        x = self.point_conv(x)  # (B*T, H*W, out_feature)
+
+        # Temporal aggregation: reshape for t_conv
+        x = x.reshape(B, T, H * W, self.out_feature).permute(0, 3, 1, 2)  # B, out, T, H*W
+        x_out = x + self.t_conv(x)
+
+        x_out = x_out.permute(0, 2, 3, 1).reshape(B, N, self.out_feature)
+
+        return x_out
+
+
+if __name__ == "__main__":
+    # Test GLUMBConvLinear
+    model = GLUMBConvLinear(
+        2240,
+        2240 * 5 // 2,  # hidden_features = 5600
+        2240,
+        use_bias=(True, True, False),
+        norm=(None, None, None),
+        act=("silu", "silu", None),
+    ).cuda()
+
+    input_tensor = torch.randn(4, 1024, 2240).cuda()  # (B, H*W, C)
+    output = model(input_tensor, HW=(32, 32))
+    print(f"Input shape: {input_tensor.shape}")
+    print(f"Output shape: {output.shape}")
+
+    # Count parameters
+    total_params = sum(p.numel() for p in model.parameters())
+    print(f"Total parameters: {total_params:,}")

--- a/diffusion/model/nets/sana_multi_scale_linear.py
+++ b/diffusion/model/nets/sana_multi_scale_linear.py
@@ -1,0 +1,459 @@
+# Copyright 2024 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+SanaMS model with 1x1 Conv replaced by Linear layers in GLUMBConv.
+This is a derivative of sana_multi_scale.py for better efficiency.
+"""
+
+import os
+
+import torch
+import torch.nn as nn
+from timm.models.layers import DropPath
+
+from diffusion.model.builder import MODELS
+from diffusion.model.nets.basic_modules import DWMlp, Mlp
+from diffusion.model.nets.basic_modules_linear import GLUMBConvLinear
+from diffusion.model.nets.sana import Sana, get_2d_sincos_pos_embed
+from diffusion.model.nets.sana_blocks import (
+    Attention,
+    CaptionEmbedder,
+    FlashAttention,
+    LiteLA,
+    MultiHeadCrossAttention,
+    MultiHeadCrossVallinaAttention,
+    PatchEmbedMS,
+    RopePosEmbed,
+    T2IFinalLayer,
+    t2i_modulate,
+)
+from diffusion.model.utils import auto_grad_checkpoint
+from diffusion.utils.import_utils import is_triton_module_available, is_xformers_available
+
+_triton_modules_available = False
+if is_triton_module_available():
+    from diffusion.model.nets.fastlinear.modules import TritonLiteMLA, TritonMBConvPreGLU
+
+    _triton_modules_available = True
+
+_xformers_available = False if os.environ.get("DISABLE_XFORMERS", "0") == "1" else is_xformers_available()
+if _xformers_available:
+    import xformers.ops
+
+
+class SanaMSBlockLinear(nn.Module):
+    """
+    A Sana block with global shared adaptive layer norm zero (adaLN-Zero) conditioning.
+    Uses GLUMBConvLinear (Linear layers instead of 1x1 Conv) for the MLP.
+    """
+
+    def __init__(
+        self,
+        hidden_size,
+        num_heads,
+        mlp_ratio=4.0,
+        drop_path=0.0,
+        qk_norm=False,
+        attn_type="flash",
+        ffn_type="glumbconv_linear",  # Changed default to use linear version
+        mlp_acts=("silu", "silu", None),
+        linear_head_dim=32,
+        cross_norm=False,
+        cross_attn_type="flash",
+        **block_kwargs,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.norm1 = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
+        if attn_type == "flash":
+            # flash self attention
+            self.attn = FlashAttention(
+                hidden_size,
+                num_heads=num_heads,
+                qkv_bias=True,
+                qk_norm=qk_norm,
+                **block_kwargs,
+            )
+        elif attn_type == "linear":
+            # linear self attention
+            self_num_heads = hidden_size // linear_head_dim
+            self.attn = LiteLA(hidden_size, hidden_size, heads=self_num_heads, eps=1e-8, qk_norm=qk_norm)
+        elif attn_type == "triton_linear":
+            if not _triton_modules_available:
+                raise ValueError(
+                    f"{attn_type} type is not available due to _triton_modules_available={_triton_modules_available}."
+                )
+            # linear self attention with triton kernel fusion
+            self_num_heads = hidden_size // linear_head_dim
+            self.attn = TritonLiteMLA(hidden_size, num_heads=self_num_heads, eps=1e-8)
+        elif attn_type == "vanilla":
+            # vanilla self attention
+            self.attn = Attention(hidden_size, num_heads=num_heads, qkv_bias=True)
+        else:
+            self.attn = None
+
+        if cross_attn_type in ["flash", "linear"]:
+            self.cross_attn = MultiHeadCrossAttention(hidden_size, num_heads, qk_norm=cross_norm, **block_kwargs)
+        elif cross_attn_type == "vanilla":
+            self.cross_attn = MultiHeadCrossVallinaAttention(hidden_size, num_heads, qk_norm=cross_norm, **block_kwargs)
+        else:
+            raise ValueError(f"{cross_attn_type} type is not defined.")
+        self.norm2 = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
+
+        if ffn_type == "dwmlp":
+            approx_gelu = lambda: nn.GELU(approximate="tanh")
+            self.mlp = DWMlp(
+                in_features=hidden_size, hidden_features=int(hidden_size * mlp_ratio), act_layer=approx_gelu, drop=0
+            )
+        elif ffn_type in ["glumbconv_linear", "glumbconv"]:
+            # Use GLUMBConvLinear instead of GLUMBConv
+            self.mlp = GLUMBConvLinear(
+                in_features=hidden_size,
+                hidden_features=int(hidden_size * mlp_ratio),
+                use_bias=(True, True, False),
+                norm=(None, None, None),
+                act=mlp_acts,
+            )
+        elif ffn_type == "mlp":
+            approx_gelu = lambda: nn.GELU(approximate="tanh")
+            self.mlp = Mlp(
+                in_features=hidden_size, hidden_features=int(hidden_size * mlp_ratio), act_layer=approx_gelu, drop=0
+            )
+        else:
+            self.mlp = None
+
+        self.drop_path = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+        self.scale_shift_table = nn.Parameter(torch.randn(6, hidden_size) / hidden_size**0.5)
+
+    def forward(self, x, y, t, mask=None, HW=None, image_rotary_emb=None, **kwargs):
+        B, N, C = x.shape
+
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = (
+            self.scale_shift_table[None] + t.reshape(B, 6, -1)
+        ).chunk(6, dim=1)
+        x = x + self.drop_path(
+            gate_msa * self.attn(t2i_modulate(self.norm1(x), shift_msa, scale_msa), HW=HW, rotary_emb=image_rotary_emb)
+        )
+        x = x + self.cross_attn(x, y, mask)
+        x = x + self.drop_path(gate_mlp * self.mlp(t2i_modulate(self.norm2(x), shift_mlp, scale_mlp), HW=HW))
+
+        return x
+
+
+#############################################################################
+#                                 Core Sana Model                                #
+#################################################################################
+@MODELS.register_module()
+class SanaMSLinear(Sana):
+    """
+    Diffusion model with a Transformer backbone.
+    Uses Linear layers instead of 1x1 Conv in GLUMBConv.
+    """
+
+    def __init__(
+        self,
+        input_size=32,
+        patch_size=2,
+        in_channels=4,
+        hidden_size=1152,
+        depth=28,
+        num_heads=16,
+        mlp_ratio=4.0,
+        class_dropout_prob=0.1,
+        learn_sigma=True,
+        pred_sigma=True,
+        drop_path: float = 0.0,
+        caption_channels=2304,
+        pe_interpolation=1.0,
+        config=None,
+        model_max_length=300,
+        qk_norm=False,
+        y_norm=False,
+        norm_eps=1e-5,
+        attn_type="flash",
+        ffn_type="glumbconv_linear",
+        use_pe=True,
+        y_norm_scale_factor=1.0,
+        patch_embed_kernel=None,
+        mlp_acts=("silu", "silu", None),
+        linear_head_dim=32,
+        cross_norm=False,
+        cross_attn_type="flash",
+        logvar=False,
+        logvar_scale_factor=1.0,
+        cfg_embed=False,
+        cfg_embed_scale=1.0,
+        lr_scale=None,
+        timestep_norm_scale_factor=1.0,
+        **kwargs,
+    ):
+        super().__init__(
+            input_size=input_size,
+            patch_size=patch_size,
+            in_channels=in_channels,
+            hidden_size=hidden_size,
+            depth=depth,
+            num_heads=num_heads,
+            mlp_ratio=mlp_ratio,
+            class_dropout_prob=class_dropout_prob,
+            learn_sigma=learn_sigma,
+            pred_sigma=pred_sigma,
+            drop_path=drop_path,
+            caption_channels=caption_channels,
+            pe_interpolation=pe_interpolation,
+            config=config,
+            model_max_length=model_max_length,
+            qk_norm=qk_norm,
+            y_norm=y_norm,
+            norm_eps=norm_eps,
+            attn_type=attn_type,
+            ffn_type=ffn_type,
+            use_pe=use_pe,
+            y_norm_scale_factor=y_norm_scale_factor,
+            patch_embed_kernel=patch_embed_kernel,
+            mlp_acts=mlp_acts,
+            linear_head_dim=linear_head_dim,
+            cross_norm=cross_norm,
+            cross_attn_type=cross_attn_type,
+            cfg_embed=cfg_embed,
+            timestep_norm_scale_factor=timestep_norm_scale_factor,
+            **kwargs,
+        )
+        self.h = self.w = 0
+        approx_gelu = lambda: nn.GELU(approximate="tanh")
+        self.t_block = nn.Sequential(nn.SiLU(), nn.Linear(hidden_size, 6 * hidden_size, bias=True))
+        self.pos_embed_ms = None
+        self.cfg_embed_scale = cfg_embed_scale
+
+        kernel_size = patch_embed_kernel or patch_size
+        self.x_embedder = PatchEmbedMS(patch_size, in_channels, hidden_size, kernel_size=kernel_size, bias=True)
+        self.y_embedder = CaptionEmbedder(
+            in_channels=caption_channels,
+            hidden_size=hidden_size,
+            uncond_prob=class_dropout_prob,
+            act_layer=approx_gelu,
+            token_num=model_max_length,
+        )
+        drop_path = [x.item() for x in torch.linspace(0, drop_path, depth)]  # stochastic depth decay rule
+        self.blocks = nn.ModuleList(
+            [
+                SanaMSBlockLinear(
+                    hidden_size,
+                    num_heads,
+                    mlp_ratio=mlp_ratio,
+                    drop_path=drop_path[i],
+                    qk_norm=qk_norm,
+                    attn_type=attn_type,
+                    ffn_type=ffn_type,
+                    mlp_acts=mlp_acts,
+                    linear_head_dim=linear_head_dim,
+                    cross_norm=cross_norm,
+                    cross_attn_type=cross_attn_type,
+                )
+                for i in range(depth)
+            ]
+        )
+        self.final_layer = T2IFinalLayer(hidden_size, patch_size, self.out_channels)
+        self.logvar_linear = None
+        if logvar:
+            self.logvar_scale_factor = logvar_scale_factor
+            self.logvar_linear = nn.Linear(hidden_size, 1)
+
+        self.lr_scale = lr_scale
+
+        self.initialize()
+
+    def forward(self, x, timestep, y, mask=None, data_info=None, return_logvar=False, jvp=False, **kwargs):
+        """
+        Forward pass of Sana.
+        x: (N, C, H, W) tensor of spatial inputs (images or latent representations of images)
+        t: (N,) tensor of diffusion timesteps
+        y: (N, 1, 120, C) tensor of class labels
+        """
+        bs = x.shape[0]
+        x = x.to(self.dtype)
+        if self.timestep_norm_scale_factor != 1.0:
+            timestep = (timestep.float() / self.timestep_norm_scale_factor).to(torch.float32)
+        else:
+            timestep = timestep.long().to(torch.float32)
+        y = y.to(self.dtype)
+        self.h, self.w = x.shape[-2] // self.patch_size, x.shape[-1] // self.patch_size
+        x = self.x_embedder(x)
+        image_pos_embed = None
+        if self.use_pe:
+            if self.pos_embed_type == "sincos":
+                if self.pos_embed_ms is None or self.pos_embed_ms.shape[1:] != x.shape[1:]:
+                    self.pos_embed_ms = (
+                        torch.from_numpy(
+                            get_2d_sincos_pos_embed(
+                                self.pos_embed.shape[-1],
+                                (self.h, self.w),
+                                pe_interpolation=self.pe_interpolation,
+                                base_size=self.base_size,
+                            )
+                        )
+                        .unsqueeze(0)
+                        .to(x.device)
+                        .to(self.dtype)
+                    )
+                x += self.pos_embed_ms  # (N, T, D), where T = H * W / patch_size ** 2
+            elif self.pos_embed_type == "flux_rope":
+                self.pos_embed_ms = RopePosEmbed(theta=10000, axes_dim=[0, 16, 16])
+                latent_image_ids = self.pos_embed_ms._prepare_latent_image_ids(bs, self.h, self.w, x.device, x.dtype)
+                image_pos_embed = self.pos_embed_ms(latent_image_ids)
+                x += image_pos_embed
+            else:
+                raise ValueError(f"Unknown pos_embed_type: {self.pos_embed_type}")
+
+        t = self.t_embedder(timestep)  # (N, D)
+        if self.cfg_embedder:
+            cfg_embed = self.cfg_embedder(data_info["cfg_scale"] * self.cfg_embed_scale)
+            t += cfg_embed
+
+        t0 = self.t_block(t)
+        y = self.y_embedder(y, self.training, mask=mask)  # (N, D)
+        if self.y_norm:
+            y = self.attention_y_norm(y)
+
+        if mask is not None:
+            mask = mask.to(torch.int16)
+            mask = mask.repeat(y.shape[0] // mask.shape[0], 1) if mask.shape[0] != y.shape[0] else mask
+            mask = mask.squeeze(1).squeeze(1)
+            if _xformers_available:
+                y = y.squeeze(1).masked_select(mask.unsqueeze(-1) != 0).view(1, -1, x.shape[-1])
+                y_lens = mask.sum(dim=1).tolist()
+            else:
+                y_lens = mask
+        elif _xformers_available:
+            y_lens = [y.shape[2]] * y.shape[0]
+            y = y.squeeze(1).view(1, -1, x.shape[-1])
+        else:
+            raise ValueError(f"Attention type is not available due to _xformers_available={_xformers_available}.")
+
+        for block in self.blocks:
+            if jvp:
+                x = block(x, y, t0, y_lens, (self.h, self.w), image_pos_embed, **kwargs)
+            # gradient checkpointing is not supported for JVP
+            else:
+                x = auto_grad_checkpoint(
+                    block,
+                    x,
+                    y,
+                    t0,
+                    y_lens,
+                    (self.h, self.w),
+                    image_pos_embed,
+                    **kwargs,
+                    use_reentrant=False,
+                )  # (N, T, D) #support grad checkpoint
+
+        x = self.final_layer(x, t)  # (N, T, patch_size ** 2 * out_channels)
+        x = self.unpatchify(x)  # (N, out_channels, H, W)
+
+        if return_logvar and self.logvar_linear is not None:
+            logvar = self.logvar_linear(t) * self.logvar_scale_factor
+            return x, logvar
+
+        return x
+
+    def __call__(self, *args, **kwargs):
+        """
+        This method allows the object to be called like a function.
+        It simply calls the forward method.
+        """
+        return self.forward(*args, **kwargs)
+
+    def forward_with_dpmsolver(self, x, timestep, y, data_info, **kwargs):
+        """
+        dpm solver donnot need variance prediction
+        """
+        # https://github.com/openai/glide-text2im/blob/main/notebooks/text2im.ipynb
+        model_out = self.forward(x, timestep, y, data_info=data_info, **kwargs)
+        return model_out.chunk(2, dim=1)[0] if self.pred_sigma else model_out
+
+    def unpatchify(self, x):
+        """
+        x: (N, T, patch_size**2 * C)
+        imgs: (N, H, W, C)
+        """
+        c = self.out_channels
+        p = self.x_embedder.patch_size[0]
+        assert self.h * self.w == x.shape[1]
+
+        x = x.reshape(shape=(x.shape[0], self.h, self.w, p, p, c))
+        x = torch.einsum("nhwpqc->nchpwq", x)
+        imgs = x.reshape(shape=(x.shape[0], c, self.h * p, self.w * p))
+        return imgs
+
+    def initialize(self):
+        super().initialize_weights()
+
+        # Initialize transformer layers:
+        def _basic_init(module):
+            if isinstance(module, nn.Linear):
+                torch.nn.init.xavier_uniform_(module.weight)
+                if module.bias is not None:
+                    nn.init.constant_(module.bias, 0)
+
+        self.apply(_basic_init)
+
+        # Initialize patch_embed like nn.Linear (instead of nn.Conv2d):
+        w = self.x_embedder.proj.weight.data
+        nn.init.xavier_uniform_(w.view([w.shape[0], -1]))
+
+        # Initialize timestep embedding MLP:
+        nn.init.normal_(self.t_embedder.mlp[0].weight, std=0.02)
+        nn.init.normal_(self.t_embedder.mlp[2].weight, std=0.02)
+        nn.init.normal_(self.t_block[1].weight, std=0.02)
+
+        # Initialize caption embedding MLP:
+        nn.init.normal_(self.y_embedder.y_proj.fc1.weight, std=0.02)
+        nn.init.normal_(self.y_embedder.y_proj.fc2.weight, std=0.02)
+
+        # Initialize cfg embedder
+        if self.cfg_embedder:
+            nn.init.normal_(self.cfg_embedder.mlp[0].weight, std=0.02)
+            nn.init.zeros_(self.cfg_embedder.mlp[2].weight)
+            if hasattr(self.cfg_embedder.mlp[2], "bias") and self.cfg_embedder.mlp[2].bias is not None:
+                nn.init.zeros_(self.cfg_embedder.mlp[2].bias)
+
+
+#################################################################################
+#                                   Sana Multi-scale Linear Configs             #
+#################################################################################
+
+
+@MODELS.register_module()
+def SanaMSLinear_600M_P1_D28(**kwargs):
+    return SanaMSLinear(depth=28, hidden_size=1152, patch_size=1, num_heads=16, **kwargs)
+
+
+@MODELS.register_module()
+def SanaMSLinear_600M_P2_D28(**kwargs):
+    return SanaMSLinear(depth=28, hidden_size=1152, patch_size=2, num_heads=16, **kwargs)
+
+
+@MODELS.register_module()
+def SanaMSLinear_1600M_P1_D20(**kwargs):
+    # 20 layers, 1648.48M
+    return SanaMSLinear(depth=20, hidden_size=2240, patch_size=1, num_heads=20, **kwargs)
+
+
+@MODELS.register_module()
+def SanaMSLinear_1600M_P2_D20(**kwargs):
+    # 20 layers, 1648.48M
+    return SanaMSLinear(depth=20, hidden_size=2240, patch_size=2, num_heads=20, **kwargs)

--- a/docs/sana_cosmos_rl.md
+++ b/docs/sana_cosmos_rl.md
@@ -2,7 +2,7 @@
   <img src="https://nvlabs.github.io/Sana/assets/cosmos-rl/sana-cosmos-rl-logo.png" width="90%" alt="SANA × Cosmos-RL Logo"/>
 </p>
 
-# SANA &times; Cosmos-RL: Post-Training (SFT/RL) for Image & Video Diffusion Models
+# SANA × Cosmos-RL: Post-Training (SFT/RL) for Image & Video Diffusion Models
 
 <div align="center">
   <a href="https://github.com/nvidia-cosmos/cosmos-rl/blob/main/examples/sana.md"><img src="https://img.shields.io/static/v1?label=SANA&message=Cosmos-RL%20README&color=blue&logo=github" alt="SANA on Cosmos-RL"></a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,10 @@ dependencies = [
     "imageio[pyav,ffmpeg]",
     "qwen-vl-utils",
     "lmdb",
+    "absl-py",
+    "ml_collections",
+    "hpsv2",
+    "open_clip_torch",
 ]
 
 

--- a/train_scripts/sol_rl/train_flux1.py
+++ b/train_scripts/sol_rl/train_flux1.py
@@ -1,0 +1,1314 @@
+import logging
+import os
+import random
+import sys
+import tempfile
+import time
+from collections import defaultdict
+from concurrent import futures
+
+_rank = int(os.environ.get("RANK", 0))
+_cache_root = os.environ.get("CACHE_ROOT", os.path.expanduser("~/.cache/sol_rl"))
+os.environ.setdefault("TRITON_CACHE_DIR", f"{_cache_root}/triton/rank_{_rank}")
+os.environ.setdefault("TORCHINDUCTOR_CACHE_DIR", f"{_cache_root}/torchinductor/rank_{_rank}")
+os.environ.setdefault("TORCHINDUCTOR_FX_GRAPH_CACHE", "1")
+
+import warnings
+
+warnings.filterwarnings("ignore", message=".*truncated.*")
+
+import transformers
+
+transformers.logging.set_verbosity_error()
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import tqdm
+import wandb
+from absl import app, flags
+from diffusers import FluxPipeline
+from diffusers.models import FluxTransformer2DModel
+from diffusers.pipelines.flux.pipeline_flux import retrieve_timesteps
+from ml_collections import config_flags
+from peft import LoraConfig, PeftModel, get_peft_model
+from PIL import Image
+from torch.cuda.amp import GradScaler
+from torch.cuda.amp import autocast as torch_autocast
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.data import DataLoader
+from torch.utils.data.distributed import DistributedSampler
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from train_utils import (
+    _HAS_TE,
+    NVFP4_RECIPE,
+    DistributedTimeLogger,
+    build_datasets_and_loaders,
+    calculate_zero_std_ratio,
+    cleanup_distributed,
+    collate_dict_items,
+    extract_prompt_reward_group,
+    filter_by_indices,
+    find_resume_candidates,
+    gather_tensor_to_all,
+    is_main_process,
+    log_rollout_images,
+    replace_linear_with_te,
+    resume_from_checkpoint,
+    return_decay,
+    save_ckpt,
+    save_debug_image_subset,
+    save_step_reward_groups,
+    select_indices_by_mode,
+    set_seed,
+    setup_distributed,
+    slice_prompt_metadata,
+    sync_lora_to_inference,
+    te,
+    unwrap_compiled,
+    wrap_forward_with_fp8,
+)
+
+import diffusion.flow_grpo.rewards
+from diffusion.flow_grpo.diffusers_patch.solver import run_sampling
+from diffusion.flow_grpo.ema import EMAModuleWrapper
+from diffusion.flow_grpo.stat_tracking import PerPromptStatTracker
+
+tqdm = tqdm.tqdm
+FLAGS = flags.FLAGS
+config_flags.DEFINE_config_file(
+    "config",
+    "configs/sol_rl/flux1.py",
+    "Training configuration.",
+)
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+FLUX_NVFP4_DEFAULT_SKIP_MODULES = [
+    "x_embedder",
+    "context_embedder",
+    "time_text_embed",
+    "norm_out",
+]
+
+TEXT_ENCODER_MAX_SEQ_LEN = 128
+TOKENIZER_MAX_LENGTH = 256
+WANDB_MAX_LOG_IMAGES = 12
+
+
+def calculate_shift(
+    image_seq_len,
+    base_seq_len: int = 256,
+    max_seq_len: int = 4096,
+    base_shift: float = 0.5,
+    max_shift: float = 1.15,
+):
+    m = (max_shift - base_shift) / (max_seq_len - base_seq_len)
+    b = base_shift - m * base_seq_len
+    return image_seq_len * m + b
+
+
+def compute_text_embeddings(prompts, pipeline, max_sequence_length, device):
+    with torch.no_grad():
+        prompt_embeds, pooled_prompt_embeds, text_ids = pipeline.encode_prompt(
+            prompt=prompts,
+            prompt_2=prompts,
+            prompt_embeds=None,
+            pooled_prompt_embeds=None,
+            device=device,
+            num_images_per_prompt=1,
+            max_sequence_length=max_sequence_length,
+            lora_scale=None,
+        )
+    return prompt_embeds.to(device), pooled_prompt_embeds.to(device), text_ids.to(device)
+
+
+def _build_generators_from_seeds(seed_list, device):
+    return [torch.Generator(device=device).manual_seed(int(seed)) for seed in seed_list]
+
+
+@torch.no_grad()
+def pipeline_with_logprob_flux(
+    pipeline,
+    prompt=None,
+    prompt_2=None,
+    height=None,
+    width=None,
+    num_inference_steps=28,
+    guidance_scale=3.5,
+    num_images_per_prompt=1,
+    generator=None,
+    latents=None,
+    prompt_embeds=None,
+    pooled_prompt_embeds=None,
+    text_ids=None,
+    output_type="pt",
+    joint_attention_kwargs=None,
+    max_sequence_length=512,
+    noise_level=0.7,
+    deterministic=False,
+    solver="flow",
+    sequential_decode=False,
+):
+    height = height or pipeline.default_sample_size * pipeline.vae_scale_factor
+    width = width or pipeline.default_sample_size * pipeline.vae_scale_factor
+
+    pipeline.check_inputs(
+        prompt,
+        prompt_2,
+        height,
+        width,
+        prompt_embeds=prompt_embeds,
+        pooled_prompt_embeds=pooled_prompt_embeds,
+        max_sequence_length=max_sequence_length,
+    )
+
+    if prompt is not None and isinstance(prompt, str):
+        batch_size = 1
+    elif prompt is not None and isinstance(prompt, list):
+        batch_size = len(prompt)
+    else:
+        batch_size = prompt_embeds.shape[0]
+
+    device = pipeline._execution_device
+    lora_scale = joint_attention_kwargs.get("scale", None) if joint_attention_kwargs is not None else None
+
+    if prompt_embeds is None or pooled_prompt_embeds is None or text_ids is None:
+        prompt_embeds, pooled_prompt_embeds, text_ids = pipeline.encode_prompt(
+            prompt=prompt,
+            prompt_2=prompt_2,
+            prompt_embeds=prompt_embeds,
+            pooled_prompt_embeds=pooled_prompt_embeds,
+            device=device,
+            num_images_per_prompt=num_images_per_prompt,
+            max_sequence_length=max_sequence_length,
+            lora_scale=lora_scale,
+        )
+
+    num_channels_latents = pipeline.transformer.config.in_channels // 4
+    if latents is None:
+        latents, latent_image_ids = pipeline.prepare_latents(
+            batch_size * num_images_per_prompt,
+            num_channels_latents,
+            height,
+            width,
+            prompt_embeds.dtype,
+            device,
+            generator,
+            latents,
+        )
+    else:
+        latents = latents.to(device)
+        latent_image_ids = pipeline._prepare_latent_image_ids(
+            batch_size * num_images_per_prompt,
+            height // pipeline.vae_scale_factor,
+            width // pipeline.vae_scale_factor,
+            device,
+            prompt_embeds.dtype,
+        )
+
+    sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps)
+    if hasattr(pipeline.scheduler.config, "use_flow_sigmas") and pipeline.scheduler.config.use_flow_sigmas:
+        sigmas = None
+
+    image_seq_len = latents.shape[1]
+    mu = calculate_shift(
+        image_seq_len,
+        pipeline.scheduler.config.get("base_image_seq_len", 256),
+        pipeline.scheduler.config.get("max_image_seq_len", 4096),
+        pipeline.scheduler.config.get("base_shift", 0.5),
+        pipeline.scheduler.config.get("max_shift", 1.15),
+    )
+    _, num_inference_steps = retrieve_timesteps(
+        pipeline.scheduler,
+        num_inference_steps,
+        device,
+        sigmas=sigmas,
+        mu=mu,
+    )
+    sigmas = pipeline.scheduler.sigmas.float()
+
+    active_transformer = pipeline.transformer
+    guidance_config = unwrap_compiled(active_transformer).config
+    if guidance_config.guidance_embeds:
+        guidance = torch.full([1], guidance_scale, device=device, dtype=torch.float32).expand(latents.shape[0])
+    else:
+        guidance = None
+
+    def v_pred_fn(z, sigma):
+        timestep = torch.full([z.shape[0]], float(sigma), device=z.device, dtype=z.dtype)
+        noise_pred = active_transformer(
+            hidden_states=z,
+            timestep=timestep,
+            guidance=guidance,
+            pooled_projections=pooled_prompt_embeds,
+            encoder_hidden_states=prompt_embeds,
+            txt_ids=text_ids,
+            img_ids=latent_image_ids,
+            joint_attention_kwargs=joint_attention_kwargs,
+            return_dict=False,
+        )[0]
+        return noise_pred
+
+    all_latents = [latents]
+    latents, all_latents, all_log_probs = run_sampling(v_pred_fn, latents, sigmas, solver, deterministic, noise_level)
+
+    latents = pipeline._unpack_latents(latents, height, width, pipeline.vae_scale_factor)
+    latents = (latents / pipeline.vae.config.scaling_factor) + pipeline.vae.config.shift_factor
+    latents = latents.to(dtype=pipeline.vae.dtype)
+
+    if sequential_decode and latents.shape[0] > 1:
+        decoded_batches = []
+        for idx in range(latents.shape[0]):
+            decoded_batches.append(pipeline.vae.decode(latents[idx : idx + 1], return_dict=False)[0])
+        image = torch.cat(decoded_batches, dim=0)
+    else:
+        image = pipeline.vae.decode(latents, return_dict=False)[0]
+
+    image = pipeline.image_processor.postprocess(image, output_type=output_type)
+    pipeline.maybe_free_model_hooks()
+
+    return image, all_latents, latent_image_ids, text_ids, all_log_probs
+
+
+def eval_fn(
+    pipeline,
+    test_dataloader,
+    text_encoders,
+    tokenizers,
+    config,
+    device,
+    rank,
+    world_size,
+    global_step,
+    reward_fn,
+    executor,
+    mixed_precision_dtype,
+    ema,
+    transformer_trainable_parameters,
+):
+    set_seed(config.seed + 1_000_000, rank)
+
+    sequential_decode = bool(getattr(config, "sequential_decode", True))
+    if config.train.ema and ema is not None:
+        ema.copy_ema_to(transformer_trainable_parameters, store_temp=True)
+
+    pipeline.transformer.eval()
+    all_rewards = defaultdict(list)
+    test_sampler = (
+        DistributedSampler(test_dataloader.dataset, num_replicas=world_size, rank=rank, shuffle=False)
+        if world_size > 1
+        else None
+    )
+    eval_loader = DataLoader(
+        test_dataloader.dataset,
+        batch_size=config.sample.test_batch_size,
+        sampler=test_sampler,
+        collate_fn=test_dataloader.collate_fn,
+        num_workers=test_dataloader.num_workers,
+    )
+
+    for prompts, prompt_metadata in tqdm(
+        eval_loader,
+        desc="Eval",
+        disable=not is_main_process(rank),
+        dynamic_ncols=True,
+    ):
+        prompt_embeds, pooled_prompt_embeds, text_ids = compute_text_embeddings(
+            prompts, pipeline, max_sequence_length=TEXT_ENCODER_MAX_SEQ_LEN, device=device
+        )
+        len(prompts)
+        with torch_autocast(enabled=(config.mixed_precision in ["fp16", "bf16"]), dtype=mixed_precision_dtype):
+            with torch.no_grad():
+                images, _, _, _, _ = pipeline_with_logprob_flux(
+                    pipeline,
+                    prompt_embeds=prompt_embeds,
+                    pooled_prompt_embeds=pooled_prompt_embeds,
+                    text_ids=text_ids,
+                    num_inference_steps=config.sample.eval_num_steps,
+                    guidance_scale=config.eval_sample_guidance_scale,
+                    output_type="pt",
+                    height=config.resolution,
+                    width=config.resolution,
+                    noise_level=config.sample.noise_level,
+                    deterministic=True,
+                    solver=config.sample.solver,
+                    sequential_decode=sequential_decode,
+                )
+        rewards_future = executor.submit(reward_fn, images, prompts, prompt_metadata, only_strict=False)
+        time.sleep(0)
+        rewards, _ = rewards_future.result()
+        for key, value in rewards.items():
+            rewards_tensor = torch.as_tensor(value, device=device).float()
+            all_rewards[key].append(gather_tensor_to_all(rewards_tensor, world_size).numpy())
+
+    enable_debug_image_save = bool(getattr(config, "enable_debug_image_save", True))
+    if is_main_process(rank):
+        final_rewards = {key: np.concatenate(value_list) for key, value_list in all_rewards.items()}
+        images_to_log = images.cpu()
+        prompts_to_log = prompts
+        if enable_debug_image_save:
+            eval_debug_dir = os.path.join(config.save_dir, "debug_images", "eval", f"step_{global_step}")
+            save_debug_image_subset(
+                images=images_to_log,
+                prompts=prompts_to_log,
+                save_root=eval_debug_dir,
+                prefix="eval",
+                resolution=config.resolution,
+                rewards=final_rewards.get("avg", None),
+                max_images=getattr(config, "debug_image_subset_size", 6),
+            )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            num_to_log = min(WANDB_MAX_LOG_IMAGES, len(images_to_log))
+            for idx in range(num_to_log):
+                image = images_to_log[idx].float()
+                pil = Image.fromarray((image.numpy().transpose(1, 2, 0) * 255).astype(np.uint8))
+                pil = pil.resize((config.resolution, config.resolution))
+                pil.save(os.path.join(tmpdir, f"{idx}.jpg"))
+
+            sampled_prompts_log = [prompts_to_log[i] for i in range(num_to_log)]
+            sampled_rewards_log = [{k: final_rewards[k][i] for k in final_rewards} for i in range(num_to_log)]
+
+            wandb.log(
+                {
+                    "eval_images": [
+                        wandb.Image(
+                            os.path.join(tmpdir, f"{idx}.jpg"),
+                            caption=f"{prompt:.1000} | "
+                            + " | ".join(f"{k}: {v:.2f}" for k, v in reward.items() if v != -10),
+                        )
+                        for idx, (prompt, reward) in enumerate(zip(sampled_prompts_log, sampled_rewards_log))
+                    ],
+                    **{f"eval_reward_{k}": np.mean(v[v != -10]) for k, v in final_rewards.items()},
+                },
+                commit=False,
+            )
+
+    if config.train.ema and ema is not None:
+        ema.copy_temp_to(transformer_trainable_parameters)
+    if world_size > 1:
+        dist.barrier()
+
+
+def _swap_pipeline_model(pipeline, mode, inference_models, transformer_ddp, original_transformer):
+    """Swap pipeline.transformer to the model specified by *mode*.
+
+    mode: "compile_nvfp4" | "compile" | "peft"
+    """
+    if mode == "peft":
+        pipeline.transformer = original_transformer
+        transformer_ddp.module.set_adapter("old")
+    else:
+        pipeline.transformer = inference_models[mode]
+
+
+def _rollout_for_one_prompt(
+    pipeline,
+    reward_fn,
+    executor,
+    prompt_text,
+    prompt_meta,
+    prompt_embed_single,
+    pooled_embed_single,
+    text_ids_single,
+    prompt_token_ids_single,
+    config,
+    device,
+    inference_models=None,
+    transformer_ddp=None,
+    original_transformer=None,
+):
+    sequential_decode = bool(getattr(config, "sequential_decode", True))
+    amp_dtype = (
+        torch.bfloat16
+        if config.mixed_precision == "bf16"
+        else (torch.float16 if config.mixed_precision == "fp16" else None)
+    )
+    enable_amp = amp_dtype is not None
+    preview_step = int(getattr(config, "preview_step", 0))
+    full_steps = int(getattr(config, "rollout_sample_num_steps", config.sample.num_steps))
+
+    draft_total = int(config.sample.per_prompt_iter_num) * int(config.sample.rollout_batch_size)
+    full_rollout_num = int(getattr(config.sample, "full_rollout_num", config.sample.best_of_n))
+    full_rollout_num = max(1, min(full_rollout_num, draft_total))
+
+    seed_pool = []
+    draft_reward_pool = []
+    prompt_samples = []
+    final_images = None
+    final_prompts = None
+    full_chunks = int(config.sample.rollout_batch_size)
+
+    preview_model_key = str(getattr(config, "preview_model", "peft"))
+    fullrollout_model_key = str(getattr(config, "fullrollout_model", "peft"))
+    _can_swap = inference_models is not None and transformer_ddp is not None and original_transformer is not None
+
+    if preview_step > 0:
+        # --- Stage 1: draft preview (fast screening) ---
+        if _can_swap:
+            _swap_pipeline_model(pipeline, preview_model_key, inference_models, transformer_ddp, original_transformer)
+
+        with torch.no_grad():
+            for iter_idx in range(config.sample.per_prompt_iter_num):
+                batch_size = int(config.sample.rollout_batch_size)
+                prompt_embeds = prompt_embed_single.repeat(batch_size, 1, 1)
+                pooled_prompt_embeds = pooled_embed_single.repeat(batch_size, 1)
+                text_ids = text_ids_single
+
+                seed_list = torch.randint(
+                    low=0,
+                    high=2**31 - 1,
+                    size=(batch_size,),
+                    device="cpu",
+                ).tolist()
+                generators = _build_generators_from_seeds(seed_list, device=device)
+
+                with torch_autocast(enabled=enable_amp, dtype=amp_dtype):
+                    images, _, _, _, _ = pipeline_with_logprob_flux(
+                        pipeline,
+                        generator=generators,
+                        prompt_embeds=prompt_embeds,
+                        pooled_prompt_embeds=pooled_prompt_embeds,
+                        text_ids=text_ids,
+                        num_inference_steps=preview_step,
+                        guidance_scale=config.rollout_sample_guidance_scale,
+                        output_type="pt",
+                        height=config.resolution,
+                        width=config.resolution,
+                        noise_level=config.sample.noise_level,
+                        deterministic=True,
+                        solver=config.sample.solver,
+                        sequential_decode=sequential_decode,
+                    )
+                rewards, _ = reward_fn(
+                    images,
+                    [prompt_text] * batch_size,
+                    [prompt_meta] * batch_size,
+                    only_strict=True,
+                )
+                draft_avg = torch.as_tensor(rewards["avg"], device=device).float()
+                seed_pool.extend(int(s) for s in seed_list)
+                draft_reward_pool.extend(draft_avg.detach().cpu().tolist())
+
+        draft_rewards = torch.as_tensor(draft_reward_pool, device=device).float()
+        stage1_indices = select_indices_by_mode(
+            draft_rewards,
+            target_count=full_rollout_num,
+            mode=getattr(config.sample, "stage1_select_mode", "best_worst"),
+        )
+        selected_seeds = [seed_pool[int(i)] for i in stage1_indices.detach().cpu().tolist()]
+
+        # --- Stage 2: full rollout (may use a different model) ---
+        if _can_swap and fullrollout_model_key != preview_model_key:
+            _swap_pipeline_model(
+                pipeline, fullrollout_model_key, inference_models, transformer_ddp, original_transformer
+            )
+
+        for start in range(0, len(selected_seeds), full_chunks):
+            seed_chunk = selected_seeds[start : start + full_chunks]
+            bs = len(seed_chunk)
+            prompt_embeds = prompt_embed_single.repeat(bs, 1, 1)
+            pooled_prompt_embeds = pooled_embed_single.repeat(bs, 1)
+            text_ids = text_ids_single
+            generators = _build_generators_from_seeds(seed_chunk, device=device)
+            with torch.no_grad():
+                with torch_autocast(enabled=enable_amp, dtype=amp_dtype):
+                    images, latents, latent_image_ids, text_ids, _ = pipeline_with_logprob_flux(
+                        pipeline,
+                        generator=generators,
+                        prompt_embeds=prompt_embeds,
+                        pooled_prompt_embeds=pooled_prompt_embeds,
+                        text_ids=text_ids,
+                        num_inference_steps=full_steps,
+                        guidance_scale=config.rollout_sample_guidance_scale,
+                        output_type="pt",
+                        height=config.resolution,
+                        width=config.resolution,
+                        noise_level=config.sample.noise_level,
+                        deterministic=True,
+                        solver=config.sample.solver,
+                        sequential_decode=sequential_decode,
+                    )
+            timesteps = pipeline.scheduler.timesteps.repeat(bs, 1).to(device)
+            latents = torch.stack(latents, dim=1)
+            rewards_future = executor.submit(
+                reward_fn,
+                images,
+                [prompt_text] * bs,
+                [prompt_meta] * bs,
+                True,
+            )
+            time.sleep(0)
+            prompt_samples.append(
+                {
+                    "prompt_ids": prompt_token_ids_single.repeat(bs, 1),
+                    "prompt_embeds": prompt_embeds,
+                    "pooled_prompt_embeds": pooled_prompt_embeds,
+                    "txt_ids": text_ids.repeat(bs, 1, 1),
+                    "img_ids": latent_image_ids.repeat(bs, 1, 1),
+                    "timesteps": timesteps,
+                    "next_timesteps": torch.concatenate([timesteps[:, 1:], torch.zeros_like(timesteps[:, :1])], dim=1),
+                    "latents_clean": latents[:, -1],
+                    "rewards_future": rewards_future,
+                }
+            )
+            final_images = images
+            final_prompts = [prompt_text] * bs
+    else:
+        for iter_idx in range(config.sample.per_prompt_iter_num):
+            batch_size = int(config.sample.rollout_batch_size)
+            prompt_embeds = prompt_embed_single.repeat(batch_size, 1, 1)
+            pooled_prompt_embeds = pooled_embed_single.repeat(batch_size, 1)
+            text_ids = text_ids_single
+            seed_list = torch.randint(
+                low=0,
+                high=2**31 - 1,
+                size=(batch_size,),
+                device="cpu",
+            ).tolist()
+            generators = _build_generators_from_seeds(seed_list, device=device)
+            with torch.no_grad():
+                with torch_autocast(enabled=enable_amp, dtype=amp_dtype):
+                    images, latents, latent_image_ids, text_ids, _ = pipeline_with_logprob_flux(
+                        pipeline,
+                        generator=generators,
+                        prompt_embeds=prompt_embeds,
+                        pooled_prompt_embeds=pooled_prompt_embeds,
+                        text_ids=text_ids,
+                        num_inference_steps=full_steps,
+                        guidance_scale=config.rollout_sample_guidance_scale,
+                        output_type="pt",
+                        height=config.resolution,
+                        width=config.resolution,
+                        noise_level=config.sample.noise_level,
+                        deterministic=True,
+                        solver=config.sample.solver,
+                        sequential_decode=sequential_decode,
+                    )
+            timesteps = pipeline.scheduler.timesteps.repeat(batch_size, 1).to(device)
+            latents = torch.stack(latents, dim=1)
+            rewards_future = executor.submit(
+                reward_fn,
+                images,
+                [prompt_text] * batch_size,
+                [prompt_meta] * batch_size,
+                True,
+            )
+            time.sleep(0)
+            prompt_samples.append(
+                {
+                    "prompt_ids": prompt_token_ids_single.repeat(batch_size, 1),
+                    "prompt_embeds": prompt_embeds,
+                    "pooled_prompt_embeds": pooled_prompt_embeds,
+                    "txt_ids": text_ids.repeat(batch_size, 1, 1),
+                    "img_ids": latent_image_ids.repeat(batch_size, 1, 1),
+                    "timesteps": timesteps,
+                    "next_timesteps": torch.concatenate([timesteps[:, 1:], torch.zeros_like(timesteps[:, :1])], dim=1),
+                    "latents_clean": latents[:, -1],
+                    "rewards_future": rewards_future,
+                }
+            )
+            final_images = images
+            final_prompts = [prompt_text] * batch_size
+
+    for item in prompt_samples:
+        rewards, _ = item["rewards_future"].result()
+        item["rewards"] = {k: torch.as_tensor(v, device=device).float() for k, v in rewards.items()}
+        del item["rewards_future"]
+
+    collated = collate_dict_items(prompt_samples)
+    final_rewards = collated["rewards"]["avg"]
+    keep_indices = select_indices_by_mode(
+        final_rewards,
+        target_count=config.sample.best_of_n,
+        mode=getattr(config.sample, "stage2_select_mode", "best_worst"),
+    )
+    collated = filter_by_indices(collated, keep_indices)
+    return collated, final_images, final_prompts
+
+
+def main(_):
+    config = FLAGS.config
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    setup_distributed(rank, local_rank, world_size)
+    device = torch.device(f"cuda:{local_rank}")
+
+    if is_main_process(rank):
+        log_dir = os.path.join(config.logdir, config.run_name)
+        os.makedirs(log_dir, exist_ok=True)
+        wandb.init(
+            project="sol-rl",
+            name=config.run_name,
+            config=config.to_dict(),
+            resume="allow",
+            dir=log_dir,
+            id=config.run_name,
+        )
+        wandb.define_metric("global_step")
+        wandb.define_metric("*", step_metric="global_step")
+    logger.info("\n%s", config)
+
+    set_seed(config.seed, rank)
+
+    # cuDNN SDPA backward graph fails on Blackwell (sm_100); fall back to flash/math
+    torch.backends.cuda.enable_cudnn_sdp(False)
+
+    mixed_precision_dtype = None
+    if config.mixed_precision == "fp16":
+        mixed_precision_dtype = torch.float16
+    elif config.mixed_precision == "bf16":
+        mixed_precision_dtype = torch.bfloat16
+    enable_amp = mixed_precision_dtype is not None
+    scaler = GradScaler(enabled=enable_amp)
+
+    pipeline = FluxPipeline.from_pretrained(config.pretrained.model)
+    pipeline.vae.requires_grad_(False)
+    pipeline.text_encoder.requires_grad_(False)
+    pipeline.text_encoder_2.requires_grad_(False)
+    pipeline.transformer.requires_grad_(not config.use_lora)
+    pipeline.set_progress_bar_config(disable=True)
+    text_encoders = [pipeline.text_encoder, pipeline.text_encoder_2]
+    tokenizers = [pipeline.tokenizer, pipeline.tokenizer_2]
+
+    text_encoder_dtype = mixed_precision_dtype if enable_amp else torch.float32
+    pipeline.vae.to(device, dtype=torch.float32)
+    pipeline.text_encoder.to(device, dtype=text_encoder_dtype)
+    pipeline.text_encoder_2.to(device, dtype=text_encoder_dtype)
+
+    transformer = pipeline.transformer.to(device, dtype=torch.bfloat16)
+    transformer.enable_gradient_checkpointing()
+
+    compile_mode = str(getattr(config, "compile_mode", "max-autotune-no-cudagraphs"))
+    preview_step = int(getattr(config, "preview_step", 0))
+    preview_model_key = str(getattr(config, "preview_model", "peft"))
+    fullrollout_model_key = str(getattr(config, "fullrollout_model", "peft"))
+
+    needed_model_types = set()
+    if preview_step > 0:
+        if preview_model_key != "peft":
+            needed_model_types.add(preview_model_key)
+        if fullrollout_model_key != "peft":
+            needed_model_types.add(fullrollout_model_key)
+    else:
+        if fullrollout_model_key != "peft":
+            needed_model_types.add(fullrollout_model_key)
+
+    inference_models = {}
+    nvfp4_skip_modules = list(getattr(config, "nvfp4_skip_modules", FLUX_NVFP4_DEFAULT_SKIP_MODULES))
+    nvfp4_min_dim = int(getattr(config, "nvfp4_min_dim", 1000))
+
+    for mtype in sorted(needed_model_types):
+        logger.info(f"[INIT] Creating inference model: {mtype!r} ...")
+        m = FluxTransformer2DModel.from_config(transformer.config).to(device, dtype=torch.bfloat16)
+        m.load_state_dict(transformer.state_dict())
+        m.requires_grad_(False)
+        m.eval()
+
+        if "nvfp4" in mtype:
+            if not _HAS_TE:
+                raise RuntimeError(f"model type {mtype!r} requires transformer_engine")
+            n_rep, n_skip, rep_d, skip_d = replace_linear_with_te(
+                m,
+                skip_modules=nvfp4_skip_modules,
+                min_dim=nvfp4_min_dim,
+            )
+            logger.info(f"[NVFP4] {mtype}: replaced {n_rep} nn.Linear -> te.Linear, skipped {n_skip}")
+            wrap_forward_with_fp8(m)
+            logger.info(f"[NVFP4] {mtype}: wrap_forward_with_fp8 applied")
+            if is_main_process(rank):
+                report_path = os.path.join(config.save_dir, f"nvfp4_quant_report_{mtype}.txt")
+                os.makedirs(os.path.dirname(report_path), exist_ok=True)
+                with open(report_path, "w") as f:
+                    f.write(f"NVFP4 Quantization Report ({mtype})\n{'=' * 60}\n")
+                    f.write(f"skip_modules: {nvfp4_skip_modules}\n")
+                    f.write(f"min_dim: {nvfp4_min_dim}\n")
+                    f.write(f"replaced: {n_rep}  skipped: {n_skip}\n\n")
+                    f.write(f"Replaced (te.Linear + NVFP4):\n{'-' * 60}\n")
+                    for fqn, inf, outf, bias, _ in rep_d:
+                        f.write(f"  {fqn:60s}  in={inf:6d}  out={outf:6d}  bias={bias}\n")
+                    f.write(f"\nSkipped (kept as nn.Linear):\n{'-' * 60}\n")
+                    for fqn, inf, outf, bias, reason in skip_d:
+                        f.write(f"  {fqn:60s}  in={inf:6d}  out={outf:6d}  bias={bias}  reason={reason}\n")
+                logger.info(f"[NVFP4] Report saved to {report_path}")
+
+        if world_size > 1:
+            dist.barrier()
+        logger.info(f"[COMPILE] torch.compile(mode={compile_mode!r}) on {mtype!r} ...")
+        m = torch.compile(m, mode=compile_mode)
+        inference_models[mtype] = m
+        logger.info(f"[INIT] {mtype!r} ready")
+
+    if inference_models:
+        logger.info(f"[INIT] Inference models created: {list(inference_models.keys())}")
+    else:
+        logger.info("[INIT] No inference models needed, using PEFT model for all inference")
+
+    if config.use_lora:
+        init_lora_weights = getattr(config.train, "lora_init_mode", config.train.lora_init_weights)
+        transformer_lora_config = LoraConfig(
+            r=config.train.lora_rank,
+            lora_alpha=config.train.lora_alpha,
+            init_lora_weights=init_lora_weights,
+            target_modules=list(
+                getattr(config.train, "flux_lora_target_modules", ["to_k", "to_q", "to_v", "to_out.0"])
+            ),
+        )
+        if config.train.lora_path:
+            transformer = PeftModel.from_pretrained(transformer, config.train.lora_path)
+            transformer.set_adapter("default")
+        else:
+            transformer = get_peft_model(transformer, transformer_lora_config)
+        transformer.add_adapter("old", transformer_lora_config)
+        transformer.set_adapter("default")
+
+    transformer.set_adapter("default")
+    transformer_trainable_parameters = list(filter(lambda p: p.requires_grad, transformer.parameters()))
+    transformer.set_adapter("old")
+    old_transformer_trainable_parameters = list(filter(lambda p: p.requires_grad, transformer.parameters()))
+    for p in old_transformer_trainable_parameters:
+        p.requires_grad_(False)
+    transformer.set_adapter("default")
+    transformer_ddp = DDP(transformer, device_ids=[local_rank], output_device=local_rank, find_unused_parameters=True)
+
+    if config.allow_tf32:
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+
+    optimizer = torch.optim.AdamW(
+        transformer_trainable_parameters,
+        lr=config.train.learning_rate,
+        betas=(config.train.adam_beta1, config.train.adam_beta2),
+        weight_decay=config.train.adam_weight_decay,
+        eps=config.train.adam_epsilon,
+    )
+
+    _, train_dataloader, train_sampler, _, test_dataloader = build_datasets_and_loaders(config, world_size, rank)
+
+    if config.sample.best_of_n == 1:
+        config.per_prompt_stat_tracking = False
+    if config.per_prompt_stat_tracking:
+        stat_tracker = PerPromptStatTracker(config.global_std)
+    else:
+        raise ValueError("per_prompt_stat_tracking must be enabled for this recipe")
+
+    reward_fn = getattr(diffusion.flow_grpo.rewards, "multi_score")(device, config.reward_fn)
+    eval_reward_fn = getattr(diffusion.flow_grpo.rewards, "multi_score")(device, config.reward_fn)
+    executor = futures.ThreadPoolExecutor(max_workers=8)
+
+    ema = None
+    if config.train.ema:
+        ema = EMAModuleWrapper(transformer_trainable_parameters, decay=0.9, update_step_interval=1, device=device)
+
+    num_train_timesteps = int(config.rollout_sample_num_steps * config.train.timestep_fraction)
+    train_iter = iter(train_dataloader)
+    optimizer.zero_grad()
+
+    # --- Resume from checkpoint ---
+    first_epoch = 0
+    global_step = 0
+    candidates = find_resume_candidates(config)
+    global_step, resume_parameters = resume_from_checkpoint(
+        candidates,
+        unwrap_compiled(transformer_ddp.module),
+        ema,
+        optimizer,
+        scaler,
+        device,
+    )
+    first_epoch = global_step
+
+    if not resume_parameters:
+        for src_param, tgt_param in zip(
+            transformer_trainable_parameters, old_transformer_trainable_parameters, strict=True
+        ):
+            tgt_param.data.copy_(src_param.detach().data)
+
+    for mtype, inf_model in inference_models.items():
+        n_synced = sync_lora_to_inference(
+            unwrap_compiled(transformer_ddp.module),
+            unwrap_compiled(inf_model),
+            adapter_name="old",
+        )
+        logger.info(f"[SYNC] Initial sync: merged {n_synced} LoRA layers -> {mtype!r}")
+
+    if global_step != 0:
+        for i in range(global_step):
+            prompts, prompt_metadata = next(train_iter)
+
+    if world_size > 1:
+        dist.barrier()
+
+    time_logger = DistributedTimeLogger(device)
+    start_time = time.time()
+    for epoch in range(first_epoch, config.num_epochs):
+        time_logger.start("total_time")
+
+        if hasattr(train_sampler, "set_epoch"):
+            train_sampler.set_epoch(epoch)
+
+        if epoch % config.save_freq == 0 and not config.debug:
+            save_ckpt(config.save_dir, transformer_ddp, global_step, rank, ema, config, optimizer, scaler)
+
+        time_logger.start("eval_time")
+        if epoch % config.eval_freq == 0 and not config.debug:
+            pipeline.text_encoder.to(device, dtype=text_encoder_dtype)
+            pipeline.text_encoder_2.to(device, dtype=text_encoder_dtype)
+            pipeline.vae.to(device, dtype=torch.float32)
+
+            py_rng_state = random.getstate()
+            np_rng_state = np.random.get_state()
+            torch_rng_state = torch.random.get_rng_state()
+            cuda_rng_state = torch.cuda.get_rng_state_all()
+
+            eval_fn(
+                pipeline,
+                test_dataloader,
+                text_encoders,
+                tokenizers,
+                config,
+                device,
+                rank,
+                world_size,
+                global_step,
+                eval_reward_fn,
+                executor,
+                mixed_precision_dtype,
+                ema,
+                transformer_trainable_parameters,
+            )
+
+            random.setstate(py_rng_state)
+            np.random.set_state(np_rng_state)
+            torch.random.set_rng_state(torch_rng_state)
+            torch.cuda.set_rng_state_all(cuda_rng_state)
+        time_logger.end("eval_time")
+
+        time_logger.start("rollout_time")
+        pipeline.text_encoder.to(device, dtype=text_encoder_dtype)
+        pipeline.text_encoder_2.to(device, dtype=text_encoder_dtype)
+        pipeline.vae.to(device, dtype=torch.float32)
+        pipeline.transformer.eval()
+        prompts, prompt_metadata = next(train_iter)
+        prompt_embeds_all, pooled_prompt_embeds_all, text_ids_all = compute_text_embeddings(
+            prompts, pipeline, max_sequence_length=TEXT_ENCODER_MAX_SEQ_LEN, device=device
+        )
+        prompt_ids_all = tokenizers[0](
+            prompts,
+            padding="max_length",
+            max_length=TOKENIZER_MAX_LENGTH,
+            truncation=True,
+            return_tensors="pt",
+        ).input_ids.to(device)
+
+        prompt_wise_samples = []
+        step_prompt_reward_groups = []
+        images_for_log = None
+        prompts_for_log = None
+        rewards_for_log = None
+
+        _saved_pipeline_transformer = pipeline.transformer
+
+        if preview_step == 0:
+            if fullrollout_model_key != "peft" and fullrollout_model_key in inference_models:
+                pipeline.transformer = inference_models[fullrollout_model_key]
+            else:
+                transformer_ddp.module.set_adapter("old")
+
+        for _p in transformer_trainable_parameters:
+            _p.requires_grad_(True)
+        for prompt_idx in tqdm(
+            range(config.sample.per_gpu_to_process_prompts),
+            desc=f"Epoch {epoch}: rollout",
+            disable=not is_main_process(rank),
+            dynamic_ncols=True,
+        ):
+            collated_prompt_samples, final_images, final_prompts = _rollout_for_one_prompt(
+                pipeline=pipeline,
+                reward_fn=reward_fn,
+                executor=executor,
+                prompt_text=prompts[prompt_idx],
+                prompt_meta=prompt_metadata[prompt_idx],
+                prompt_embed_single=prompt_embeds_all[prompt_idx : prompt_idx + 1],
+                pooled_embed_single=pooled_prompt_embeds_all[prompt_idx : prompt_idx + 1],
+                text_ids_single=text_ids_all,
+                prompt_token_ids_single=prompt_ids_all[prompt_idx : prompt_idx + 1],
+                config=config,
+                device=device,
+                inference_models=inference_models,
+                transformer_ddp=transformer_ddp,
+                original_transformer=_saved_pipeline_transformer,
+            )
+            prompt_wise_samples.append(collated_prompt_samples)
+            prompt_meta_i = slice_prompt_metadata(prompt_metadata, prompt_idx)
+            step_prompt_reward_groups.append(
+                extract_prompt_reward_group(
+                    prompt_idx=prompt_idx,
+                    prompt_text=prompts[prompt_idx],
+                    prompt_meta=prompt_meta_i,
+                    intra_prompt_data_list=[collated_prompt_samples],
+                )
+            )
+            images_for_log = final_images
+            prompts_for_log = final_prompts
+            rewards_for_log = collated_prompt_samples["rewards"]["avg"]
+
+        pipeline.transformer = _saved_pipeline_transformer
+        transformer_ddp.module.set_adapter("default")
+        for _p in transformer_trainable_parameters:
+            _p.requires_grad_(True)
+
+        save_step_reward_groups(
+            config=config,
+            global_step=global_step,
+            epoch=epoch,
+            rank=rank,
+            world_size=world_size,
+            prompt_reward_groups=step_prompt_reward_groups,
+        )
+
+        collated_samples = collate_dict_items(prompt_wise_samples)
+
+        log_rollout_images(images_for_log, prompts_for_log, rewards_for_log, config, global_step, rank)
+
+        collated_samples["rewards"]["avg"] = (
+            collated_samples["rewards"]["avg"].unsqueeze(1).repeat(1, num_train_timesteps)
+        )
+
+        gathered_rewards_dict = {
+            key: gather_tensor_to_all(value, world_size).numpy() for key, value in collated_samples["rewards"].items()
+        }
+        if is_main_process(rank):
+            rewards_to_log = gathered_rewards_dict["avg"]
+            rewards_to_log = rewards_to_log.reshape(
+                world_size * config.sample.per_gpu_to_process_prompts, -1, num_train_timesteps
+            )
+            rewards_to_log = rewards_to_log.mean(axis=-1)
+            wandb.log(
+                {
+                    "epoch": epoch,
+                    "reward/mean": rewards_to_log.mean(),
+                    "reward/max": rewards_to_log.max(axis=1).mean(),
+                    "reward/min": rewards_to_log.min(axis=1).mean(),
+                    "reward/range": rewards_to_log.max(axis=1).mean() - rewards_to_log.min(axis=1).mean(),
+                },
+                commit=False,
+            )
+
+        prompt_ids_all_global = gather_tensor_to_all(collated_samples["prompt_ids"], world_size)
+        prompts_all_decoded = tokenizers[0].batch_decode(prompt_ids_all_global.cpu().numpy(), skip_special_tokens=True)
+        advantages = stat_tracker.update(prompts_all_decoded, gathered_rewards_dict["avg"])
+
+        if is_main_process(rank):
+            group_size, trained_prompt_num = stat_tracker.get_stats()
+            zero_std_ratio, reward_std_mean = calculate_zero_std_ratio(prompts_all_decoded, gathered_rewards_dict)
+            wandb.log(
+                {
+                    "group_size": group_size,
+                    "trained_prompt_num": trained_prompt_num,
+                    "zero_std_ratio": zero_std_ratio,
+                    "reward_std_mean": reward_std_mean,
+                    "mean_reward_100": stat_tracker.get_mean_of_top_rewards(100),
+                    "mean_reward_75": stat_tracker.get_mean_of_top_rewards(75),
+                    "mean_reward_50": stat_tracker.get_mean_of_top_rewards(50),
+                    "mean_reward_25": stat_tracker.get_mean_of_top_rewards(25),
+                    "mean_reward_10": stat_tracker.get_mean_of_top_rewards(10),
+                },
+                commit=False,
+            )
+        stat_tracker.clear()
+
+        samples_per_gpu = collated_samples["timesteps"].shape[0]
+        if advantages.ndim == 1:
+            advantages = advantages[:, None]
+        if advantages.shape[0] != world_size * samples_per_gpu:
+            raise RuntimeError("Unexpected advantage shape after all-gather")
+        collated_samples["advantages"] = torch.from_numpy(
+            advantages.reshape(world_size, samples_per_gpu, -1)[rank].astype("float32")
+        ).to(device)
+
+        del collated_samples["rewards"]
+        del collated_samples["prompt_ids"]
+        time_logger.end("rollout_time")
+
+        pipeline.text_encoder.to("cpu")
+        pipeline.text_encoder_2.to("cpu")
+        pipeline.vae.to("cpu")
+        torch.cuda.empty_cache()
+
+        total_batch_size_filtered, num_timesteps_filtered = collated_samples["timesteps"].shape
+        assert total_batch_size_filtered == config.sample.per_gpu_total_samples_to_train
+
+        time_logger.start("train_time")
+        transformer_ddp.train()
+        effective_grad_accum_steps = config.train.gradient_accumulation_steps * num_train_timesteps
+        current_accumulated_steps = 0
+        gradient_update_times = 0
+
+        for inner_epoch in range(config.train.num_inner_epochs):
+            perm = torch.randperm(total_batch_size_filtered, device=device)
+            shuffled_samples = {k: v[perm] for k, v in collated_samples.items()}
+            perms_time = torch.stack(
+                [torch.randperm(num_timesteps_filtered, device=device) for _ in range(total_batch_size_filtered)]
+            )
+            for key in ["timesteps", "next_timesteps"]:
+                shuffled_samples[key] = shuffled_samples[key][
+                    torch.arange(total_batch_size_filtered, device=device)[:, None],
+                    perms_time,
+                ]
+
+            training_batch_size = config.train.batch_size
+            batches = []
+            for batch_idx in range(config.train.n_batch_per_epoch):
+                start = batch_idx * training_batch_size
+                end = (batch_idx + 1) * training_batch_size
+                batches.append({k: v[start:end] for k, v in shuffled_samples.items()})
+
+            info_accumulated = defaultdict(list)
+            for train_batch in tqdm(
+                batches,
+                desc=f"Epoch {epoch}.{inner_epoch}: train",
+                disable=not is_main_process(rank),
+                dynamic_ncols=True,
+            ):
+                current_bs = len(train_batch["prompt_embeds"])
+                embeds = train_batch["prompt_embeds"]
+                pooled_embeds = train_batch["pooled_prompt_embeds"]
+                txt_ids_batch = train_batch["txt_ids"][0]
+                img_ids_batch = train_batch["img_ids"][0]
+                if transformer_ddp.module.config.guidance_embeds:
+                    guidance_batch = torch.full(
+                        [current_bs],
+                        float(config.train_sample_guidance_scale),
+                        device=device,
+                        dtype=torch.float32,
+                    )
+                else:
+                    guidance_batch = None
+
+                for j_idx in range(num_train_timesteps):
+                    x0 = train_batch["latents_clean"]
+                    t = torch.clamp(train_batch["timesteps"][:, j_idx] / 1000.0, 0.0, 1.0).to(x0.dtype)
+                    t_expanded = t.view(-1, *([1] * (len(x0.shape) - 1)))
+                    noise = torch.randn_like(x0)
+                    xt = (1 - t_expanded) * x0 + t_expanded * noise
+                    timestep_for_model = t
+
+                    transformer_ddp.module.set_adapter("old")
+                    for _p in transformer_trainable_parameters:
+                        _p.requires_grad_(True)
+                    with torch.no_grad():
+                        with torch_autocast(enabled=enable_amp, dtype=mixed_precision_dtype):
+                            old_prediction = transformer_ddp.module(
+                                hidden_states=xt,
+                                timestep=timestep_for_model,
+                                guidance=guidance_batch,
+                                encoder_hidden_states=embeds,
+                                pooled_projections=pooled_embeds,
+                                txt_ids=txt_ids_batch,
+                                img_ids=img_ids_batch,
+                                return_dict=False,
+                            )[0].detach()
+                    transformer_ddp.module.set_adapter("default")
+                    for _p in transformer_trainable_parameters:
+                        _p.requires_grad_(True)
+                    with torch_autocast(enabled=enable_amp, dtype=mixed_precision_dtype):
+                        forward_prediction = transformer_ddp(
+                            hidden_states=xt,
+                            timestep=timestep_for_model,
+                            guidance=guidance_batch,
+                            encoder_hidden_states=embeds,
+                            pooled_projections=pooled_embeds,
+                            txt_ids=txt_ids_batch,
+                            img_ids=img_ids_batch,
+                            return_dict=False,
+                        )[0]
+                    with torch.no_grad():
+                        with torch_autocast(enabled=enable_amp, dtype=mixed_precision_dtype):
+                            with transformer_ddp.module.disable_adapter():
+                                ref_forward_prediction = transformer_ddp.module(
+                                    hidden_states=xt,
+                                    timestep=timestep_for_model,
+                                    guidance=guidance_batch,
+                                    encoder_hidden_states=embeds,
+                                    pooled_projections=pooled_embeds,
+                                    txt_ids=txt_ids_batch,
+                                    img_ids=img_ids_batch,
+                                    return_dict=False,
+                                )[0]
+                            transformer_ddp.module.set_adapter("default")
+
+                    advantages_clip = torch.clamp(
+                        train_batch["advantages"][:, j_idx],
+                        -config.train.adv_clip_max,
+                        config.train.adv_clip_max,
+                    )
+                    if hasattr(config.train, "adv_mode"):
+                        if config.train.adv_mode == "positive_only":
+                            advantages_clip = torch.clamp(advantages_clip, 0, config.train.adv_clip_max)
+                        elif config.train.adv_mode == "negative_only":
+                            advantages_clip = torch.clamp(advantages_clip, -config.train.adv_clip_max, 0)
+                        elif config.train.adv_mode == "one_only":
+                            advantages_clip = torch.where(
+                                advantages_clip > 0, torch.ones_like(advantages_clip), torch.zeros_like(advantages_clip)
+                            )
+                        elif config.train.adv_mode == "binary":
+                            advantages_clip = torch.sign(advantages_clip)
+
+                    normalized_adv = (advantages_clip / config.train.adv_clip_max) / 2.0 + 0.5
+                    r = torch.clamp(normalized_adv, 0, 1)
+
+                    positive_prediction = config.beta * forward_prediction + (1 - config.beta) * old_prediction.detach()
+                    implicit_negative_prediction = (
+                        1.0 + config.beta
+                    ) * old_prediction.detach() - config.beta * forward_prediction
+
+                    x0_prediction = xt - t_expanded * positive_prediction
+                    with torch.no_grad():
+                        weight_factor = (
+                            torch.abs(x0_prediction.double() - x0.double())
+                            .mean(dim=tuple(range(1, x0.ndim)), keepdim=True)
+                            .clip(min=1e-5)
+                        )
+                    positive_loss = ((x0_prediction - x0) ** 2 / weight_factor).mean(dim=tuple(range(1, x0.ndim)))
+
+                    negative_x0_prediction = xt - t_expanded * implicit_negative_prediction
+                    with torch.no_grad():
+                        negative_weight_factor = (
+                            torch.abs(negative_x0_prediction.double() - x0.double())
+                            .mean(dim=tuple(range(1, x0.ndim)), keepdim=True)
+                            .clip(min=1e-5)
+                        )
+                    negative_loss = ((negative_x0_prediction - x0) ** 2 / negative_weight_factor).mean(
+                        dim=tuple(range(1, x0.ndim))
+                    )
+
+                    ori_policy_loss = r * positive_loss / config.beta + (1.0 - r) * negative_loss / config.beta
+                    policy_loss = (ori_policy_loss * config.train.adv_clip_max).mean()
+                    loss = policy_loss
+                    loss_terms = {}
+                    loss_terms["policy_loss"] = policy_loss.detach()
+                    loss_terms["unweighted_policy_loss"] = ori_policy_loss.mean().detach()
+                    loss_terms["x0_norm"] = torch.mean(x0**2).detach()
+                    loss_terms["x0_norm_max"] = torch.max(x0**2).detach()
+                    loss_terms["old_deviate"] = torch.mean((forward_prediction - old_prediction) ** 2).detach()
+                    loss_terms["old_deviate_max"] = torch.max((forward_prediction - old_prediction) ** 2).detach()
+
+                    kl_div_loss = ((forward_prediction - ref_forward_prediction) ** 2).mean(
+                        dim=tuple(range(1, x0.ndim))
+                    )
+                    loss += config.train.beta * torch.mean(kl_div_loss)
+                    kl_div_loss = torch.mean(kl_div_loss)
+
+                    loss_terms["kl_div_loss"] = torch.mean(kl_div_loss).detach()
+                    loss_terms["kl_div"] = torch.mean(
+                        ((forward_prediction - ref_forward_prediction) ** 2).mean(dim=tuple(range(1, x0.ndim)))
+                    ).detach()
+                    loss_terms["old_kl_div"] = torch.mean(
+                        ((old_prediction - ref_forward_prediction) ** 2).mean(dim=tuple(range(1, x0.ndim)))
+                    ).detach()
+                    loss_terms["total_loss"] = loss.detach()
+
+                    scaled_loss = loss / effective_grad_accum_steps
+                    if torch.isnan(scaled_loss) or torch.isinf(scaled_loss):
+                        scaled_loss = scaled_loss * 0.0
+
+                    if mixed_precision_dtype == torch.float16:
+                        scaler.scale(scaled_loss).backward()
+                    else:
+                        scaled_loss.backward()
+                    current_accumulated_steps += 1
+
+                    for k_info, v_info in loss_terms.items():
+                        info_accumulated[k_info].append(v_info)
+
+                    if current_accumulated_steps % effective_grad_accum_steps == 0:
+                        if mixed_precision_dtype == torch.float16:
+                            scaler.unscale_(optimizer)
+                        grad_norm = torch.nn.utils.clip_grad_norm_(
+                            transformer_ddp.module.parameters(), config.train.max_grad_norm
+                        )
+                        if mixed_precision_dtype == torch.float16:
+                            scaler.step(optimizer)
+                            scaler.update()
+                        else:
+                            optimizer.step()
+                        optimizer.zero_grad()
+                        gradient_update_times += 1
+
+                        log_info = {k: torch.mean(torch.stack(v)).item() for k, v in info_accumulated.items()}
+                        if torch.is_tensor(grad_norm):
+                            log_info["grad_norm"] = grad_norm.detach().float().item()
+                        else:
+                            log_info["grad_norm"] = float(grad_norm)
+                        info_tensor = torch.tensor([log_info[k] for k in sorted(log_info)], device=device)
+                        dist.all_reduce(info_tensor, op=dist.ReduceOp.AVG)
+                        reduced_log = {k: info_tensor[i].item() for i, k in enumerate(sorted(log_info))}
+                        if is_main_process(rank):
+                            wandb.log(
+                                {
+                                    "global_step": global_step,
+                                    "gradient_update_times": gradient_update_times,
+                                    "epoch": epoch,
+                                    "inner_epoch": inner_epoch,
+                                    "current_time": time.time() - start_time,
+                                    **reduced_log,
+                                },
+                                commit=False,
+                            )
+                        global_step += 1
+                        info_accumulated = defaultdict(list)
+
+                    if (
+                        config.train.ema
+                        and ema is not None
+                        and (current_accumulated_steps % effective_grad_accum_steps == 0)
+                    ):
+                        ema.step(transformer_trainable_parameters, global_step)
+
+        time_logger.end("train_time")
+
+        if world_size > 1:
+            dist.barrier()
+        with torch.no_grad():
+            decay = return_decay(
+                global_step,
+                config.decay_type,
+                custom_decay_step=getattr(config, "custom_decay_step", 0),
+                custom_decay_value=getattr(config, "custom_decay_value", 0.0),
+            )
+            for src_param, tgt_param in zip(
+                transformer_trainable_parameters, old_transformer_trainable_parameters, strict=True
+            ):
+                tgt_param.data.copy_(tgt_param.detach().data * decay + src_param.detach().clone().data * (1.0 - decay))
+
+        for mtype, inf_model in inference_models.items():
+            sync_lora_to_inference(
+                unwrap_compiled(transformer_ddp.module),
+                unwrap_compiled(inf_model),
+                adapter_name="old",
+            )
+
+        time_logger.end("total_time")
+        stats = time_logger.get_results()
+
+        if is_main_process(rank):
+            time_logs = {f"time/{k}": v for k, v in stats.items()}
+            wandb.log(time_logs, commit=True)
+            logger.info("Step %d Time Report: %s", global_step, time_logs)
+
+        time_logger.empty_cache()
+
+    if is_main_process(rank):
+        wandb.finish()
+    cleanup_distributed()
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/train_scripts/sol_rl/train_sana.py
+++ b/train_scripts/sol_rl/train_sana.py
@@ -1,0 +1,1158 @@
+"""
+Sana post-training (BON + preview rollout) using diffusers SanaPipeline.
+Structure mirrors train_sd3 (Sol-RL) with BON + preview rollout.
+"""
+
+import os
+import sys
+from collections import defaultdict
+
+_rank = int(os.environ.get("RANK", 0))
+_cache_root = os.environ.get("CACHE_ROOT", os.path.expanduser("~/.cache/sol_rl"))
+os.environ.setdefault("TRITON_CACHE_DIR", f"{_cache_root}/triton/rank_{_rank}")
+os.environ.setdefault("TORCHINDUCTOR_CACHE_DIR", f"{_cache_root}/torchinductor/rank_{_rank}")
+os.environ.setdefault("TORCHINDUCTOR_FX_GRAPH_CACHE", "1")
+
+import logging
+import random
+import time
+from concurrent import futures
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import tqdm
+import wandb
+from absl import app, flags
+from diffusers import SanaPipeline
+from ml_collections import config_flags
+from peft import LoraConfig, PeftModel, get_peft_model
+from PIL import Image
+from torch.cuda.amp import GradScaler
+from torch.cuda.amp import autocast as torch_autocast
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.data import DataLoader
+from torch.utils.data.distributed import DistributedSampler
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+import pyrallis
+from train_utils import (
+    _HAS_TE,
+    NVFP4_RECIPE,
+    DistributedTimeLogger,
+    build_datasets_and_loaders,
+    calculate_zero_std_ratio,
+    cleanup_distributed,
+    collate_dict_items,
+    extract_prompt_reward_group,
+    filter_by_indices,
+    find_resume_candidates,
+    gather_tensor_to_all,
+    is_main_process,
+    log_rollout_images,
+    replace_linear_with_te,
+    resume_from_checkpoint,
+    return_decay,
+    save_ckpt,
+    save_step_reward_groups,
+    select_indices_by_mode,
+    set_seed,
+    setup_distributed,
+    slice_prompt_metadata,
+    sync_lora_to_inference,
+    te,
+    to_jsonable,
+    unwrap_compiled,
+    wrap_forward_with_fp8,
+)
+
+import diffusion.flow_grpo.rewards
+import diffusion.model.nets.sana_multi_scale  # noqa: F401
+import diffusion.model.nets.sana_multi_scale_linear  # noqa: F401
+from diffusion.flow_grpo.diffusers_patch.solver import run_sampling
+from diffusion.flow_grpo.ema import EMAModuleWrapper
+from diffusion.flow_grpo.stat_tracking import PerPromptStatTracker
+from diffusion.model.builder import MODELS
+from diffusion.utils.config import SanaConfig, model_init_config
+
+tqdm = tqdm.tqdm
+FLAGS = flags.FLAGS
+config_flags.DEFINE_config_file(
+    "config",
+    "configs/sol_rl/sana.py",
+    "Training configuration.",
+)
+flags.DEFINE_string(
+    "native_config", "diffusers_to_native/config_sana10_training_linear.yaml", "Native model YAML config path"
+)
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+TEXT_ENCODER_MAX_SEQ_LEN = 300
+TOKENIZER_MAX_LENGTH = 300
+WANDB_MAX_LOG_IMAGES = 12
+
+
+# ===================== Latent Helpers =====================
+
+
+def _prepare_latents_from_seeds(seed_list, num_channels, latent_h, latent_w, device, dtype):
+    latents = []
+    for seed in seed_list:
+        g = torch.Generator(device=device).manual_seed(int(seed))
+        latents.append(torch.randn(1, num_channels, latent_h, latent_w, device=device, dtype=dtype, generator=g))
+    return torch.cat(latents, dim=0)
+
+
+# ===================== Rollout with Native Sana =====================
+
+
+@torch.no_grad()
+def pipeline_with_logprob_sana(
+    transformer,
+    vae,
+    *,
+    latents=None,
+    num_channels=None,
+    latent_size=None,
+    prompt_embeds=None,
+    prompt_attention_mask=None,
+    negative_prompt_embeds=None,
+    negative_prompt_attention_mask=None,
+    num_inference_steps=20,
+    guidance_scale=4.5,
+    noise_level=0.7,
+    deterministic=False,
+    sequential_decode=False,
+    solver="flow",
+):
+    """Native DiT forward + flow sampling + VAE decode (mirrors sana_inference_yaml_linear.py).
+
+    Returns
+    -------
+    images       : Tensor (B, C, H, W) in [0, 1]
+    all_latents  : list[Tensor] – latent state after each step
+    sigmas       : Tensor (num_steps,) – sigma schedule used (0-1 range)
+    """
+    assert prompt_embeds is not None
+
+    if latents is None:
+        assert num_channels is not None and latent_size is not None
+        latents = torch.randn(
+            prompt_embeds.shape[0],
+            num_channels,
+            latent_size,
+            latent_size,
+            device=prompt_embeds.device,
+            dtype=prompt_embeds.dtype,
+        )
+
+    device = latents.device
+    dtype = latents.dtype
+    sigmas = torch.linspace(1.0, 0.0, num_inference_steps + 1, device=device, dtype=dtype)
+
+    do_cfg = guidance_scale > 1.0 and negative_prompt_embeds is not None
+
+    caption_4d = prompt_embeds.unsqueeze(1) if prompt_embeds.dim() == 3 else prompt_embeds
+    mask_4d = (
+        prompt_attention_mask.unsqueeze(1).unsqueeze(1).to(torch.int16)
+        if prompt_attention_mask is not None and prompt_attention_mask.dim() == 2
+        else prompt_attention_mask
+    )
+
+    if do_cfg:
+        neg_4d = negative_prompt_embeds.unsqueeze(1) if negative_prompt_embeds.dim() == 3 else negative_prompt_embeds
+        neg_mask_4d = (
+            negative_prompt_attention_mask.unsqueeze(1).unsqueeze(1).to(torch.int16)
+            if negative_prompt_attention_mask is not None and negative_prompt_attention_mask.dim() == 2
+            else negative_prompt_attention_mask
+        )
+        y_in = torch.cat([neg_4d, caption_4d], dim=0)
+        m_in = torch.cat([neg_mask_4d, mask_4d], dim=0) if mask_4d is not None else None
+    else:
+        y_in = caption_4d
+        m_in = mask_4d
+
+    def v_pred_fn(z, sigma):
+        z_in = torch.cat([z, z], dim=0) if do_cfg else z
+        t_batch = sigma.expand(z_in.shape[0]).to(device)
+        pred = transformer(z_in, t_batch, y_in, mask=m_in)
+        if do_cfg:
+            u, c = pred.chunk(2)
+            pred = u + guidance_scale * (c - u)
+        return pred
+
+    latents, all_latents, _ = run_sampling(
+        v_pred_fn,
+        latents,
+        sigmas,
+        solver,
+        deterministic,
+        noise_level,
+    )
+
+    vae_dtype = next(vae.parameters()).dtype
+    latents_dec = latents.to(vae_dtype) / vae.config.scaling_factor
+    if sequential_decode and latents_dec.shape[0] > 1:
+        decoded = []
+        for idx in range(latents_dec.shape[0]):
+            decoded.append(vae.decode(latents_dec[idx : idx + 1], return_dict=False)[0])
+        image = torch.cat(decoded, dim=0)
+    else:
+        image = vae.decode(latents_dec, return_dict=False)[0]
+    images = (image / 2 + 0.5).clamp(0, 1)
+
+    return images, all_latents, sigmas[:-1]
+
+
+# ===================== Inference Model Selection =====================
+
+
+def _select_inference_transformer(mode, inference_models, transformer_ddp, peft_transformer):
+    """Return the transformer to use for inference based on *mode*.
+    mode: "compile_nvfp4" | "compile" | "peft"
+    """
+    if mode == "peft":
+        transformer_ddp.module.set_adapter("old")
+        return peft_transformer
+    return inference_models[mode]
+
+
+# ===================== Rollout for One Prompt =====================
+
+
+def _rollout_for_one_prompt(
+    rollout_transformer,
+    vae,
+    num_channels,
+    latent_size,
+    reward_fn,
+    executor,
+    prompt_text,
+    prompt_meta,
+    prompt_embed_single,
+    prompt_mask_single,
+    neg_prompt_embed_single,
+    neg_prompt_mask_single,
+    prompt_token_ids_single,
+    config,
+    device,
+    inference_models=None,
+    transformer_ddp=None,
+    peft_transformer=None,
+):
+    preview_step = int(getattr(config, "preview_step", 0))
+    full_steps = int(getattr(config, "rollout_sample_num_steps", config.sample.num_steps))
+    draft_total = int(config.sample.per_prompt_iter_num) * int(config.sample.rollout_batch_size)
+    full_rollout_num = max(
+        1, min(int(getattr(config.sample, "full_rollout_num", config.sample.best_of_n)), draft_total)
+    )
+    full_chunks = int(config.sample.rollout_batch_size)
+
+    solver = str(getattr(config.sample, "solver", "flow"))
+    noise_level = float(getattr(config.sample, "noise_level", 0.7))
+    deterministic = True
+
+    seed_pool, draft_reward_pool = [], []
+    prompt_samples = []
+    final_images = final_prompts = None
+
+    preview_model_key = str(getattr(config, "preview_model", "peft"))
+    fullrollout_model_key = str(getattr(config, "fullrollout_model", "peft"))
+    _can_swap = inference_models is not None and transformer_ddp is not None and peft_transformer is not None
+
+    if preview_step > 0:
+        if _can_swap:
+            current_transformer = _select_inference_transformer(
+                preview_model_key, inference_models, transformer_ddp, peft_transformer
+            )
+        else:
+            current_transformer = rollout_transformer
+
+        with torch.no_grad():
+            for _ in range(config.sample.per_prompt_iter_num):
+                bs = int(config.sample.rollout_batch_size)
+                p_emb = prompt_embed_single.repeat(bs, 1, 1)
+                p_mask = prompt_mask_single.repeat(bs, 1)
+                neg_emb = neg_prompt_embed_single.repeat(bs, 1, 1)
+                neg_mask = neg_prompt_mask_single.repeat(bs, 1)
+                seed_list = torch.randint(0, 2**31 - 1, (bs,), device="cpu").tolist()
+                init_latents = _prepare_latents_from_seeds(
+                    seed_list, num_channels, latent_size, latent_size, device, p_emb.dtype
+                )
+                images, _, _ = pipeline_with_logprob_sana(
+                    current_transformer,
+                    vae,
+                    latents=init_latents,
+                    prompt_embeds=p_emb,
+                    prompt_attention_mask=p_mask,
+                    negative_prompt_embeds=neg_emb,
+                    negative_prompt_attention_mask=neg_mask,
+                    num_inference_steps=preview_step,
+                    guidance_scale=config.rollout_sample_guidance_scale,
+                    noise_level=noise_level,
+                    deterministic=deterministic,
+                    solver=solver,
+                )
+                rewards, _ = reward_fn(images, [prompt_text] * bs, [prompt_meta] * bs, only_strict=True)
+                seed_pool.extend(int(s) for s in seed_list)
+                draft_reward_pool.extend(torch.as_tensor(rewards["avg"], device=device).float().detach().cpu().tolist())
+
+        draft_rewards = torch.as_tensor(draft_reward_pool, device=device).float()
+        stage1_idx = select_indices_by_mode(
+            draft_rewards, full_rollout_num, getattr(config.sample, "stage1_select_mode", "best_worst")
+        )
+        selected_seeds = [seed_pool[int(i)] for i in stage1_idx.cpu().tolist()]
+
+        if _can_swap and fullrollout_model_key != preview_model_key:
+            current_transformer = _select_inference_transformer(
+                fullrollout_model_key, inference_models, transformer_ddp, peft_transformer
+            )
+
+        for start in range(0, len(selected_seeds), full_chunks):
+            chunk_seeds = selected_seeds[start : start + full_chunks]
+            bs = len(chunk_seeds)
+            p_emb = prompt_embed_single.repeat(bs, 1, 1)
+            p_mask = prompt_mask_single.repeat(bs, 1)
+            neg_emb = neg_prompt_embed_single.repeat(bs, 1, 1)
+            neg_mask = neg_prompt_mask_single.repeat(bs, 1)
+            init_latents = _prepare_latents_from_seeds(
+                chunk_seeds, num_channels, latent_size, latent_size, device, p_emb.dtype
+            )
+            with torch.no_grad():
+                images, all_latents, step_sigmas = pipeline_with_logprob_sana(
+                    current_transformer,
+                    vae,
+                    latents=init_latents,
+                    prompt_embeds=p_emb,
+                    prompt_attention_mask=p_mask,
+                    negative_prompt_embeds=neg_emb,
+                    negative_prompt_attention_mask=neg_mask,
+                    num_inference_steps=full_steps,
+                    guidance_scale=config.rollout_sample_guidance_scale,
+                    noise_level=noise_level,
+                    deterministic=deterministic,
+                    solver=solver,
+                )
+            timesteps = step_sigmas.unsqueeze(0).repeat(bs, 1)
+            latents = torch.stack(all_latents, dim=1)
+            rewards_future = executor.submit(reward_fn, images, [prompt_text] * bs, [prompt_meta] * bs, True)
+            time.sleep(0)
+            prompt_samples.append(
+                {
+                    "prompt_ids": prompt_token_ids_single.repeat(bs, 1),
+                    "prompt_embeds": p_emb,
+                    "prompt_attention_mask": p_mask,
+                    "timesteps": timesteps,
+                    "next_timesteps": torch.cat([timesteps[:, 1:], torch.zeros_like(timesteps[:, :1])], dim=1),
+                    "latents_clean": latents[:, -1],
+                    "rewards_future": rewards_future,
+                }
+            )
+            final_images, final_prompts = images, [prompt_text] * bs
+    else:
+        for _ in range(config.sample.per_prompt_iter_num):
+            bs = int(config.sample.rollout_batch_size)
+            p_emb = prompt_embed_single.repeat(bs, 1, 1)
+            p_mask = prompt_mask_single.repeat(bs, 1)
+            neg_emb = neg_prompt_embed_single.repeat(bs, 1, 1)
+            neg_mask = neg_prompt_mask_single.repeat(bs, 1)
+            seed_list = torch.randint(0, 2**31 - 1, (bs,), device="cpu").tolist()
+            init_latents = _prepare_latents_from_seeds(
+                seed_list, num_channels, latent_size, latent_size, device, p_emb.dtype
+            )
+            with torch.no_grad():
+                images, all_latents, step_sigmas = pipeline_with_logprob_sana(
+                    rollout_transformer,
+                    vae,
+                    latents=init_latents,
+                    prompt_embeds=p_emb,
+                    prompt_attention_mask=p_mask,
+                    negative_prompt_embeds=neg_emb,
+                    negative_prompt_attention_mask=neg_mask,
+                    num_inference_steps=full_steps,
+                    guidance_scale=config.rollout_sample_guidance_scale,
+                    noise_level=noise_level,
+                    deterministic=deterministic,
+                    solver=solver,
+                )
+            timesteps = step_sigmas.unsqueeze(0).repeat(bs, 1)
+            latents = torch.stack(all_latents, dim=1)
+            rewards_future = executor.submit(reward_fn, images, [prompt_text] * bs, [prompt_meta] * bs, True)
+            time.sleep(0)
+            prompt_samples.append(
+                {
+                    "prompt_ids": prompt_token_ids_single.repeat(bs, 1),
+                    "prompt_embeds": p_emb,
+                    "prompt_attention_mask": p_mask,
+                    "timesteps": timesteps,
+                    "next_timesteps": torch.cat([timesteps[:, 1:], torch.zeros_like(timesteps[:, :1])], dim=1),
+                    "latents_clean": latents[:, -1],
+                    "rewards_future": rewards_future,
+                }
+            )
+            final_images, final_prompts = images, [prompt_text] * bs
+
+    for item in prompt_samples:
+        rewards, _ = item["rewards_future"].result()
+        item["rewards"] = {k: torch.as_tensor(v, device=device).float() for k, v in rewards.items()}
+        del item["rewards_future"]
+
+    collated = collate_dict_items(prompt_samples)
+    keep = select_indices_by_mode(
+        collated["rewards"]["avg"],
+        config.sample.best_of_n,
+        getattr(config.sample, "stage2_select_mode", "best_worst"),
+    )
+    collated = filter_by_indices(collated, keep)
+    return collated, final_images, final_prompts
+
+
+# ===================== Eval Function =====================
+
+
+def eval_fn(
+    pipeline,
+    eval_transformer,
+    vae,
+    num_channels,
+    latent_size,
+    test_dataloader,
+    config,
+    device,
+    rank,
+    world_size,
+    global_step,
+    reward_fn,
+    executor,
+    mixed_precision_dtype,
+    ema,
+    transformer_trainable_parameters,
+):
+    set_seed(config.seed + 1_000_000, rank)
+
+    if config.train.ema and ema is not None:
+        ema.copy_ema_to(transformer_trainable_parameters, store_temp=True)
+    eval_transformer.eval()
+    all_rewards = defaultdict(list)
+
+    test_sampler = (
+        DistributedSampler(test_dataloader.dataset, num_replicas=world_size, rank=rank, shuffle=False)
+        if world_size > 1
+        else None
+    )
+    eval_loader = DataLoader(
+        test_dataloader.dataset,
+        batch_size=config.sample.test_batch_size,
+        sampler=test_sampler,
+        collate_fn=test_dataloader.collate_fn,
+        num_workers=0,
+    )
+
+    solver = str(getattr(config.sample, "solver", "flow"))
+    for test_batch in tqdm(eval_loader, desc="Eval:", disable=not is_main_process(rank)):
+        prompts, prompt_metadata = test_batch
+        with torch.no_grad():
+            prompt_embeds, prompt_mask, neg_embeds, neg_mask = pipeline.encode_prompt(
+                prompt=prompts,
+                negative_prompt="",
+                device=device,
+                max_sequence_length=TEXT_ENCODER_MAX_SEQ_LEN,
+                do_classifier_free_guidance=True,
+            )
+            images, _, _ = pipeline_with_logprob_sana(
+                eval_transformer,
+                vae,
+                num_channels=num_channels,
+                latent_size=latent_size,
+                prompt_embeds=prompt_embeds,
+                prompt_attention_mask=prompt_mask,
+                negative_prompt_embeds=neg_embeds,
+                negative_prompt_attention_mask=neg_mask,
+                num_inference_steps=config.sample.eval_num_steps,
+                guidance_scale=config.eval_sample_guidance_scale,
+                solver=solver,
+            )
+        rewards_future = executor.submit(reward_fn, images, prompts, prompt_metadata, only_strict=False)
+        time.sleep(0)
+        rewards, _ = rewards_future.result()
+        for key, value in rewards.items():
+            all_rewards[key].extend(value)
+
+    final_rewards = {k: np.array([x.cpu() if torch.is_tensor(x) else x for x in v]) for k, v in all_rewards.items()}
+    if is_main_process(rank) and final_rewards:
+        wandb.log(
+            {**{f"eval_reward_{k}": np.mean(v[v != -10]) for k, v in final_rewards.items()}},
+            commit=False,
+        )
+        for k, v in final_rewards.items():
+            logger.info("eval_reward_%s: %.4f", k, np.mean(v[v != -10]))
+
+    if config.train.ema and ema is not None:
+        ema.copy_temp_to(transformer_trainable_parameters)
+    if world_size > 1:
+        dist.barrier()
+
+
+# ===================== Main =====================
+
+
+def main(_):
+    config = FLAGS.config
+
+    # cuDNN SDPA backward graph fails on Blackwell (sm_100); fall back to flash/math
+    torch.backends.cuda.enable_cudnn_sdp(False)
+
+    start_time = time.time()
+
+    # --- Distributed Setup ---
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    setup_distributed(rank, local_rank, world_size)
+    device = torch.device(f"cuda:{local_rank}")
+
+    if is_main_process(rank):
+        log_dir = os.path.join(config.logdir, config.run_name)
+        os.makedirs(log_dir, exist_ok=True)
+        wandb.init(
+            project="sol-rl",
+            name=config.run_name,
+            config=config.to_dict(),
+            resume="allow",
+            dir=log_dir,
+            id=config.run_name,
+        )
+        wandb.define_metric("global_step")
+        wandb.define_metric("*", step_metric="global_step")
+    logger.info(f"\n{config}")
+
+    set_seed(config.seed, rank)
+
+    mixed_precision_dtype = {"fp16": torch.float16, "bf16": torch.bfloat16}.get(config.mixed_precision)
+    enable_amp = mixed_precision_dtype is not None
+    scaler = GradScaler(enabled=enable_amp and mixed_precision_dtype == torch.float16)
+
+    # ===================== Build native transformer from YAML config =====================
+    with open(config.native_config, encoding="utf-8") as _f:
+        native_cfg = pyrallis.load(SanaConfig, _f)
+
+    # ===================== Build pipeline (text encoder + VAE only) =====================
+    pipeline = SanaPipeline.from_pretrained(
+        "Efficient-Large-Model/Sana_1600M_1024px_BF16_diffusers", torch_dtype=torch.bfloat16
+    )
+    pipeline.vae.requires_grad_(False)
+    pipeline.text_encoder.requires_grad_(False)
+    pipeline.set_progress_bar_config(disable=True)
+
+    text_encoder_dtype = mixed_precision_dtype if enable_amp else torch.float32
+    pipeline.vae.to(device, dtype=torch.bfloat16)
+    pipeline.text_encoder.to(device, dtype=text_encoder_dtype)
+    vae = pipeline.vae
+    del pipeline.transformer
+    torch.cuda.empty_cache()
+    latent_size = config.resolution // 32
+    if getattr(native_cfg, "work_dir", None):
+        os.makedirs(native_cfg.work_dir, exist_ok=True)
+    model_kwargs = model_init_config(native_cfg, latent_size=latent_size)
+    transformer = MODELS.build(dict(type=native_cfg.model.model), default_args=model_kwargs)
+    transformer.to(device, dtype=torch.bfloat16)
+
+    ckpt_path = native_cfg.model.load_from
+    logger.info(f"[INIT] Loading native checkpoint from {ckpt_path}")
+    ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    if isinstance(ckpt, dict):
+        if "state_dict" in ckpt:
+            state = ckpt["state_dict"]
+        elif "model" in ckpt:
+            state = ckpt["model"]
+        else:
+            state = ckpt
+    else:
+        state = ckpt
+    missing, unexpected = transformer.load_state_dict(state, strict=False)
+    if missing:
+        logger.warning(f"[weights] missing {len(missing)} keys (showing up to 10): {missing[:10]}")
+
+    for blk in transformer.blocks:
+        if hasattr(blk.attn, "eps"):
+            blk.attn.eps = 1e-15
+
+    num_channels = native_cfg.vae.vae_latent_dim
+    transformer.requires_grad_(not config.use_lora)
+
+    # --- Inference models (deepcopy + optional compile/nvfp4) ---
+    compile_mode = str(getattr(config, "compile_mode", "max-autotune-no-cudagraphs"))
+    preview_step = int(getattr(config, "preview_step", 0))
+    preview_model_key = str(getattr(config, "preview_model", "peft"))
+    fullrollout_model_key = str(getattr(config, "fullrollout_model", "peft"))
+
+    needed_model_types = set()
+    if preview_step > 0:
+        if preview_model_key != "peft":
+            needed_model_types.add(preview_model_key)
+        if fullrollout_model_key != "peft":
+            needed_model_types.add(fullrollout_model_key)
+    else:
+        if fullrollout_model_key != "peft":
+            needed_model_types.add(fullrollout_model_key)
+
+    inference_models = {}
+    nvfp4_skip_modules = list(getattr(config, "nvfp4_skip_modules", []))
+    nvfp4_min_dim = int(getattr(config, "nvfp4_min_dim", 0))
+
+    for mtype in sorted(needed_model_types):
+        logger.info(f"[INIT] Creating inference model: {mtype!r} ...")
+        m = MODELS.build(dict(type=native_cfg.model.model), default_args=model_kwargs)
+        m.to(device, dtype=torch.bfloat16)
+        m.load_state_dict(state, strict=False)
+        for blk in m.blocks:
+            if hasattr(blk.attn, "eps"):
+                blk.attn.eps = 1e-15
+        m.eval()
+        m.requires_grad_(False)
+
+        if "nvfp4" in mtype:
+            if not _HAS_TE:
+                raise RuntimeError(f"{mtype!r} requires transformer_engine")
+            n_rep, n_skip, rep_d, skip_d = replace_linear_with_te(
+                m, skip_modules=nvfp4_skip_modules, min_dim=nvfp4_min_dim, replace_conv1x1=True
+            )
+            logger.info(f"[NVFP4] {mtype}: replaced {n_rep} -> te.Linear, skipped {n_skip}")
+            if is_main_process(rank):
+                os.makedirs(config.save_dir, exist_ok=True)
+                report_path = os.path.join(config.save_dir, f"nvfp4_report_{mtype}.txt")
+                with open(report_path, "w") as f:
+                    f.write(f"NVFP4 Quantization Report: {mtype}\n")
+                    f.write(f"skip_modules={nvfp4_skip_modules}, min_dim={nvfp4_min_dim}\n")
+                    f.write(f"replaced={n_rep}, skipped={n_skip}\n\n")
+                    f.write(f"REPLACED ({len(rep_d)}):\n")
+                    for fqn, inf, outf, b, _ in rep_d:
+                        f.write(f"  {fqn:60s} {inf:>5d} -> {outf:>5d}  bias={b}\n")
+                    f.write(f"\nSKIPPED ({len(skip_d)}):\n")
+                    for fqn, inf, outf, b, r in skip_d:
+                        f.write(f"  {fqn:60s} {inf:>5d} -> {outf:>5d}  bias={b}  reason={r}\n")
+                logger.info(f"[NVFP4] Report saved to {report_path}")
+            wrap_forward_with_fp8(m)
+
+        if world_size > 1:
+            dist.barrier()
+        logger.info(f"[COMPILE] torch.compile(mode={compile_mode!r}) on {mtype!r} ...")
+        m = torch.compile(m, mode=compile_mode)
+        inference_models[mtype] = m
+        logger.info(f"[INIT] {mtype!r} ready")
+
+    if inference_models:
+        logger.info(f"[INIT] Inference models created: {list(inference_models.keys())}")
+    else:
+        logger.info("[INIT] No inference models needed, using PEFT model for all inference")
+
+    # --- LoRA ---
+    if config.use_lora:
+        init_lora_weights = getattr(config.train, "lora_init_mode", config.train.lora_init_weights)
+        lora_cfg = LoraConfig(
+            r=config.train.lora_rank,
+            lora_alpha=config.train.lora_alpha,
+            init_lora_weights=init_lora_weights,
+            target_modules=list(config.train.lora_target_modules),
+        )
+        if config.train.lora_path:
+            transformer = PeftModel.from_pretrained(transformer, config.train.lora_path)
+            transformer.set_adapter("default")
+        else:
+            transformer = get_peft_model(transformer, lora_cfg)
+        transformer.add_adapter("old", lora_cfg)
+        transformer.set_adapter("default")
+    peft_transformer = transformer
+
+    # --- DDP ---
+    transformer_ddp = DDP(transformer, device_ids=[local_rank], output_device=local_rank, find_unused_parameters=False)
+    transformer_ddp.module.set_adapter("default")
+    transformer_trainable_parameters = list(filter(lambda p: p.requires_grad, transformer_ddp.module.parameters()))
+    transformer_ddp.module.set_adapter("old")
+    old_transformer_trainable_parameters = list(filter(lambda p: p.requires_grad, transformer_ddp.module.parameters()))
+    transformer_ddp.module.set_adapter("default")
+
+    if config.allow_tf32:
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+
+    optimizer = torch.optim.AdamW(
+        transformer_trainable_parameters,
+        lr=config.train.learning_rate,
+        betas=(config.train.adam_beta1, config.train.adam_beta2),
+        weight_decay=config.train.adam_weight_decay,
+        eps=config.train.adam_epsilon,
+    )
+
+    # --- EMA ---
+    ema = None
+    if config.train.ema:
+        ema = EMAModuleWrapper(
+            transformer_trainable_parameters,
+            decay=getattr(config.train, "ema_decay", 0.9),
+            update_step_interval=getattr(config.train, "ema_update_step_interval", 1),
+            device=device,
+        )
+
+    # --- Datasets ---
+    _, train_dataloader, train_sampler, _, test_dataloader = build_datasets_and_loaders(config, world_size, rank)
+    train_iter = iter(train_dataloader)
+
+    stat_tracker = PerPromptStatTracker(config.global_std) if config.per_prompt_stat_tracking else None
+    executor = futures.ThreadPoolExecutor(max_workers=8)
+
+    reward_fn = getattr(diffusion.flow_grpo.rewards, "multi_score")(device, config.reward_fn)
+    eval_reward_fn = getattr(diffusion.flow_grpo.rewards, "multi_score")(device, config.reward_fn)
+
+    # --- Timestep config ---
+    timestep_clip = getattr(config, "timestep_clip", None)
+    if timestep_clip is not None:
+        _ts_start, _ts_end = int(timestep_clip[0]), int(timestep_clip[1])
+        num_train_timesteps = _ts_end - _ts_start
+    else:
+        _ts_start = _ts_end = None
+        num_train_timesteps = int(config.rollout_sample_num_steps * config.train.timestep_fraction)
+
+    # --- Resume ---
+    first_epoch = 0
+    global_step = 0
+    candidates = find_resume_candidates(config)
+    global_step, _resumed = resume_from_checkpoint(
+        candidates,
+        transformer_ddp.module,
+        ema,
+        optimizer,
+        scaler,
+        device,
+    )
+    first_epoch = global_step
+
+    if first_epoch == 0:
+        for src_p, tgt_p in zip(transformer_trainable_parameters, old_transformer_trainable_parameters, strict=True):
+            tgt_p.data.copy_(src_p.detach().data)
+
+    # Sync initial old adapter → inference models
+    for mtype, inf_model in inference_models.items():
+        sync_lora_to_inference(transformer_ddp.module, unwrap_compiled(inf_model), adapter_name="old")
+
+    optimizer.zero_grad()
+    time_logger = DistributedTimeLogger(device)
+
+    if global_step != 0:
+        for _ in range(global_step):
+            next(train_iter)
+
+    if world_size > 1:
+        dist.barrier()
+
+    # ================================================================
+    #  Training Loop
+    # ================================================================
+    for epoch in range(first_epoch, config.num_epochs):
+        time_logger.start("total_time")
+
+        if hasattr(train_sampler, "set_epoch"):
+            train_sampler.set_epoch(epoch)
+
+        if epoch % config.save_freq == 0 and not config.debug:
+            save_ckpt(config.save_dir, transformer_ddp, global_step, rank, ema, config, optimizer, scaler)
+
+        time_logger.start("eval_time")
+        if epoch % config.eval_freq == 0 and not config.debug:
+            torch.cuda.empty_cache()
+            py_rng = random.getstate()
+            np_rng = np.random.get_state()
+            torch_rng = torch.random.get_rng_state()
+            cuda_rng = torch.cuda.get_rng_state_all()
+            eval_fn(
+                pipeline,
+                peft_transformer,
+                vae,
+                num_channels,
+                latent_size,
+                test_dataloader,
+                config,
+                device,
+                rank,
+                world_size,
+                global_step,
+                eval_reward_fn,
+                executor,
+                mixed_precision_dtype,
+                ema,
+                transformer_trainable_parameters,
+            )
+            random.setstate(py_rng)
+            np.random.set_state(np_rng)
+            torch.random.set_rng_state(torch_rng)
+            torch.cuda.set_rng_state_all(cuda_rng)
+        time_logger.end("eval_time")
+
+        # ============================================================
+        #  ROLLOUT
+        # ============================================================
+        time_logger.start("rollout_time")
+        peft_transformer.eval()
+        prompts, prompt_metadata = next(train_iter)
+
+        time_logger.start("text_tokenizer_time")
+        with torch.no_grad():
+            prompt_embeds, prompt_masks, neg_embeds, neg_masks = pipeline.encode_prompt(
+                prompt=prompts,
+                negative_prompt="",
+                device=device,
+                max_sequence_length=TEXT_ENCODER_MAX_SEQ_LEN,
+                do_classifier_free_guidance=True,
+            )
+        txt_tokens = pipeline.tokenizer(
+            prompts,
+            max_length=TOKENIZER_MAX_LENGTH,
+            padding="max_length",
+            truncation=True,
+            return_tensors="pt",
+        )
+        time_logger.end("text_tokenizer_time")
+
+        prompt_ids_all = txt_tokens.input_ids.to(device)
+        prompt_embeds_list = [prompt_embeds[i : i + 1] for i in range(len(prompts))]
+        prompt_masks_list = [prompt_masks[i : i + 1] for i in range(len(prompts))]
+        neg_embeds_single = neg_embeds[0:1]
+        neg_masks_single = neg_masks[0:1]
+
+        prompt_wise_samples = []
+        step_prompt_reward_groups = []
+        images_for_log = prompts_for_log = rewards_for_log = None
+
+        if preview_step == 0:
+            if fullrollout_model_key != "peft" and fullrollout_model_key in inference_models:
+                default_rollout_transformer = inference_models[fullrollout_model_key]
+            else:
+                transformer_ddp.module.set_adapter("old")
+                default_rollout_transformer = peft_transformer
+        else:
+            default_rollout_transformer = peft_transformer
+
+        for prompt_idx in tqdm(
+            range(config.sample.per_gpu_to_process_prompts),
+            desc=f"Epoch {epoch}: rollout",
+            disable=not is_main_process(rank),
+            dynamic_ncols=True,
+        ):
+            collated_prompt_samples, final_images, final_prompts = _rollout_for_one_prompt(
+                rollout_transformer=default_rollout_transformer,
+                vae=vae,
+                num_channels=num_channels,
+                latent_size=latent_size,
+                reward_fn=reward_fn,
+                executor=executor,
+                prompt_text=prompts[prompt_idx],
+                prompt_meta=prompt_metadata[prompt_idx],
+                prompt_embed_single=prompt_embeds_list[prompt_idx],
+                prompt_mask_single=prompt_masks_list[prompt_idx],
+                neg_prompt_embed_single=neg_embeds_single,
+                neg_prompt_mask_single=neg_masks_single,
+                prompt_token_ids_single=prompt_ids_all[prompt_idx : prompt_idx + 1],
+                config=config,
+                device=device,
+                inference_models=inference_models,
+                transformer_ddp=transformer_ddp,
+                peft_transformer=peft_transformer,
+            )
+            prompt_wise_samples.append(collated_prompt_samples)
+            prompt_meta_i = slice_prompt_metadata(prompt_metadata, prompt_idx)
+            step_prompt_reward_groups.append(
+                extract_prompt_reward_group(prompt_idx, prompts[prompt_idx], prompt_meta_i, [collated_prompt_samples])
+            )
+            images_for_log, prompts_for_log = final_images, final_prompts
+            rewards_for_log = collated_prompt_samples["rewards"]["avg"]
+
+        transformer_ddp.module.set_adapter("default")
+
+        save_step_reward_groups(
+            config=config,
+            global_step=global_step,
+            epoch=epoch,
+            rank=rank,
+            world_size=world_size,
+            prompt_reward_groups=step_prompt_reward_groups,
+        )
+        collated_samples = collate_dict_items(prompt_wise_samples)
+
+        log_rollout_images(images_for_log, prompts_for_log, rewards_for_log, config, global_step, rank)
+
+        collated_samples["rewards"]["avg"] = (
+            collated_samples["rewards"]["avg"].unsqueeze(1).repeat(1, num_train_timesteps)
+        )
+
+        gathered_rewards_dict = {
+            k: gather_tensor_to_all(v, world_size).numpy() for k, v in collated_samples["rewards"].items()
+        }
+        if is_main_process(rank):
+            r2l = (
+                gathered_rewards_dict["avg"]
+                .reshape(world_size * config.sample.per_gpu_to_process_prompts, -1, num_train_timesteps)
+                .mean(axis=-1)
+            )
+            wandb.log(
+                {
+                    "epoch": epoch,
+                    "reward/mean": r2l.mean(),
+                    "reward/max": r2l.max(axis=1).mean(),
+                    "reward/min": r2l.min(axis=1).mean(),
+                    "reward/range": r2l.max(axis=1).mean() - r2l.min(axis=1).mean(),
+                },
+                commit=False,
+            )
+
+        prompt_ids_global = gather_tensor_to_all(collated_samples["prompt_ids"], world_size)
+        prompts_decoded = pipeline.tokenizer.batch_decode(prompt_ids_global.cpu().numpy(), skip_special_tokens=True)
+
+        if stat_tracker is not None:
+            advantages = stat_tracker.update(prompts_decoded, gathered_rewards_dict["avg"])
+            if is_main_process(rank):
+                gs, tp = stat_tracker.get_stats()
+                zsr, rsm = calculate_zero_std_ratio(prompts_decoded, gathered_rewards_dict)
+                wandb.log(
+                    {
+                        "group_size": gs,
+                        "trained_prompt_num": tp,
+                        "zero_std_ratio": zsr,
+                        "reward_std_mean": rsm,
+                        "mean_reward_100": stat_tracker.get_mean_of_top_rewards(100),
+                        "mean_reward_50": stat_tracker.get_mean_of_top_rewards(50),
+                    },
+                    commit=False,
+                )
+            stat_tracker.clear()
+        else:
+            avg = gathered_rewards_dict["avg"]
+            advantages = (avg - avg.mean()) / (avg.std() + 1e-4)
+
+        samples_per_gpu = collated_samples["timesteps"].shape[0]
+        if advantages.ndim == 1:
+            advantages = advantages[:, None]
+        collated_samples["advantages"] = torch.from_numpy(advantages.reshape(world_size, samples_per_gpu, -1)[rank]).to(
+            device
+        )
+        del collated_samples["rewards"]
+        del collated_samples["prompt_ids"]
+        time_logger.end("rollout_time")
+
+        # ============================================================
+        #  TRAINING
+        # ============================================================
+        total_batch_size_filtered, num_timesteps_filtered = collated_samples["timesteps"].shape
+
+        time_logger.start("train_time")
+        effective_grad_accum_steps = config.train.gradient_accumulation_steps * num_train_timesteps
+        current_accumulated_steps = 0
+        gradient_update_times = 0
+
+        for inner_epoch in range(config.train.num_inner_epochs):
+            perm = torch.randperm(total_batch_size_filtered, device=device)
+            shuffled = {k: v[perm] for k, v in collated_samples.items()}
+            perms_time = torch.stack(
+                [torch.randperm(num_timesteps_filtered, device=device) for _ in range(total_batch_size_filtered)]
+            )
+            for key in ["timesteps", "next_timesteps"]:
+                shuffled[key] = shuffled[key][
+                    torch.arange(total_batch_size_filtered, device=device)[:, None], perms_time
+                ]
+
+            batches = []
+            for bi in range(config.train.n_batch_per_epoch):
+                s, e = bi * config.train.batch_size, (bi + 1) * config.train.batch_size
+                batches.append({k: v[s:e] for k, v in shuffled.items()})
+
+            info_accumulated = defaultdict(list)
+            for train_batch in tqdm(
+                batches,
+                desc=f"Epoch {epoch}.{inner_epoch}: train",
+                disable=not is_main_process(rank),
+                dynamic_ncols=True,
+            ):
+                embeds = train_batch["prompt_embeds"]
+                embeds_mask = train_batch["prompt_attention_mask"]
+                embeds_4d = embeds.unsqueeze(1)
+                mask_4d = embeds_mask.unsqueeze(1).unsqueeze(1).to(torch.int16) if embeds_mask is not None else None
+
+                for j_idx in range(num_train_timesteps):
+                    x0 = train_batch["latents_clean"]
+                    sigma = train_batch["timesteps"][:, j_idx]
+                    sigma_expanded = sigma.view(-1, *([1] * (len(x0.shape) - 1)))
+                    noise = torch.randn_like(x0.float())
+                    xt = ((1 - sigma_expanded) * x0 + sigma_expanded * noise).to(torch.bfloat16)
+
+                    transformer_ddp.module.set_adapter("old")
+                    with torch.no_grad():
+                        old_prediction = transformer_ddp(xt, sigma, embeds_4d, mask=mask_4d).detach()
+                    transformer_ddp.module.set_adapter("default")
+
+                    forward_prediction = transformer_ddp(xt, sigma, embeds_4d, mask=mask_4d)
+
+                    with torch.no_grad():
+                        with transformer_ddp.module.disable_adapter():
+                            ref_forward_prediction = transformer_ddp(xt, sigma, embeds_4d, mask=mask_4d)
+                        transformer_ddp.module.set_adapter("default")
+
+                    loss_terms = {}
+                    advantages_clip = torch.clamp(
+                        train_batch["advantages"][:, j_idx], -config.train.adv_clip_max, config.train.adv_clip_max
+                    )
+                    if hasattr(config.train, "adv_mode"):
+                        if config.train.adv_mode == "positive_only":
+                            advantages_clip = torch.clamp(advantages_clip, 0, config.train.adv_clip_max)
+                        elif config.train.adv_mode == "negative_only":
+                            advantages_clip = torch.clamp(advantages_clip, -config.train.adv_clip_max, 0)
+                        elif config.train.adv_mode == "one_only":
+                            advantages_clip = torch.where(
+                                advantages_clip > 0, torch.ones_like(advantages_clip), torch.zeros_like(advantages_clip)
+                            )
+                        elif config.train.adv_mode == "binary":
+                            advantages_clip = torch.sign(advantages_clip)
+
+                    r = torch.clamp((advantages_clip / config.train.adv_clip_max) / 2.0 + 0.5, 0, 1)
+
+                    positive_prediction = config.beta * forward_prediction + (1 - config.beta) * old_prediction.detach()
+                    implicit_negative_prediction = (
+                        1.0 + config.beta
+                    ) * old_prediction.detach() - config.beta * forward_prediction
+
+                    x0_prediction = xt - sigma_expanded * positive_prediction
+                    with torch.no_grad():
+                        weight_factor = (
+                            torch.abs(x0_prediction.double() - x0.double())
+                            .mean(dim=tuple(range(1, x0.ndim)), keepdim=True)
+                            .clip(min=1e-5)
+                        )
+                    positive_loss = ((x0_prediction - x0) ** 2 / weight_factor).mean(dim=tuple(range(1, x0.ndim)))
+
+                    negative_x0_prediction = xt - sigma_expanded * implicit_negative_prediction
+                    with torch.no_grad():
+                        neg_wf = (
+                            torch.abs(negative_x0_prediction.double() - x0.double())
+                            .mean(dim=tuple(range(1, x0.ndim)), keepdim=True)
+                            .clip(min=1e-5)
+                        )
+                    negative_loss = ((negative_x0_prediction - x0) ** 2 / neg_wf).mean(dim=tuple(range(1, x0.ndim)))
+
+                    ori_policy_loss = r * positive_loss / config.beta + (1.0 - r) * negative_loss / config.beta
+                    policy_loss = (ori_policy_loss * config.train.adv_clip_max).mean()
+                    loss = policy_loss
+                    loss_terms["policy_loss"] = policy_loss.detach()
+                    loss_terms["unweighted_policy_loss"] = ori_policy_loss.mean().detach()
+
+                    kl_div_loss = ((forward_prediction - ref_forward_prediction) ** 2).mean(
+                        dim=tuple(range(1, x0.ndim))
+                    )
+                    loss += config.train.beta * torch.mean(kl_div_loss)
+                    loss_terms["kl_div_loss"] = torch.mean(kl_div_loss).detach()
+                    loss_terms["kl_div"] = loss_terms["kl_div_loss"]
+                    loss_terms["old_kl_div"] = torch.mean(
+                        ((old_prediction - ref_forward_prediction) ** 2).mean(dim=tuple(range(1, x0.ndim)))
+                    ).detach()
+                    loss_terms["x0_norm"] = torch.mean(x0**2).detach()
+                    loss_terms["x0_norm_max"] = torch.max(x0**2).detach()
+                    loss_terms["old_deviate"] = torch.mean((forward_prediction - old_prediction) ** 2).detach()
+                    loss_terms["old_deviate_max"] = torch.max((forward_prediction - old_prediction) ** 2).detach()
+                    loss_terms["total_loss"] = loss.detach()
+
+                    scaled_loss = loss / effective_grad_accum_steps
+                    if torch.isnan(scaled_loss) or torch.isinf(scaled_loss):
+                        scaled_loss = scaled_loss * 0.0
+
+                    if mixed_precision_dtype == torch.float16:
+                        scaler.scale(scaled_loss).backward()
+                    else:
+                        scaled_loss.backward()
+                    current_accumulated_steps += 1
+
+                    for ki, vi in loss_terms.items():
+                        info_accumulated[ki].append(vi)
+
+                    if current_accumulated_steps % effective_grad_accum_steps == 0:
+                        if mixed_precision_dtype == torch.float16:
+                            scaler.unscale_(optimizer)
+                        grad_norm = torch.nn.utils.clip_grad_norm_(
+                            transformer_ddp.module.parameters(), config.train.max_grad_norm
+                        )
+                        if mixed_precision_dtype == torch.float16:
+                            scaler.step(optimizer)
+                            scaler.update()
+                        else:
+                            optimizer.step()
+                        optimizer.zero_grad()
+                        gradient_update_times += 1
+
+                        log_info = {k: torch.mean(torch.stack(v)).item() for k, v in info_accumulated.items()}
+                        log_info["grad_norm"] = (
+                            grad_norm.detach().float().item() if torch.is_tensor(grad_norm) else float(grad_norm)
+                        )
+                        info_tensor = torch.tensor([log_info[k] for k in sorted(log_info)], device=device)
+                        dist.all_reduce(info_tensor, op=dist.ReduceOp.AVG)
+                        reduced = {k: info_tensor[i].item() for i, k in enumerate(sorted(log_info))}
+                        if is_main_process(rank):
+                            _log_dict = {
+                                "global_step": global_step,
+                                "gradient_update_times": gradient_update_times,
+                                "epoch": epoch,
+                                "inner_epoch": inner_epoch,
+                                "current_time": time.time() - start_time,
+                                **reduced,
+                            }
+                            wandb.log(_log_dict, commit=False)
+                            logger.info(
+                                "[step %d] loss=%.6f policy=%.6f grad=%.6f kl=%.6f",
+                                global_step,
+                                reduced.get("total_loss", 0),
+                                reduced.get("policy_loss", 0),
+                                reduced.get("grad_norm", 0),
+                                reduced.get("kl_div_loss", 0),
+                            )
+                        global_step += 1
+                        info_accumulated = defaultdict(list)
+
+                    if (
+                        config.train.ema
+                        and ema is not None
+                        and (current_accumulated_steps % effective_grad_accum_steps == 0)
+                    ):
+                        ema.step(transformer_trainable_parameters, global_step)
+
+        time_logger.end("train_time")
+
+        if world_size > 1:
+            dist.barrier()
+        with torch.no_grad():
+            decay = return_decay(
+                global_step,
+                config.decay_type,
+                custom_decay_step=getattr(config, "custom_decay_step", 0),
+                custom_decay_value=getattr(config, "custom_decay_value", 0.0),
+            )
+            for src_p, tgt_p in zip(
+                transformer_trainable_parameters, old_transformer_trainable_parameters, strict=True
+            ):
+                tgt_p.data.copy_(tgt_p.detach().data * decay + src_p.detach().clone().data * (1.0 - decay))
+
+        for mtype, inf_model in inference_models.items():
+            sync_lora_to_inference(transformer_ddp.module, unwrap_compiled(inf_model), adapter_name="old")
+
+        time_logger.end("total_time")
+        stats = time_logger.get_results()
+        if is_main_process(rank):
+            wandb.log({f"time/{k}": v for k, v in stats.items()}, commit=True)
+            logger.info("Step %d Time: %s", global_step, stats)
+        time_logger.empty_cache()
+
+    if is_main_process(rank):
+        wandb.finish()
+    cleanup_distributed()
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/train_scripts/sol_rl/train_sd3.py
+++ b/train_scripts/sol_rl/train_sd3.py
@@ -1,0 +1,1173 @@
+import copy
+import os
+import sys
+from collections import defaultdict
+from contextlib import nullcontext
+
+_rank = int(os.environ.get("RANK", 0))
+_cache_root = os.environ.get("CACHE_ROOT", os.path.expanduser("~/.cache/sol_rl"))
+os.environ.setdefault("TRITON_CACHE_DIR", f"{_cache_root}/triton/rank_{_rank}")
+os.environ.setdefault("TORCHINDUCTOR_CACHE_DIR", f"{_cache_root}/torchinductor/rank_{_rank}")
+os.environ.setdefault("TORCHINDUCTOR_FX_GRAPH_CACHE", "1")
+
+import logging
+import random
+import tempfile
+import time
+from concurrent import futures
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import tqdm
+import wandb
+from absl import app, flags
+from diffusers import StableDiffusion3Pipeline
+from ml_collections import config_flags
+from peft import LoraConfig, PeftModel, get_peft_model
+from PIL import Image
+from torch.cuda.amp import GradScaler
+from torch.cuda.amp import autocast as torch_autocast
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.data import DataLoader
+from torch.utils.data.distributed import DistributedSampler
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from train_utils import (
+    _HAS_TE,
+    NVFP4_RECIPE,
+    BF16TELinear,
+    DistributedTimeLogger,
+    build_datasets_and_loaders,
+    calculate_zero_std_ratio,
+    cleanup_distributed,
+    collate_dict_items,
+    extract_prompt_reward_group,
+    filter_by_indices,
+    find_resume_candidates,
+    gather_tensor_to_all,
+    is_main_process,
+    log_rollout_images,
+    replace_linear_with_te,
+    resume_from_checkpoint,
+    return_decay,
+    save_ckpt,
+    save_debug_image_subset,
+    save_step_reward_groups,
+    select_indices_by_mode,
+    set_seed,
+    setup_distributed,
+    slice_prompt_metadata,
+    sync_lora_to_inference,
+    te,
+    to_jsonable,
+    unwrap_compiled,
+    wrap_forward_with_fp8,
+)
+
+import diffusion.flow_grpo.rewards
+from diffusion.flow_grpo.diffusers_patch.pipeline_with_logprob import pipeline_with_logprob
+from diffusion.flow_grpo.diffusers_patch.train_dreambooth_lora_sd3 import encode_prompt
+from diffusion.flow_grpo.ema import EMAModuleWrapper
+from diffusion.flow_grpo.stat_tracking import PerPromptStatTracker
+
+tqdm = tqdm.tqdm
+FLAGS = flags.FLAGS
+config_flags.DEFINE_config_file(
+    "config",
+    "configs/sol_rl/sd3.py",
+    "Training configuration.",
+)
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+TEXT_ENCODER_MAX_SEQ_LEN = 128
+TOKENIZER_MAX_LENGTH = 256
+WANDB_MAX_LOG_IMAGES = 12
+
+
+def compute_text_embeddings(prompts, text_encoders, tokenizers, max_sequence_length, device):
+    with torch.no_grad():
+        prompt_embeds, pooled_prompt_embeds = encode_prompt(
+            text_encoders,
+            tokenizers,
+            prompts,
+            max_sequence_length,
+        )
+        prompt_embeds = prompt_embeds.to(device)
+        pooled_prompt_embeds = pooled_prompt_embeds.to(device)
+    return prompt_embeds, pooled_prompt_embeds
+
+
+def _build_sd3_latents_from_seeds(seed_list, latent_shape, device, dtype):
+    latents = []
+    channels, latent_h, latent_w = latent_shape
+    for seed in seed_list:
+        generator = torch.Generator(device=device).manual_seed(int(seed))
+        latents.append(
+            torch.randn(
+                1,
+                channels,
+                latent_h,
+                latent_w,
+                device=device,
+                dtype=dtype,
+                generator=generator,
+            )
+        )
+    return torch.cat(latents, dim=0)
+
+
+def _fp8_autocast(enabled):
+    """Return te.fp8_autocast context if enabled and TE is available, else nullcontext."""
+    if enabled and _HAS_TE:
+        return te.fp8_autocast(enabled=True, fp8_recipe=NVFP4_RECIPE)
+    return nullcontext()
+
+
+def eval_fn(
+    pipeline,
+    test_dataloader,
+    text_encoders,
+    tokenizers,
+    config,
+    device,
+    rank,
+    world_size,
+    global_step,
+    reward_fn,
+    executor,
+    mixed_precision_dtype,
+    ema,
+    transformer_trainable_parameters,
+):
+    set_seed(config.seed + 1_000_000, rank)
+
+    sequential_decode = bool(getattr(config, "sequential_decode", True))
+    if config.train.ema and ema is not None:
+        ema.copy_ema_to(transformer_trainable_parameters, store_temp=True)
+
+    pipeline.transformer.eval()
+    neg_prompt_embed, neg_pooled_prompt_embed = compute_text_embeddings(
+        [""], text_encoders, tokenizers, max_sequence_length=TEXT_ENCODER_MAX_SEQ_LEN, device=device
+    )
+
+    all_rewards = defaultdict(list)
+    test_sampler = (
+        DistributedSampler(test_dataloader.dataset, num_replicas=world_size, rank=rank, shuffle=False)
+        if world_size > 1
+        else None
+    )
+    eval_loader = DataLoader(
+        test_dataloader.dataset,
+        batch_size=config.sample.test_batch_size,
+        sampler=test_sampler,
+        collate_fn=test_dataloader.collate_fn,
+        num_workers=test_dataloader.num_workers,
+    )
+
+    for prompts, prompt_metadata in tqdm(
+        eval_loader,
+        desc="Eval",
+        disable=not is_main_process(rank),
+        dynamic_ncols=True,
+    ):
+        prompt_embeds, pooled_prompt_embeds = compute_text_embeddings(
+            prompts, text_encoders, tokenizers, max_sequence_length=TEXT_ENCODER_MAX_SEQ_LEN, device=device
+        )
+        bs = len(prompts)
+        with torch_autocast(enabled=(config.mixed_precision in ["fp16", "bf16"]), dtype=mixed_precision_dtype):
+            with torch.no_grad():
+                images, _, _ = pipeline_with_logprob(
+                    pipeline,
+                    prompt_embeds=prompt_embeds,
+                    pooled_prompt_embeds=pooled_prompt_embeds,
+                    negative_prompt_embeds=neg_prompt_embed.repeat(bs, 1, 1),
+                    negative_pooled_prompt_embeds=neg_pooled_prompt_embed.repeat(bs, 1),
+                    num_inference_steps=config.sample.eval_num_steps,
+                    guidance_scale=config.eval_sample_guidance_scale,
+                    output_type="pt",
+                    height=config.resolution,
+                    width=config.resolution,
+                    noise_level=config.sample.noise_level,
+                    deterministic=True,
+                    solver=config.sample.solver,
+                    model_type="sd3",
+                    sequential_decode=sequential_decode,
+                )
+        rewards_future = executor.submit(reward_fn, images, prompts, prompt_metadata, only_strict=False)
+        time.sleep(0)
+        rewards, _ = rewards_future.result()
+        for key, value in rewards.items():
+            rewards_tensor = torch.as_tensor(value, device=device).float()
+            all_rewards[key].append(gather_tensor_to_all(rewards_tensor, world_size).numpy())
+
+    enable_debug_image_save = bool(getattr(config, "enable_debug_image_save", True))
+    if is_main_process(rank):
+        final_rewards = {key: np.concatenate(value_list) for key, value_list in all_rewards.items()}
+        images_to_log = images.cpu()
+        prompts_to_log = prompts
+        if enable_debug_image_save:
+            eval_debug_dir = os.path.join(config.save_dir, "debug_images", "eval", f"step_{global_step}")
+            save_debug_image_subset(
+                images=images_to_log,
+                prompts=prompts_to_log,
+                save_root=eval_debug_dir,
+                prefix="eval",
+                resolution=config.resolution,
+                rewards=final_rewards.get("avg", None),
+                max_images=getattr(config, "debug_image_subset_size", 6),
+            )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            num_to_log = min(WANDB_MAX_LOG_IMAGES, len(images_to_log))
+            for idx in range(num_to_log):
+                image = images_to_log[idx].float()
+                pil = Image.fromarray((image.numpy().transpose(1, 2, 0) * 255).astype(np.uint8))
+                pil = pil.resize((config.resolution, config.resolution))
+                pil.save(os.path.join(tmpdir, f"{idx}.jpg"))
+
+            sampled_prompts_log = [prompts_to_log[i] for i in range(num_to_log)]
+            sampled_rewards_log = [{k: final_rewards[k][i] for k in final_rewards} for i in range(num_to_log)]
+
+            wandb.log(
+                {
+                    "eval_images": [
+                        wandb.Image(
+                            os.path.join(tmpdir, f"{idx}.jpg"),
+                            caption=f"{prompt:.1000} | "
+                            + " | ".join(f"{k}: {v:.2f}" for k, v in reward.items() if v != -10),
+                        )
+                        for idx, (prompt, reward) in enumerate(zip(sampled_prompts_log, sampled_rewards_log))
+                    ],
+                    **{f"eval_reward_{k}": np.mean(v[v != -10]) for k, v in final_rewards.items()},
+                },
+                commit=False,
+            )
+
+    if config.train.ema and ema is not None:
+        ema.copy_temp_to(transformer_trainable_parameters)
+    if world_size > 1:
+        dist.barrier()
+
+
+def _swap_pipeline_model(pipeline, mode, inference_models, transformer_ddp, original_transformer):
+    """Swap pipeline.transformer to the model specified by *mode*.
+
+    mode: "compile_nvfp4" | "compile" | "peft"
+    """
+    if mode == "peft":
+        pipeline.transformer = original_transformer
+        transformer_ddp.module.set_adapter("old")
+    else:
+        pipeline.transformer = inference_models[mode]
+
+
+def _rollout_for_one_prompt(
+    pipeline,
+    reward_fn,
+    executor,
+    prompt_text,
+    prompt_meta,
+    prompt_embed_single,
+    pooled_embed_single,
+    neg_prompt_embed_single,
+    neg_pooled_prompt_embed_single,
+    prompt_token_ids_single,
+    config,
+    device,
+    inference_models=None,
+    transformer_ddp=None,
+    original_transformer=None,
+):
+    sequential_decode = bool(getattr(config, "sequential_decode", True))
+    amp_dtype = (
+        torch.bfloat16
+        if config.mixed_precision == "bf16"
+        else (torch.float16 if config.mixed_precision == "fp16" else None)
+    )
+    enable_amp = amp_dtype is not None
+    preview_step = int(getattr(config, "preview_step", 0))
+    full_steps = int(getattr(config, "rollout_sample_num_steps", config.sample.num_steps))
+
+    draft_total = int(config.sample.per_prompt_iter_num) * int(config.sample.rollout_batch_size)
+    full_rollout_num = int(getattr(config.sample, "full_rollout_num", config.sample.best_of_n))
+    full_rollout_num = max(1, min(full_rollout_num, draft_total))
+
+    latent_h = config.resolution // 8
+    latent_w = config.resolution // 8
+    latent_shape = (16, latent_h, latent_w)
+
+    seed_pool = []
+    draft_reward_pool = []
+    prompt_samples = []
+    final_images = None
+    final_prompts = None
+    full_chunks = int(config.sample.rollout_batch_size)
+
+    preview_model_key = str(getattr(config, "preview_model", "peft"))
+    fullrollout_model_key = str(getattr(config, "fullrollout_model", "peft"))
+    _can_swap = inference_models is not None and transformer_ddp is not None and original_transformer is not None
+
+    if preview_step > 0:
+        # --- Stage 1: draft preview (fast screening) ---
+        if _can_swap:
+            _swap_pipeline_model(pipeline, preview_model_key, inference_models, transformer_ddp, original_transformer)
+
+        with torch.no_grad():
+            for iter_idx in range(config.sample.per_prompt_iter_num):
+                batch_size = int(config.sample.rollout_batch_size)
+                prompt_embeds = prompt_embed_single.repeat(batch_size, 1, 1)
+                pooled_prompt_embeds = pooled_embed_single.repeat(batch_size, 1)
+                neg_prompt_embeds = neg_prompt_embed_single.repeat(batch_size, 1, 1)
+                neg_pooled_prompt_embeds = neg_pooled_prompt_embed_single.repeat(batch_size, 1)
+
+                seed_list = torch.randint(
+                    low=0,
+                    high=2**31 - 1,
+                    size=(batch_size,),
+                    device="cpu",
+                ).tolist()
+                init_latents = _build_sd3_latents_from_seeds(
+                    seed_list,
+                    latent_shape=latent_shape,
+                    device=device,
+                    dtype=prompt_embeds.dtype,
+                )
+
+                with torch_autocast(enabled=enable_amp, dtype=amp_dtype):
+                    images, _, _ = pipeline_with_logprob(
+                        pipeline,
+                        latents=init_latents,
+                        prompt_embeds=prompt_embeds,
+                        pooled_prompt_embeds=pooled_prompt_embeds,
+                        negative_prompt_embeds=neg_prompt_embeds,
+                        negative_pooled_prompt_embeds=neg_pooled_prompt_embeds,
+                        num_inference_steps=preview_step,
+                        guidance_scale=config.rollout_sample_guidance_scale,
+                        output_type="pt",
+                        height=config.resolution,
+                        width=config.resolution,
+                        noise_level=config.sample.noise_level,
+                        deterministic=True,
+                        solver=config.sample.solver,
+                        model_type="sd3",
+                        sequential_decode=sequential_decode,
+                    )
+                rewards, _ = reward_fn(
+                    images,
+                    [prompt_text] * batch_size,
+                    [prompt_meta] * batch_size,
+                    only_strict=True,
+                )
+                draft_avg = torch.as_tensor(rewards["avg"], device=device).float()
+                seed_pool.extend(int(s) for s in seed_list)
+                draft_reward_pool.extend(draft_avg.detach().cpu().tolist())
+
+        draft_rewards = torch.as_tensor(draft_reward_pool, device=device).float()
+        stage1_indices = select_indices_by_mode(
+            draft_rewards,
+            target_count=full_rollout_num,
+            mode=getattr(config.sample, "stage1_select_mode", "best_worst"),
+        )
+        selected_seeds = [seed_pool[int(i)] for i in stage1_indices.detach().cpu().tolist()]
+
+        # --- Stage 2: full rollout (may use a different model) ---
+        if _can_swap and fullrollout_model_key != preview_model_key:
+            _swap_pipeline_model(
+                pipeline, fullrollout_model_key, inference_models, transformer_ddp, original_transformer
+            )
+
+        for start in range(0, len(selected_seeds), full_chunks):
+            seed_chunk = selected_seeds[start : start + full_chunks]
+            bs = len(seed_chunk)
+            prompt_embeds = prompt_embed_single.repeat(bs, 1, 1)
+            pooled_prompt_embeds = pooled_embed_single.repeat(bs, 1)
+            neg_prompt_embeds = neg_prompt_embed_single.repeat(bs, 1, 1)
+            neg_pooled_prompt_embeds = neg_pooled_prompt_embed_single.repeat(bs, 1)
+            init_latents = _build_sd3_latents_from_seeds(
+                seed_chunk,
+                latent_shape=latent_shape,
+                device=device,
+                dtype=prompt_embeds.dtype,
+            )
+            with torch.no_grad():
+                with torch_autocast(enabled=enable_amp, dtype=amp_dtype):
+                    images, latents, _ = pipeline_with_logprob(
+                        pipeline,
+                        latents=init_latents,
+                        prompt_embeds=prompt_embeds,
+                        pooled_prompt_embeds=pooled_prompt_embeds,
+                        negative_prompt_embeds=neg_prompt_embeds,
+                        negative_pooled_prompt_embeds=neg_pooled_prompt_embeds,
+                        num_inference_steps=full_steps,
+                        guidance_scale=config.rollout_sample_guidance_scale,
+                        output_type="pt",
+                        height=config.resolution,
+                        width=config.resolution,
+                        noise_level=config.sample.noise_level,
+                        deterministic=True,
+                        solver=config.sample.solver,
+                        model_type="sd3",
+                        sequential_decode=sequential_decode,
+                    )
+            timesteps = pipeline.scheduler.timesteps.repeat(bs, 1).to(device)
+            latents = torch.stack(latents, dim=1)
+            rewards_future = executor.submit(
+                reward_fn,
+                images,
+                [prompt_text] * bs,
+                [prompt_meta] * bs,
+                True,
+            )
+            time.sleep(0)
+            prompt_samples.append(
+                {
+                    "prompt_ids": prompt_token_ids_single.repeat(bs, 1),
+                    "prompt_embeds": prompt_embeds,
+                    "pooled_prompt_embeds": pooled_prompt_embeds,
+                    "timesteps": timesteps,
+                    "next_timesteps": torch.concatenate([timesteps[:, 1:], torch.zeros_like(timesteps[:, :1])], dim=1),
+                    "latents_clean": latents[:, -1],
+                    "rewards_future": rewards_future,
+                }
+            )
+            final_images = images
+            final_prompts = [prompt_text] * bs
+    else:
+        for iter_idx in range(config.sample.per_prompt_iter_num):
+            batch_size = int(config.sample.rollout_batch_size)
+            prompt_embeds = prompt_embed_single.repeat(batch_size, 1, 1)
+            pooled_prompt_embeds = pooled_embed_single.repeat(batch_size, 1)
+            neg_prompt_embeds = neg_prompt_embed_single.repeat(batch_size, 1, 1)
+            neg_pooled_prompt_embeds = neg_pooled_prompt_embed_single.repeat(batch_size, 1)
+            seed_list = torch.randint(
+                low=0,
+                high=2**31 - 1,
+                size=(batch_size,),
+                device="cpu",
+            ).tolist()
+            init_latents = _build_sd3_latents_from_seeds(
+                seed_list,
+                latent_shape=latent_shape,
+                device=device,
+                dtype=prompt_embeds.dtype,
+            )
+            with torch.no_grad():
+                with torch_autocast(enabled=enable_amp, dtype=amp_dtype):
+                    images, latents, _ = pipeline_with_logprob(
+                        pipeline,
+                        latents=init_latents,
+                        prompt_embeds=prompt_embeds,
+                        pooled_prompt_embeds=pooled_prompt_embeds,
+                        negative_prompt_embeds=neg_prompt_embeds,
+                        negative_pooled_prompt_embeds=neg_pooled_prompt_embeds,
+                        num_inference_steps=full_steps,
+                        guidance_scale=config.rollout_sample_guidance_scale,
+                        output_type="pt",
+                        height=config.resolution,
+                        width=config.resolution,
+                        noise_level=config.sample.noise_level,
+                        deterministic=True,
+                        solver=config.sample.solver,
+                        model_type="sd3",
+                        sequential_decode=sequential_decode,
+                    )
+            timesteps = pipeline.scheduler.timesteps.repeat(batch_size, 1).to(device)
+            latents = torch.stack(latents, dim=1)
+            rewards_future = executor.submit(
+                reward_fn,
+                images,
+                [prompt_text] * batch_size,
+                [prompt_meta] * batch_size,
+                True,
+            )
+            time.sleep(0)
+            prompt_samples.append(
+                {
+                    "prompt_ids": prompt_token_ids_single.repeat(batch_size, 1),
+                    "prompt_embeds": prompt_embeds,
+                    "pooled_prompt_embeds": pooled_prompt_embeds,
+                    "timesteps": timesteps,
+                    "next_timesteps": torch.concatenate([timesteps[:, 1:], torch.zeros_like(timesteps[:, :1])], dim=1),
+                    "latents_clean": latents[:, -1],
+                    "rewards_future": rewards_future,
+                }
+            )
+            final_images = images
+            final_prompts = [prompt_text] * batch_size
+
+    for item in prompt_samples:
+        rewards, _ = item["rewards_future"].result()
+        item["rewards"] = {k: torch.as_tensor(v, device=device).float() for k, v in rewards.items()}
+        del item["rewards_future"]
+
+    collated = collate_dict_items(prompt_samples)
+    final_rewards = collated["rewards"]["avg"]
+    keep_indices = select_indices_by_mode(
+        final_rewards,
+        target_count=config.sample.best_of_n,
+        mode=getattr(config.sample, "stage2_select_mode", "best_worst"),
+    )
+    collated = filter_by_indices(collated, keep_indices)
+    return collated, final_images, final_prompts
+
+
+def main(_):
+    config = FLAGS.config
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    setup_distributed(rank, local_rank, world_size)
+    device = torch.device(f"cuda:{local_rank}")
+
+    if is_main_process(rank):
+        log_dir = os.path.join(config.logdir, config.run_name)
+        os.makedirs(log_dir, exist_ok=True)
+        wandb.init(
+            project="sol-rl",
+            name=config.run_name,
+            config=config.to_dict(),
+            resume="allow",
+            dir=log_dir,
+            id=config.run_name,
+        )
+        wandb.define_metric("global_step")
+        wandb.define_metric("*", step_metric="global_step")
+    logger.info("\n%s", config)
+
+    set_seed(config.seed, rank)
+
+    mixed_precision_dtype = None
+    if config.mixed_precision == "fp16":
+        mixed_precision_dtype = torch.float16
+    elif config.mixed_precision == "bf16":
+        mixed_precision_dtype = torch.bfloat16
+    enable_amp = mixed_precision_dtype is not None
+    scaler = GradScaler(enabled=enable_amp)
+
+    pipeline = StableDiffusion3Pipeline.from_pretrained(config.pretrained.model)
+    pipeline.vae.requires_grad_(False)
+    pipeline.text_encoder.requires_grad_(False)
+    pipeline.text_encoder_2.requires_grad_(False)
+    pipeline.text_encoder_3.requires_grad_(False)
+    pipeline.transformer.requires_grad_(not config.use_lora)
+    pipeline.safety_checker = None
+    pipeline.set_progress_bar_config(disable=True)
+    text_encoders = [pipeline.text_encoder, pipeline.text_encoder_2, pipeline.text_encoder_3]
+    tokenizers = [pipeline.tokenizer, pipeline.tokenizer_2, pipeline.tokenizer_3]
+
+    text_encoder_dtype = mixed_precision_dtype if enable_amp else torch.float32
+    pipeline.vae.to(device, dtype=torch.float32)
+    pipeline.text_encoder.to(device, dtype=text_encoder_dtype)
+    pipeline.text_encoder_2.to(device, dtype=text_encoder_dtype)
+    pipeline.text_encoder_3.to(device, dtype=text_encoder_dtype)
+
+    transformer = pipeline.transformer.to(device)
+
+    # --- Inference models: clean copies (no PEFT), optionally nvfp4 + torch.compile ---
+    compile_mode = str(getattr(config, "compile_mode", "max-autotune-no-cudagraphs"))
+    preview_step = int(getattr(config, "preview_step", 0))
+    preview_model_key = str(getattr(config, "preview_model", "peft"))
+    fullrollout_model_key = str(getattr(config, "fullrollout_model", "peft"))
+
+    needed_model_types = set()
+    if preview_step > 0:
+        if preview_model_key != "peft":
+            needed_model_types.add(preview_model_key)
+        if fullrollout_model_key != "peft":
+            needed_model_types.add(fullrollout_model_key)
+    else:
+        if fullrollout_model_key != "peft":
+            needed_model_types.add(fullrollout_model_key)
+
+    inference_models = {}
+    nvfp4_skip_modules = list(getattr(config, "nvfp4_skip_modules", []))
+    nvfp4_min_dim = int(getattr(config, "nvfp4_min_dim", 0))
+
+    for mtype in sorted(needed_model_types):
+        logger.info(f"[INIT] Creating inference model: {mtype!r} ...")
+        m = copy.deepcopy(transformer)
+        m.eval()
+        m.requires_grad_(False)
+        m.to(dtype=torch.bfloat16)
+
+        if "nvfp4" in mtype:
+            if not _HAS_TE:
+                raise RuntimeError(f"model type {mtype!r} requires transformer_engine")
+            n_rep, n_skip, rep_d, skip_d = replace_linear_with_te(
+                m,
+                skip_modules=nvfp4_skip_modules,
+                min_dim=nvfp4_min_dim,
+            )
+            logger.info(f"[NVFP4] {mtype}: replaced {n_rep} nn.Linear -> te.Linear, skipped {n_skip}")
+            wrap_forward_with_fp8(m)
+            logger.info(f"[NVFP4] {mtype}: wrap_forward_with_fp8 applied")
+            if is_main_process(rank):
+                report_path = os.path.join(config.save_dir, f"nvfp4_quant_report_{mtype}.txt")
+                os.makedirs(os.path.dirname(report_path), exist_ok=True)
+                with open(report_path, "w") as f:
+                    f.write(f"NVFP4 Quantization Report ({mtype})\n{'=' * 60}\n")
+                    f.write(f"skip_modules: {nvfp4_skip_modules}\n")
+                    f.write(f"min_dim: {nvfp4_min_dim}\n")
+                    f.write(f"replaced: {n_rep}  skipped: {n_skip}\n\n")
+                    f.write(f"Replaced (te.Linear + NVFP4):\n{'-' * 60}\n")
+                    for fqn, inf, outf, bias, _ in rep_d:
+                        f.write(f"  {fqn:60s}  in={inf:6d}  out={outf:6d}  bias={bias}\n")
+                    f.write(f"\nSkipped (kept as nn.Linear):\n{'-' * 60}\n")
+                    for fqn, inf, outf, bias, reason in skip_d:
+                        f.write(f"  {fqn:60s}  in={inf:6d}  out={outf:6d}  bias={bias}  reason={reason}\n")
+                logger.info(f"[NVFP4] Report saved to {report_path}")
+
+        if world_size > 1:
+            dist.barrier()
+        logger.info(f"[COMPILE] torch.compile(mode={compile_mode!r}) on {mtype!r} ...")
+        m = torch.compile(m, mode=compile_mode)
+        inference_models[mtype] = m
+        logger.info(f"[INIT] {mtype!r} ready")
+
+    if inference_models:
+        logger.info(f"[INIT] Inference models created: {list(inference_models.keys())}")
+    else:
+        logger.info("[INIT] No inference models needed, using PEFT model for all inference")
+
+    if config.use_lora:
+        init_lora_weights = getattr(config.train, "lora_init_mode", config.train.lora_init_weights)
+        transformer_lora_config = LoraConfig(
+            r=config.train.lora_rank,
+            lora_alpha=config.train.lora_alpha,
+            init_lora_weights=init_lora_weights,
+            target_modules=list(config.train.lora_target_modules),
+        )
+        if config.train.lora_path:
+            transformer = PeftModel.from_pretrained(transformer, config.train.lora_path)
+            transformer.set_adapter("default")
+        else:
+            transformer = get_peft_model(transformer, transformer_lora_config)
+        transformer.add_adapter("old", transformer_lora_config)
+        transformer.set_adapter("default")
+
+    transformer_ddp = DDP(transformer, device_ids=[local_rank], output_device=local_rank, find_unused_parameters=False)
+    transformer_ddp.module.set_adapter("default")
+    transformer_trainable_parameters = list(filter(lambda p: p.requires_grad, transformer_ddp.module.parameters()))
+    transformer_ddp.module.set_adapter("old")
+    old_transformer_trainable_parameters = list(filter(lambda p: p.requires_grad, transformer_ddp.module.parameters()))
+    transformer_ddp.module.set_adapter("default")
+
+    if config.allow_tf32:
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+
+    optimizer = torch.optim.AdamW(
+        transformer_trainable_parameters,
+        lr=config.train.learning_rate,
+        betas=(config.train.adam_beta1, config.train.adam_beta2),
+        weight_decay=config.train.adam_weight_decay,
+        eps=config.train.adam_epsilon,
+    )
+
+    _, train_dataloader, train_sampler, _, test_dataloader = build_datasets_and_loaders(config, world_size, rank)
+
+    neg_prompt_embed, neg_pooled_prompt_embed = compute_text_embeddings(
+        [""], text_encoders, tokenizers, max_sequence_length=TEXT_ENCODER_MAX_SEQ_LEN, device=device
+    )
+
+    if config.sample.best_of_n == 1:
+        config.per_prompt_stat_tracking = False
+    if config.per_prompt_stat_tracking:
+        stat_tracker = PerPromptStatTracker(config.global_std)
+    else:
+        raise ValueError("per_prompt_stat_tracking must be enabled for this recipe")
+
+    reward_fn = getattr(diffusion.flow_grpo.rewards, "multi_score")(device, config.reward_fn)
+    eval_reward_fn = getattr(diffusion.flow_grpo.rewards, "multi_score")(device, config.reward_fn)
+    executor = futures.ThreadPoolExecutor(max_workers=8)
+
+    ema = None
+    if config.train.ema:
+        ema = EMAModuleWrapper(transformer_trainable_parameters, decay=0.9, update_step_interval=1, device=device)
+
+    num_train_timesteps = int(config.rollout_sample_num_steps * config.train.timestep_fraction)
+    train_iter = iter(train_dataloader)
+    optimizer.zero_grad()
+
+    # --- Resume from checkpoint ---
+    first_epoch = 0
+    global_step = 0
+    candidates = find_resume_candidates(config)
+    global_step, resume_parameters = resume_from_checkpoint(
+        candidates,
+        transformer_ddp.module,
+        ema,
+        optimizer,
+        scaler,
+        device,
+    )
+    first_epoch = global_step
+
+    if not resume_parameters:
+        for src_param, tgt_param in zip(
+            transformer_trainable_parameters, old_transformer_trainable_parameters, strict=True
+        ):
+            tgt_param.data.copy_(src_param.detach().data)
+
+    if global_step != 0:
+        for i in range(global_step):
+            prompts, prompt_metadata = next(train_iter)
+
+    if world_size > 1:
+        dist.barrier()
+
+    # Sync old adapter weights → all inference models (after resume or fresh init)
+    for mtype, inf_model in inference_models.items():
+        n_synced = sync_lora_to_inference(
+            transformer_ddp.module,
+            unwrap_compiled(inf_model),
+            adapter_name="old",
+        )
+        logger.info(f"[SYNC] Initial sync: merged {n_synced} LoRA layers → {mtype!r}")
+
+    time_logger = DistributedTimeLogger(device)
+    start_time = time.time()
+    for epoch in range(first_epoch, config.num_epochs):
+        time_logger.start("total_time")
+
+        if hasattr(train_sampler, "set_epoch"):
+            train_sampler.set_epoch(epoch)
+
+        if epoch % config.save_freq == 0 and not config.debug:
+            save_ckpt(config.save_dir, transformer_ddp, global_step, rank, ema, config, optimizer, scaler)
+
+        time_logger.start("eval_time")
+        if epoch % config.eval_freq == 0 and not config.debug:
+            py_rng_state = random.getstate()
+            np_rng_state = np.random.get_state()
+            torch_rng_state = torch.random.get_rng_state()
+            cuda_rng_state = torch.cuda.get_rng_state_all()
+
+            eval_fn(
+                pipeline,
+                test_dataloader,
+                text_encoders,
+                tokenizers,
+                config,
+                device,
+                rank,
+                world_size,
+                global_step,
+                eval_reward_fn,
+                executor,
+                mixed_precision_dtype,
+                ema,
+                transformer_trainable_parameters,
+            )
+
+            random.setstate(py_rng_state)
+            np.random.set_state(np_rng_state)
+            torch.random.set_rng_state(torch_rng_state)
+            torch.cuda.set_rng_state_all(cuda_rng_state)
+        time_logger.end("eval_time")
+
+        time_logger.start("rollout_time")
+        pipeline.transformer.eval()
+        prompts, prompt_metadata = next(train_iter)
+        prompt_embeds_all, pooled_prompt_embeds_all = compute_text_embeddings(
+            prompts, text_encoders, tokenizers, max_sequence_length=TEXT_ENCODER_MAX_SEQ_LEN, device=device
+        )
+        prompt_ids_all = tokenizers[0](
+            prompts,
+            padding="max_length",
+            max_length=TOKENIZER_MAX_LENGTH,
+            truncation=True,
+            return_tensors="pt",
+        ).input_ids.to(device)
+
+        prompt_wise_samples = []
+        step_prompt_reward_groups = []
+        images_for_log = None
+        prompts_for_log = None
+        rewards_for_log = None
+
+        _saved_pipeline_transformer = pipeline.transformer
+
+        # For non-preview path, set up the model once (same as before)
+        if preview_step == 0:
+            if fullrollout_model_key != "peft" and fullrollout_model_key in inference_models:
+                pipeline.transformer = inference_models[fullrollout_model_key]
+            else:
+                transformer_ddp.module.set_adapter("old")
+
+        for prompt_idx in tqdm(
+            range(config.sample.per_gpu_to_process_prompts),
+            desc=f"Epoch {epoch}: rollout",
+            disable=not is_main_process(rank),
+            dynamic_ncols=True,
+        ):
+            collated_prompt_samples, final_images, final_prompts = _rollout_for_one_prompt(
+                pipeline=pipeline,
+                reward_fn=reward_fn,
+                executor=executor,
+                prompt_text=prompts[prompt_idx],
+                prompt_meta=prompt_metadata[prompt_idx],
+                prompt_embed_single=prompt_embeds_all[prompt_idx : prompt_idx + 1],
+                pooled_embed_single=pooled_prompt_embeds_all[prompt_idx : prompt_idx + 1],
+                neg_prompt_embed_single=neg_prompt_embed,
+                neg_pooled_prompt_embed_single=neg_pooled_prompt_embed,
+                prompt_token_ids_single=prompt_ids_all[prompt_idx : prompt_idx + 1],
+                config=config,
+                device=device,
+                inference_models=inference_models,
+                transformer_ddp=transformer_ddp,
+                original_transformer=_saved_pipeline_transformer,
+            )
+            prompt_wise_samples.append(collated_prompt_samples)
+            prompt_meta_i = slice_prompt_metadata(prompt_metadata, prompt_idx)
+            step_prompt_reward_groups.append(
+                extract_prompt_reward_group(
+                    prompt_idx=prompt_idx,
+                    prompt_text=prompts[prompt_idx],
+                    prompt_meta=prompt_meta_i,
+                    intra_prompt_data_list=[collated_prompt_samples],
+                )
+            )
+            images_for_log = final_images
+            prompts_for_log = final_prompts
+            rewards_for_log = collated_prompt_samples["rewards"]["avg"]
+
+        # Restore original transformer and switch back to "default" adapter
+        pipeline.transformer = _saved_pipeline_transformer
+        transformer_ddp.module.set_adapter("default")
+
+        save_step_reward_groups(
+            config=config,
+            global_step=global_step,
+            epoch=epoch,
+            rank=rank,
+            world_size=world_size,
+            prompt_reward_groups=step_prompt_reward_groups,
+        )
+
+        collated_samples = collate_dict_items(prompt_wise_samples)
+
+        log_rollout_images(images_for_log, prompts_for_log, rewards_for_log, config, global_step, rank)
+
+        collated_samples["rewards"]["avg"] = (
+            collated_samples["rewards"]["avg"].unsqueeze(1).repeat(1, num_train_timesteps)
+        )
+
+        gathered_rewards_dict = {
+            key: gather_tensor_to_all(value, world_size).numpy() for key, value in collated_samples["rewards"].items()
+        }
+        if is_main_process(rank):
+            rewards_to_log = gathered_rewards_dict["avg"]
+            rewards_to_log = rewards_to_log.reshape(
+                world_size * config.sample.per_gpu_to_process_prompts, -1, num_train_timesteps
+            )
+            rewards_to_log = rewards_to_log.mean(axis=-1)
+            wandb.log(
+                {
+                    "epoch": epoch,
+                    "reward/mean": rewards_to_log.mean(),
+                    "reward/max": rewards_to_log.max(axis=1).mean(),
+                    "reward/min": rewards_to_log.min(axis=1).mean(),
+                    "reward/range": rewards_to_log.max(axis=1).mean() - rewards_to_log.min(axis=1).mean(),
+                },
+                commit=False,
+            )
+
+        prompt_ids_all_global = gather_tensor_to_all(collated_samples["prompt_ids"], world_size)
+        prompts_all_decoded = tokenizers[0].batch_decode(prompt_ids_all_global.cpu().numpy(), skip_special_tokens=True)
+        advantages = stat_tracker.update(prompts_all_decoded, gathered_rewards_dict["avg"])
+
+        if is_main_process(rank):
+            group_size, trained_prompt_num = stat_tracker.get_stats()
+            zero_std_ratio, reward_std_mean = calculate_zero_std_ratio(prompts_all_decoded, gathered_rewards_dict)
+            wandb.log(
+                {
+                    "group_size": group_size,
+                    "trained_prompt_num": trained_prompt_num,
+                    "zero_std_ratio": zero_std_ratio,
+                    "reward_std_mean": reward_std_mean,
+                    "mean_reward_100": stat_tracker.get_mean_of_top_rewards(100),
+                    "mean_reward_75": stat_tracker.get_mean_of_top_rewards(75),
+                    "mean_reward_50": stat_tracker.get_mean_of_top_rewards(50),
+                    "mean_reward_25": stat_tracker.get_mean_of_top_rewards(25),
+                    "mean_reward_10": stat_tracker.get_mean_of_top_rewards(10),
+                },
+                commit=False,
+            )
+        stat_tracker.clear()
+
+        samples_per_gpu = collated_samples["timesteps"].shape[0]
+        if advantages.ndim == 1:
+            advantages = advantages[:, None]
+        if advantages.shape[0] != world_size * samples_per_gpu:
+            raise RuntimeError("Unexpected advantage shape after all-gather")
+        collated_samples["advantages"] = torch.from_numpy(advantages.reshape(world_size, samples_per_gpu, -1)[rank]).to(
+            device
+        )
+
+        del collated_samples["rewards"]
+        del collated_samples["prompt_ids"]
+        time_logger.end("rollout_time")
+
+        total_batch_size_filtered, num_timesteps_filtered = collated_samples["timesteps"].shape
+        assert total_batch_size_filtered == config.sample.per_gpu_total_samples_to_train
+
+        time_logger.start("train_time")
+        transformer_ddp.train()
+        effective_grad_accum_steps = config.train.gradient_accumulation_steps * num_train_timesteps
+        current_accumulated_steps = 0
+        gradient_update_times = 0
+
+        for inner_epoch in range(config.train.num_inner_epochs):
+            perm = torch.randperm(total_batch_size_filtered, device=device)
+            shuffled_samples = {k: v[perm] for k, v in collated_samples.items()}
+            perms_time = torch.stack(
+                [torch.randperm(num_timesteps_filtered, device=device) for _ in range(total_batch_size_filtered)]
+            )
+            for key in ["timesteps", "next_timesteps"]:
+                shuffled_samples[key] = shuffled_samples[key][
+                    torch.arange(total_batch_size_filtered, device=device)[:, None],
+                    perms_time,
+                ]
+
+            training_batch_size = config.train.batch_size
+            batches = []
+            for batch_idx in range(config.train.n_batch_per_epoch):
+                start = batch_idx * training_batch_size
+                end = (batch_idx + 1) * training_batch_size
+                batches.append({k: v[start:end] for k, v in shuffled_samples.items()})
+
+            info_accumulated = defaultdict(list)
+            for train_batch in tqdm(
+                batches,
+                desc=f"Epoch {epoch}.{inner_epoch}: train",
+                disable=not is_main_process(rank),
+                dynamic_ncols=True,
+            ):
+                current_bs = len(train_batch["prompt_embeds"])
+                if config.train_sample_guidance_scale > 1.0:
+                    embeds = torch.cat(
+                        [
+                            neg_prompt_embed.repeat(current_bs, 1, 1),
+                            train_batch["prompt_embeds"],
+                        ]
+                    )
+                    pooled_embeds = torch.cat(
+                        [
+                            neg_pooled_prompt_embed.repeat(current_bs, 1),
+                            train_batch["pooled_prompt_embeds"],
+                        ]
+                    )
+                else:
+                    embeds = train_batch["prompt_embeds"]
+                    pooled_embeds = train_batch["pooled_prompt_embeds"]
+
+                for j_idx in range(num_train_timesteps):
+                    x0 = train_batch["latents_clean"]
+                    t = train_batch["timesteps"][:, j_idx] / 1000.0
+                    t_expanded = t.view(-1, *([1] * (len(x0.shape) - 1)))
+                    noise = torch.randn_like(x0.float())
+                    xt = (1 - t_expanded) * x0 + t_expanded * noise
+
+                    with torch_autocast(enabled=enable_amp, dtype=mixed_precision_dtype):
+                        transformer_ddp.module.set_adapter("old")
+                        with torch.no_grad():
+                            old_prediction = transformer_ddp(
+                                hidden_states=xt,
+                                timestep=train_batch["timesteps"][:, j_idx],
+                                encoder_hidden_states=embeds,
+                                pooled_projections=pooled_embeds,
+                                return_dict=False,
+                            )[0].detach()
+                        transformer_ddp.module.set_adapter("default")
+                        forward_prediction = transformer_ddp(
+                            hidden_states=xt,
+                            timestep=train_batch["timesteps"][:, j_idx],
+                            encoder_hidden_states=embeds,
+                            pooled_projections=pooled_embeds,
+                            return_dict=False,
+                        )[0]
+                        with torch.no_grad():
+                            with transformer_ddp.module.disable_adapter():
+                                ref_forward_prediction = transformer_ddp(
+                                    hidden_states=xt,
+                                    timestep=train_batch["timesteps"][:, j_idx],
+                                    encoder_hidden_states=embeds,
+                                    pooled_projections=pooled_embeds,
+                                    return_dict=False,
+                                )[0]
+                            transformer_ddp.module.set_adapter("default")
+
+                    advantages_clip = torch.clamp(
+                        train_batch["advantages"][:, j_idx],
+                        -config.train.adv_clip_max,
+                        config.train.adv_clip_max,
+                    )
+                    if hasattr(config.train, "adv_mode"):
+                        if config.train.adv_mode == "positive_only":
+                            advantages_clip = torch.clamp(advantages_clip, 0, config.train.adv_clip_max)
+                        elif config.train.adv_mode == "negative_only":
+                            advantages_clip = torch.clamp(advantages_clip, -config.train.adv_clip_max, 0)
+                        elif config.train.adv_mode == "one_only":
+                            advantages_clip = torch.where(
+                                advantages_clip > 0, torch.ones_like(advantages_clip), torch.zeros_like(advantages_clip)
+                            )
+                        elif config.train.adv_mode == "binary":
+                            advantages_clip = torch.sign(advantages_clip)
+
+                    normalized_adv = (advantages_clip / config.train.adv_clip_max) / 2.0 + 0.5
+                    r = torch.clamp(normalized_adv, 0, 1)
+
+                    positive_prediction = config.beta * forward_prediction + (1 - config.beta) * old_prediction.detach()
+                    implicit_negative_prediction = (
+                        1.0 + config.beta
+                    ) * old_prediction.detach() - config.beta * forward_prediction
+
+                    x0_prediction = xt - t_expanded * positive_prediction
+                    with torch.no_grad():
+                        weight_factor = (
+                            torch.abs(x0_prediction.double() - x0.double())
+                            .mean(dim=tuple(range(1, x0.ndim)), keepdim=True)
+                            .clip(min=1e-5)
+                        )
+                    positive_loss = ((x0_prediction - x0) ** 2 / weight_factor).mean(dim=tuple(range(1, x0.ndim)))
+
+                    negative_x0_prediction = xt - t_expanded * implicit_negative_prediction
+                    with torch.no_grad():
+                        negative_weight_factor = (
+                            torch.abs(negative_x0_prediction.double() - x0.double())
+                            .mean(dim=tuple(range(1, x0.ndim)), keepdim=True)
+                            .clip(min=1e-5)
+                        )
+                    negative_loss = ((negative_x0_prediction - x0) ** 2 / negative_weight_factor).mean(
+                        dim=tuple(range(1, x0.ndim))
+                    )
+
+                    ori_policy_loss = r * positive_loss / config.beta + (1.0 - r) * negative_loss / config.beta
+                    policy_loss = (ori_policy_loss * config.train.adv_clip_max).mean()
+                    loss = policy_loss
+                    loss_terms = {}
+                    loss_terms["policy_loss"] = policy_loss.detach()
+                    loss_terms["unweighted_policy_loss"] = ori_policy_loss.mean().detach()
+
+                    kl_div_loss = ((forward_prediction - ref_forward_prediction) ** 2).mean(
+                        dim=tuple(range(1, x0.ndim))
+                    )
+                    loss += config.train.beta * torch.mean(kl_div_loss)
+                    kl_div_loss = torch.mean(kl_div_loss)
+
+                    loss_terms["kl_div_loss"] = torch.mean(kl_div_loss).detach()
+                    loss_terms["kl_div"] = torch.mean(
+                        ((forward_prediction - ref_forward_prediction) ** 2).mean(dim=tuple(range(1, x0.ndim)))
+                    ).detach()
+                    loss_terms["old_kl_div"] = torch.mean(
+                        ((old_prediction - ref_forward_prediction) ** 2).mean(dim=tuple(range(1, x0.ndim)))
+                    ).detach()
+                    loss_terms["x0_norm"] = torch.mean(x0**2).detach()
+                    loss_terms["x0_norm_max"] = torch.max(x0**2).detach()
+                    loss_terms["old_deviate"] = torch.mean((forward_prediction - old_prediction) ** 2).detach()
+                    loss_terms["old_deviate_max"] = torch.max((forward_prediction - old_prediction) ** 2).detach()
+                    loss_terms["total_loss"] = loss.detach()
+
+                    scaled_loss = loss / effective_grad_accum_steps
+                    if torch.isnan(scaled_loss) or torch.isinf(scaled_loss):
+                        scaled_loss = scaled_loss * 0.0
+
+                    if mixed_precision_dtype == torch.float16:
+                        scaler.scale(scaled_loss).backward()
+                    else:
+                        scaled_loss.backward()
+                    current_accumulated_steps += 1
+
+                    for k_info, v_info in loss_terms.items():
+                        info_accumulated[k_info].append(v_info)
+
+                    if current_accumulated_steps % effective_grad_accum_steps == 0:
+                        if mixed_precision_dtype == torch.float16:
+                            scaler.unscale_(optimizer)
+                        grad_norm = torch.nn.utils.clip_grad_norm_(
+                            transformer_ddp.module.parameters(), config.train.max_grad_norm
+                        )
+                        if mixed_precision_dtype == torch.float16:
+                            scaler.step(optimizer)
+                            scaler.update()
+                        else:
+                            optimizer.step()
+                        optimizer.zero_grad()
+                        gradient_update_times += 1
+
+                        log_info = {k: torch.mean(torch.stack(v)).item() for k, v in info_accumulated.items()}
+                        if torch.is_tensor(grad_norm):
+                            log_info["grad_norm"] = grad_norm.detach().float().item()
+                        else:
+                            log_info["grad_norm"] = float(grad_norm)
+                        info_tensor = torch.tensor([log_info[k] for k in sorted(log_info)], device=device)
+                        dist.all_reduce(info_tensor, op=dist.ReduceOp.AVG)
+                        reduced_log = {k: info_tensor[i].item() for i, k in enumerate(sorted(log_info))}
+                        if is_main_process(rank):
+                            wandb.log(
+                                {
+                                    "global_step": global_step,
+                                    "gradient_update_times": gradient_update_times,
+                                    "epoch": epoch,
+                                    "inner_epoch": inner_epoch,
+                                    "current_time": time.time() - start_time,
+                                    **reduced_log,
+                                },
+                                commit=False,
+                            )
+                        global_step += 1
+                        info_accumulated = defaultdict(list)
+
+                    if (
+                        config.train.ema
+                        and ema is not None
+                        and (current_accumulated_steps % effective_grad_accum_steps == 0)
+                    ):
+                        ema.step(transformer_trainable_parameters, global_step)
+
+        time_logger.end("train_time")
+
+        if world_size > 1:
+            dist.barrier()
+        with torch.no_grad():
+            decay = return_decay(
+                global_step,
+                config.decay_type,
+                custom_decay_step=getattr(config, "custom_decay_step", 0),
+                custom_decay_value=getattr(config, "custom_decay_value", 0.0),
+            )
+            for src_param, tgt_param in zip(
+                transformer_trainable_parameters, old_transformer_trainable_parameters, strict=True
+            ):
+                tgt_param.data.copy_(tgt_param.detach().data * decay + src_param.detach().clone().data * (1.0 - decay))
+
+        # Sync updated old adapter → all inference models for next rollout
+        for mtype, inf_model in inference_models.items():
+            sync_lora_to_inference(
+                transformer_ddp.module,
+                unwrap_compiled(inf_model),
+                adapter_name="old",
+            )
+
+        time_logger.end("total_time")
+        stats = time_logger.get_results()
+
+        if is_main_process(rank):
+            time_logs = {f"time/{k}": v for k, v in stats.items()}
+            wandb.log(time_logs, commit=True)
+            logger.info("Step %d Time Report: %s", global_step, time_logs)
+
+        time_logger.empty_cache()
+
+    if is_main_process(rank):
+        wandb.finish()
+    cleanup_distributed()
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/train_scripts/sol_rl/train_utils.py
+++ b/train_scripts/sol_rl/train_utils.py
@@ -1,0 +1,672 @@
+"""Shared utilities for Sol-RL training scripts (SD3, FLUX.1, SANA)."""
+
+import json
+import logging
+import os
+import random
+import tempfile
+from collections import defaultdict
+from functools import wraps
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import wandb
+from PIL import Image
+from torch.utils.data import DataLoader
+from torch.utils.data.distributed import DistributedSampler
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import transformer_engine.pytorch as te
+    from transformer_engine.common.recipe import DelayedScaling, Format
+
+    NVFP4_RECIPE = DelayedScaling(
+        fp8_format=Format.E2M1,
+        amax_history_len=16,
+        amax_compute_algo="max",
+    )
+    _HAS_TE = True
+except ImportError:
+    te = None
+    NVFP4_RECIPE = None
+    _HAS_TE = False
+
+
+# ---------------------------------------------------------------------------
+# Distributed helpers
+# ---------------------------------------------------------------------------
+
+
+def setup_distributed(rank, local_rank, world_size):
+    os.environ["MASTER_ADDR"] = os.getenv("MASTER_ADDR", "localhost")
+    os.environ["MASTER_PORT"] = os.getenv("MASTER_PORT", "12355")
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    torch.cuda.set_device(local_rank)
+
+
+def cleanup_distributed():
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def is_main_process(rank):
+    return rank == 0
+
+
+def set_seed(seed, rank=0):
+    random.seed(seed + rank)
+    np.random.seed(seed + rank)
+    torch.manual_seed(seed + rank)
+    torch.cuda.manual_seed_all(seed + rank)
+
+
+def gather_tensor_to_all(tensor, world_size):
+    tensor = tensor.contiguous()
+    gathered = [torch.zeros_like(tensor) for _ in range(world_size)]
+    dist.all_gather(gathered, tensor)
+    return torch.cat(gathered, dim=0).cpu()
+
+
+# ---------------------------------------------------------------------------
+# Time logging
+# ---------------------------------------------------------------------------
+
+
+class DistributedTimeLogger:
+    def __init__(self, device):
+        self.device = device
+        self.starts = {}
+        self.ends = {}
+        self.results = defaultdict(float)
+        self.is_distributed = dist.is_available() and dist.is_initialized()
+        self.rank = dist.get_rank() if self.is_distributed else 0
+
+    def start(self, name):
+        torch.cuda.synchronize(self.device)
+        ev = torch.cuda.Event(enable_timing=True)
+        ev.record()
+        self.starts[name] = ev
+
+    def end(self, name):
+        if name not in self.starts:
+            return
+        ev = torch.cuda.Event(enable_timing=True)
+        ev.record()
+        torch.cuda.synchronize(self.device)
+        self.results[name] += self.starts[name].elapsed_time(ev) / 1000.0
+        self.ends[name] = ev
+
+    def get_results(self, aggregate=True):
+        final = {}
+        for name, dur in self.results.items():
+            t = torch.tensor([dur], device=self.device)
+            if self.is_distributed and aggregate:
+                dist.reduce(t, dst=0, op=dist.ReduceOp.MAX)
+            if self.rank == 0:
+                final[name] = t.item()
+        return final if self.rank == 0 else None
+
+    def empty_cache(self):
+        self.starts.clear()
+        self.ends.clear()
+        self.results.clear()
+
+
+# ---------------------------------------------------------------------------
+# JSON / reward trace serialization
+# ---------------------------------------------------------------------------
+
+
+def to_jsonable(value):
+    if torch.is_tensor(value):
+        if value.numel() == 1:
+            return value.item()
+        return value.detach().cpu().tolist()
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, (np.floating, np.integer)):
+        return value.item()
+    if isinstance(value, dict):
+        return {k: to_jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [to_jsonable(v) for v in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def slice_prompt_metadata(prompt_metadata, prompt_idx):
+    if isinstance(prompt_metadata, (list, tuple)):
+        if 0 <= prompt_idx < len(prompt_metadata):
+            return prompt_metadata[prompt_idx]
+        return None
+    if isinstance(prompt_metadata, dict):
+        sliced = {}
+        for k, v in prompt_metadata.items():
+            if torch.is_tensor(v) and v.ndim > 0 and prompt_idx < v.shape[0]:
+                sliced[k] = v[prompt_idx]
+            elif isinstance(v, np.ndarray) and v.ndim > 0 and prompt_idx < v.shape[0]:
+                sliced[k] = v[prompt_idx]
+            elif isinstance(v, (list, tuple)) and prompt_idx < len(v):
+                sliced[k] = v[prompt_idx]
+            else:
+                sliced[k] = v
+        return sliced
+    return prompt_metadata
+
+
+def extract_prompt_reward_group(prompt_idx, prompt_text, prompt_meta, intra_prompt_data_list):
+    rollouts, rollout_idx = [], 0
+    for chunk_idx, sample_item in enumerate(intra_prompt_data_list):
+        rewards_dict = sample_item["rewards"]
+        if "avg" not in rewards_dict:
+            raise KeyError("Expected reward key 'avg' not found in rewards dict.")
+        chunk_size = int(rewards_dict["avg"].shape[0])
+        for row_idx in range(chunk_size):
+            rollouts.append(
+                {
+                    "rollout_idx": rollout_idx,
+                    "chunk_idx": chunk_idx,
+                    "idx_in_chunk": row_idx,
+                    "rewards": {rn: float(rt[row_idx].detach().cpu().item()) for rn, rt in rewards_dict.items()},
+                }
+            )
+            rollout_idx += 1
+    return {
+        "prompt_idx_local": int(prompt_idx),
+        "prompt_text": str(prompt_text),
+        "prompt_metadata": to_jsonable(prompt_meta),
+        "num_rollouts": len(rollouts),
+        "rollouts": rollouts,
+    }
+
+
+def save_step_reward_groups(config, global_step, epoch, rank, world_size, prompt_reward_groups):
+    reward_trace_dir = os.path.join(config.save_dir, "reward_traces")
+    os.makedirs(reward_trace_dir, exist_ok=True)
+    payload = {
+        "global_step": int(global_step),
+        "epoch": int(epoch),
+        "rank": int(rank),
+        "world_size": int(world_size),
+        "num_prompt_groups": len(prompt_reward_groups),
+        "total_rollouts": int(sum(g["num_rollouts"] for g in prompt_reward_groups)),
+        "prompt_reward_groups": prompt_reward_groups,
+    }
+    output_path = os.path.join(reward_trace_dir, f"step_{int(global_step):08d}_rank_{int(rank)}.json")
+    tmp = output_path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=True, indent=2)
+    os.replace(tmp, output_path)
+
+
+# ---------------------------------------------------------------------------
+# Training helpers
+# ---------------------------------------------------------------------------
+
+
+def return_decay(step, decay_type, custom_decay_step=0, custom_decay_value=0.0):
+    if decay_type == 0:
+        flat, uprate, uphold = 0, 0.0, 0.0
+    elif decay_type == 1:
+        flat, uprate, uphold = 0, 0.001, 0.5
+    elif decay_type == 2:
+        flat, uprate, uphold = 75, 0.0075, 0.999
+    elif decay_type == 3:
+        assert custom_decay_step > 0 and custom_decay_value > 0, (
+            f"decay_type=3 requires custom_decay_step>0 and custom_decay_value>0, "
+            f"got step={custom_decay_step}, value={custom_decay_value}"
+        )
+        flat, uprate, uphold = 0, custom_decay_value / custom_decay_step, custom_decay_value
+    else:
+        raise ValueError(f"Unsupported decay_type={decay_type}")
+    if step < flat:
+        return 0.0
+    return min((step - flat) * uprate, uphold)
+
+
+def calculate_zero_std_ratio(prompts, gathered_rewards):
+    prompt_array = np.array(prompts)
+    unique_prompts, inverse_indices, counts = np.unique(prompt_array, return_inverse=True, return_counts=True)
+    if len(unique_prompts) == 0:
+        return 0.0, 0.0
+    grouped_rewards = gathered_rewards["avg"][np.argsort(inverse_indices), 0]
+    split_indices = np.cumsum(counts)[:-1]
+    reward_groups = np.split(grouped_rewards, split_indices)
+    prompt_std_devs = np.array([np.std(group) for group in reward_groups])
+    zero_std_count = np.count_nonzero(prompt_std_devs == 0)
+    return zero_std_count / len(prompt_std_devs), float(prompt_std_devs.mean())
+
+
+# ---------------------------------------------------------------------------
+# Collation / filtering
+# ---------------------------------------------------------------------------
+
+
+def collate_dict_items(items):
+    if not items:
+        return {}
+    return {
+        key: (
+            torch.cat([it[key] for it in items], dim=0)
+            if not isinstance(items[0][key], dict)
+            else {k2: torch.cat([it[key][k2] for it in items], dim=0) for k2 in items[0][key]}
+        )
+        for key in items[0].keys()
+    }
+
+
+def filter_by_indices(collated_samples, keep_indices):
+    filtered = {}
+    for key, value in collated_samples.items():
+        if isinstance(value, torch.Tensor):
+            filtered[key] = value[keep_indices]
+        elif isinstance(value, dict):
+            filtered[key] = {sk: (sv[keep_indices] if isinstance(sv, torch.Tensor) else sv) for sk, sv in value.items()}
+        else:
+            filtered[key] = value
+    return filtered
+
+
+def select_indices_by_mode(rewards, target_count, mode):
+    total = rewards.shape[0]
+    target_count = max(1, min(int(target_count), total))
+    mode = str(mode).lower()
+
+    if mode == "random":
+        return torch.randperm(total, device=rewards.device)[:target_count]
+
+    if mode == "mean_deviation":
+        return torch.topk(torch.abs(rewards - rewards.mean()), target_count, largest=True).indices
+
+    if mode == "extremes_random":
+        if total == 1:
+            return torch.tensor([0], dtype=torch.long, device=rewards.device)
+        extremes = torch.unique(torch.stack([torch.argmax(rewards), torch.argmin(rewards)]))
+        if target_count <= extremes.numel():
+            return extremes[:target_count]
+        mask = torch.ones(total, dtype=torch.bool, device=rewards.device)
+        mask[extremes] = False
+        remaining = torch.nonzero(mask, as_tuple=False).squeeze(1)
+        rk = min(target_count - extremes.numel(), remaining.numel())
+        return torch.cat([extremes, remaining[torch.randperm(remaining.numel(), device=rewards.device)[:rk]]])
+
+    n_best = target_count // 2
+    n_worst = target_count - n_best
+    best = (
+        torch.topk(rewards, n_best, largest=True).indices
+        if n_best > 0
+        else torch.empty(0, dtype=torch.long, device=rewards.device)
+    )
+    worst = (
+        torch.topk(rewards, n_worst, largest=False).indices
+        if n_worst > 0
+        else torch.empty(0, dtype=torch.long, device=rewards.device)
+    )
+    return torch.cat([best, worst])
+
+
+# ---------------------------------------------------------------------------
+# Debug images
+# ---------------------------------------------------------------------------
+
+
+def save_debug_image_subset(images, prompts, save_root, prefix, resolution, rewards=None, max_images=6):
+    os.makedirs(save_root, exist_ok=True)
+    for idx in range(min(int(max_images), len(images))):
+        pil = Image.fromarray((images[idx].float().cpu().numpy().transpose(1, 2, 0) * 255).astype(np.uint8))
+        pil = pil.resize((resolution, resolution))
+        ps = str(prompts[idx]).replace("/", "_").replace("\\", "_").replace(":", "_")[:60]
+        if rewards is not None and len(rewards) > idx:
+            fn = f"{prefix}_{idx:02d}_r{float(rewards[idx]):.3f}_{ps}.jpg"
+        else:
+            fn = f"{prefix}_{idx:02d}_{ps}.jpg"
+        pil.save(os.path.join(save_root, fn))
+
+
+# ---------------------------------------------------------------------------
+# Compile / LoRA / NVFP4 helpers
+# ---------------------------------------------------------------------------
+
+
+def unwrap_compiled(model):
+    return model._orig_mod if hasattr(model, "_orig_mod") else model
+
+
+@torch.no_grad()
+def sync_lora_to_inference(peft_model, inference_model, adapter_name="old"):
+    synced = 0
+    for name, module in peft_model.base_model.model.named_modules():
+        if not hasattr(module, "lora_A") or adapter_name not in module.lora_A:
+            continue
+        base_weight = module.base_layer.weight.data
+        lora_A = module.lora_A[adapter_name].weight.data
+        lora_B = module.lora_B[adapter_name].weight.data
+        scaling = module.scaling[adapter_name]
+        merged = base_weight + scaling * (lora_B @ lora_A)
+
+        target = inference_model
+        for part in name.split("."):
+            target = getattr(target, part)
+        target.weight.data.copy_(merged)
+        synced += 1
+    return synced
+
+
+def wrap_forward_with_fp8(module):
+    original_forward = module.forward
+
+    @wraps(original_forward)
+    def wrapped(*args, **kwargs):
+        with te.fp8_autocast(enabled=True, fp8_recipe=NVFP4_RECIPE):
+            return original_forward(*args, **kwargs)
+
+    module.forward = wrapped
+    return original_forward
+
+
+class BF16TELinear(nn.Module):
+    """Wrapper around te.Linear that casts input to bfloat16."""
+
+    def __init__(self, te_linear):
+        super().__init__()
+        self.te_linear = te_linear
+
+    @property
+    def weight(self):
+        return self.te_linear.weight
+
+    @property
+    def bias(self):
+        return self.te_linear.bias
+
+    @property
+    def in_features(self):
+        return self.te_linear.in_features
+
+    @property
+    def out_features(self):
+        return self.te_linear.out_features
+
+    def forward(self, x):
+        return self.te_linear(x.to(torch.bfloat16))
+
+
+class BF16TEConv1x1AsLinear(nn.Module):
+    """Replaces a 1x1 Conv2d with te.Linear for NVFP4 quantization."""
+
+    def __init__(self, te_linear):
+        super().__init__()
+        self.te_linear = te_linear
+
+    @property
+    def weight(self):
+        return self.te_linear.weight
+
+    @property
+    def bias(self):
+        return self.te_linear.bias
+
+    def forward(self, x):
+        B, C, H, W = x.shape
+        x_2d = x.flatten(2).transpose(1, 2).contiguous()
+        y_2d = self.te_linear(x_2d.to(torch.bfloat16))
+        return y_2d.transpose(1, 2).reshape(B, -1, H, W)
+
+
+def _is_replaceable_conv1x1(module):
+    return (
+        isinstance(module, nn.Conv2d)
+        and module.kernel_size == (1, 1)
+        and module.stride == (1, 1)
+        and module.groups == 1
+    )
+
+
+def replace_linear_with_te(model, skip_modules=None, min_dim=0, replace_conv1x1=False, _prefix=""):
+    if skip_modules is None:
+        skip_modules = []
+    replaced = skipped = 0
+    replaced_details, skipped_details = [], []
+
+    for name, child in list(model.named_children()):
+        fqn = f"{_prefix}.{name}" if _prefix else name
+
+        is_linear = isinstance(child, nn.Linear)
+        is_conv1x1 = replace_conv1x1 and _is_replaceable_conv1x1(child)
+
+        if is_linear or is_conv1x1:
+            in_feat = child.in_features if is_linear else child.in_channels
+            out_feat = child.out_features if is_linear else child.out_channels
+            has_bias = child.bias is not None
+
+            skip_reason = None
+            if any(pat in fqn for pat in skip_modules):
+                skip_reason = "name_pattern"
+            elif min_dim > 0 and max(in_feat, out_feat) <= min_dim:
+                skip_reason = f"small_dim(<={min_dim})"
+
+            info = (fqn, in_feat, out_feat, has_bias, skip_reason)
+            if skip_reason:
+                skipped += 1
+                skipped_details.append(info)
+            else:
+                te_lin = te.Linear(in_feat, out_feat, bias=has_bias).to(
+                    device=child.weight.device, dtype=child.weight.dtype
+                )
+                with torch.no_grad():
+                    weight = child.weight.reshape(out_feat, in_feat) if is_conv1x1 else child.weight
+                    te_lin.weight.copy_(weight)
+                    if has_bias and te_lin.bias is not None:
+                        te_lin.bias.copy_(child.bias)
+
+                wrapper = BF16TEConv1x1AsLinear(te_lin) if is_conv1x1 else BF16TELinear(te_lin)
+                setattr(model, name, wrapper)
+                replaced += 1
+                replaced_details.append(info)
+        else:
+            r, s, rd, sd = replace_linear_with_te(
+                child, skip_modules, min_dim=min_dim, replace_conv1x1=replace_conv1x1, _prefix=fqn
+            )
+            replaced += r
+            skipped += s
+            replaced_details.extend(rd)
+            skipped_details.extend(sd)
+
+    return replaced, skipped, replaced_details, skipped_details
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint save / resume
+# ---------------------------------------------------------------------------
+
+
+def save_ckpt(save_dir, transformer_ddp, global_step, rank, ema, config, optimizer, scaler):
+    """Save LoRA adapters, EMA, optimizer and scaler to a checkpoint directory."""
+    if not is_main_process(rank):
+        return
+    save_root = os.path.join(save_dir, "checkpoints", f"checkpoint-{global_step}")
+    model_to_save = unwrap_compiled(transformer_ddp.module)
+    save_root_lora = os.path.join(save_root, "lora")
+    os.makedirs(save_root_lora, exist_ok=True)
+    model_to_save.save_pretrained(save_root_lora)
+    if getattr(config.train, "ema", False) and ema is not None:
+        torch.save(ema.state_dict(), os.path.join(save_root, "ema.pt"))
+    torch.save(optimizer.state_dict(), os.path.join(save_root, "optimizer.pt"))
+    if scaler is not None:
+        torch.save(scaler.state_dict(), os.path.join(save_root, "scaler.pt"))
+    _logger.info("Saved checkpoint to %s", save_root)
+
+
+def find_resume_candidates(config):
+    """Return a list of ``(step, path)`` checkpoint candidates sorted by step descending."""
+    if not (getattr(config, "resume_from", None) and getattr(config, "resume", False)):
+        return []
+    ckpt_dir = os.path.join(config.resume_from, "checkpoints")
+    if not os.path.exists(ckpt_dir):
+        _logger.warning("Resume path %s does not exist. Starting from scratch.", ckpt_dir)
+        os.makedirs(ckpt_dir, exist_ok=True)
+        return []
+    candidates = []
+    try:
+        for d in os.listdir(ckpt_dir):
+            full = os.path.join(ckpt_dir, d)
+            if d.startswith("checkpoint-") and os.path.isdir(full):
+                try:
+                    candidates.append((int(d.split("-")[-1]), full))
+                except ValueError:
+                    continue
+        candidates.sort(key=lambda x: x[0], reverse=True)
+    except Exception as e:
+        _logger.warning("Error searching for checkpoints: %s", e)
+    try:
+        if getattr(config, "resume_path", None):
+            explicit_step = int(os.path.basename(config.resume_path).split("-")[-1])
+            candidates.insert(0, (explicit_step, config.resume_path))
+    except Exception:
+        pass
+    return candidates
+
+
+def resume_from_checkpoint(candidates, peft_model, ema, optimizer, scaler, device):
+    """Try to load training state from *candidates* (output of :func:`find_resume_candidates`).
+
+    *peft_model* should be the unwrapped PeftModel
+    (use ``unwrap_compiled(transformer_ddp.module)`` when the module may be compiled).
+
+    Returns ``(global_step, resumed)`` where *resumed* is ``True`` on success.
+    """
+    for ckpt_step, ckpt_path in candidates:
+        try:
+            _logger.info("Attempting to resume from %s (step %d)", ckpt_path, ckpt_step)
+            lora_path = os.path.join(ckpt_path, "lora")
+            lora_path_old = os.path.join(lora_path, "old")
+            peft_model.load_adapter(lora_path, adapter_name="default", is_trainable=True)
+            peft_model.load_adapter(lora_path_old, adapter_name="old", is_trainable=False)
+            ema_path = os.path.join(ckpt_path, "ema.pt")
+            if os.path.exists(ema_path) and ema is not None:
+                ema.load_state_dict(torch.load(ema_path, map_location=device))
+            opt_path = os.path.join(ckpt_path, "optimizer.pt")
+            if os.path.exists(opt_path):
+                optimizer.load_state_dict(torch.load(opt_path, map_location=device))
+            scaler_path = os.path.join(ckpt_path, "scaler.pt")
+            if os.path.exists(scaler_path) and scaler is not None:
+                scaler.load_state_dict(torch.load(scaler_path, map_location=device))
+            _logger.info("Successfully resumed from step %d", ckpt_step)
+            return ckpt_step, True
+        except Exception as e:
+            _logger.warning("Failed to load checkpoint %s: %s. Trying next...", ckpt_path, e)
+            continue
+    if candidates:
+        _logger.warning("All checkpoints failed to load. Starting from scratch.")
+    return 0, False
+
+
+# ---------------------------------------------------------------------------
+# Rollout image logging
+# ---------------------------------------------------------------------------
+
+
+def log_rollout_images(images, prompts, rewards, config, global_step, rank, max_wandb_images=12):
+    """Save debug images to disk and log to wandb during rollout."""
+    debug_image_every_steps = max(1, int(getattr(config, "debug_image_every_steps", 10)))
+    enable_debug_image_save = bool(getattr(config, "enable_debug_image_save", True))
+    if not (
+        enable_debug_image_save
+        and is_main_process(rank)
+        and images is not None
+        and global_step % debug_image_every_steps == 0
+    ):
+        return
+    images_to_log = images.cpu()
+    num_to_log = min(max_wandb_images, len(images_to_log))
+    rollout_debug_dir = os.path.join(
+        config.save_dir,
+        "debug_images",
+        "rollout",
+        f"step_{global_step}",
+    )
+    save_debug_image_subset(
+        images=images_to_log,
+        prompts=prompts,
+        save_root=rollout_debug_dir,
+        prefix="rollout",
+        resolution=config.resolution,
+        rewards=rewards,
+        max_images=getattr(config, "debug_image_subset_size", 6),
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for idx in range(num_to_log):
+            image = images_to_log[idx].float()
+            pil = Image.fromarray((image.numpy().transpose(1, 2, 0) * 255).astype(np.uint8))
+            pil = pil.resize((config.resolution, config.resolution))
+            pil.save(os.path.join(tmpdir, f"{idx}.jpg"))
+        wandb.log(
+            {
+                "images": [
+                    wandb.Image(
+                        os.path.join(tmpdir, f"{idx}.jpg"),
+                        caption=f"{prompts[idx]:.100} | avg: {rewards[idx]:.2f}",
+                    )
+                    for idx in range(num_to_log)
+                ],
+            },
+            commit=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dataset / dataloader construction
+# ---------------------------------------------------------------------------
+
+
+def build_datasets_and_loaders(config, world_size, rank):
+    """Build train/test datasets with distributed samplers and dataloaders.
+
+    Returns ``(train_dataset, train_dataloader, train_sampler, test_dataset, test_dataloader)``.
+    """
+    from diffusion.flow_grpo.prompt_dataset import (
+        DistributedKRepeatSampler,
+        GenevalPromptDataset,
+        TextPromptDataset,
+    )
+
+    if config.prompt_fn == "general_ocr":
+        train_dataset = TextPromptDataset(config.dataset, "train")
+        test_dataset = TextPromptDataset(config.dataset, "test")
+    elif config.prompt_fn == "geneval":
+        train_dataset = GenevalPromptDataset(config.dataset, "train")
+        test_dataset = GenevalPromptDataset(config.dataset, "test")
+    else:
+        raise NotImplementedError(f"Unsupported prompt_fn={config.prompt_fn}")
+
+    train_sampler = DistributedKRepeatSampler(
+        dataset=train_dataset,
+        batch_size=config.sample.per_gpu_to_process_prompts,
+        k=1,
+        num_replicas=world_size,
+        rank=rank,
+        seed=config.seed,
+    )
+    train_dataloader = DataLoader(
+        train_dataset,
+        batch_sampler=train_sampler,
+        num_workers=0,
+        collate_fn=train_dataset.collate_fn,
+        pin_memory=True,
+    )
+    test_sampler = (
+        DistributedSampler(test_dataset, num_replicas=world_size, rank=rank, shuffle=False) if world_size > 1 else None
+    )
+    test_dataloader = DataLoader(
+        test_dataset,
+        batch_size=config.sample.test_batch_size,
+        sampler=test_sampler,
+        collate_fn=test_dataset.collate_fn,
+        num_workers=0,
+        pin_memory=True,
+    )
+    return train_dataset, train_dataloader, train_sampler, test_dataset, test_dataloader


### PR DESCRIPTION
## Summary
- add the Sol-RL post-training stack under `diffusion/flow_grpo` with reward scorers, remote reward clients, evaluation helpers, EMA, and diffusers patches
- add the linear-attention Sana network variants plus Sol-RL training entrypoints and configs for Sana, SD3, and Flux.1 under `train_scripts/sol_rl` and `configs/sol_rl`
- include the Python dependencies required by the new Sol-RL pipeline and preserve the upstream `main` docs updates by cherry-picking the fork-only commits onto the latest upstream branch

## Test plan
- [x] `python -m compileall diffusion/flow_grpo diffusion/model/nets train_scripts/sol_rl`
- [x] `ReadLints` on the changed config and Python directories
- [ ] end-to-end training/evaluation not run in this environment