### PR TITLE
fix: pin PyTorch to 2.6.0 for flash-attn compatibility

### DIFF
--- a/environment_setup.sh
+++ b/environment_setup.sh
@@ -21,11 +21,13 @@ else
     echo "Skipping conda environment creation. Make sure you have the correct environment activated."
 fi
 
-# init a raw torch to avoid installation errors.
-# pip install torch
-
 # update pip to latest version for pyproject.toml setup.
 pip install -U pip
+
+# Pin PyTorch to a version compatible with flash-attn==2.8.2.
+# PyTorch>=2.8.0 does not yet have prebuilt flash-attn wheels; pinning to 2.6.0 ensures
+# a successful install. See: https://github.com/NVlabs/Sana/issues/375
+pip install torch==2.6.0+cu128 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
 
 # for fast attn
 pip install -U xformers==0.0.32.post2 --index-url https://download.pytorch.org/whl/cu128


### PR DESCRIPTION
## Problem

Users who have PyTorch 2.8.0 installed encounter a setup failure because `flash-attn==2.8.2` does not yet have prebuilt wheels for torch>=2.8.0. The current script has the torch install commented out (`# pip install torch`), which leaves the environment vulnerable to version mismatches.

Reported in #375.

## Fix

Uncomment and pin the PyTorch install to `torch==2.6.0+cu128` — the latest version with confirmed `flash-attn==2.8.2` wheel support — and place it before the `xformers` and `flash-attn` installs to guarantee a consistent baseline.

```diff
-# init a raw torch to avoid installation errors.
-# pip install torch
-
-# update pip to latest version for pyproject.toml setup.
 pip install -U pip
+
+# Pin PyTorch to a version compatible with flash-attn==2.8.2.
+# PyTorch>=2.8.0 does not yet have prebuilt flash-attn wheels; pinning to 2.6.0 ensures
+# a successful install. See: https://github.com/NVlabs/Sana/issues/375
+pip install torch==2.6.0+cu128 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
```

## Testing

Verified the install sequence resolves correctly with a fresh conda env on CUDA 12.8.