### PR TITLE
ci: enable fork PR testing + fix autolint label removal

### DIFF
--- a/.github/workflows/bot-autolint.yaml
+++ b/.github/workflows/bot-autolint.yaml
@@ -9,6 +9,10 @@ on:
       - synchronize
       - labeled
       - unlabeled
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
 # run only one unit test for a branch / tag.
 concurrency:
   group: ci-lint-${{ github.head_ref || github.ref }}
@@ -45,6 +49,7 @@ jobs:
           git commit -m "[CI-Lint] Fix code style issues with pre-commit ${{ github.sha }}" -a
           git push
       - name: Remove label(s) after lint
+        if: always()
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: lint wanted

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
         required: false
         type: boolean
         default: false
-  pull_request:
+  pull_request_target:
     types: [labeled, unlabeled, opened, synchronize, reopened]
     paths-ignore:
       - '**.md'
@@ -27,6 +27,9 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       # - name: Set up Python
       #   uses: actions/setup-python@v5
       #   with:
@@ -37,13 +40,16 @@ jobs:
     needs: pre-commit
     if: |
       github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' ||
-      github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests')
+      github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'run-tests')
     runs-on:
       - self-hosted
       - sana-runner
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       # - name: Set up Python
       #   uses: actions/setup-python@v5
       #   with:
@@ -80,13 +86,16 @@ jobs:
     needs: pre-commit
     if: |
       github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' ||
-      github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests')
+      github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'run-tests')
     runs-on:
       - self-hosted
       - sana-runner
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       # - name: Set up Python
       #   uses: actions/setup-python@v5
       #   with:
@@ -123,13 +132,16 @@ jobs:
     needs: pre-commit
     if: |
       github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' ||
-      github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests')
+      github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'run-tests')
     runs-on:
       - self-hosted
       - sana-runner
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       # - name: Set up Python
       #   uses: actions/setup-python@v5
       #   with:
@@ -166,13 +178,16 @@ jobs:
     needs: pre-commit
     if: |
       github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' ||
-      github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests')
+      github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'run-tests')
     runs-on:
       - self-hosted
       - sana-runner
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       # - name: Set up Python
       #   uses: actions/setup-python@v5
       #   with:
@@ -209,13 +224,16 @@ jobs:
     needs: pre-commit
     if: |
       github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' ||
-      github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests')
+      github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'run-tests')
     runs-on:
       - self-hosted
       - sana-runner
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Clean Python caches
         run: |
           echo "Removing stale Python byte code files..."
@@ -248,13 +266,16 @@ jobs:
     needs: pre-commit
     if: |
       github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' ||
-      github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests')
+      github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'run-tests')
     runs-on:
       - self-hosted
       - sana-runner
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Clean Python caches
         run: |
           echo "Removing stale Python byte code files..."
@@ -285,7 +306,7 @@ jobs:
           sana-run --pty -m ci -J test-training-sol-rl bash tests/bash/training/test_training_sol_rl.sh
   remove-label:
     needs: [test-inference, test-training-vae, test-training-fsdp, test-training-video, test-training-longsana]
-    if: always() && github.event_name == 'pull_request'
+    if: always() && github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:


### PR DESCRIPTION
## Summary

- **Enable fork PR testing on self-hosted runners.** Switch `ci.yaml` from `pull_request` to `pull_request_target` so fork PRs get the secrets needed by our self-hosted `sana-runner` (`CONDA_SH_PATH`, `CONDA_ENV_NAME`, `HF_TOKEN`, `SANA_SLURM_*`). Today fork PRs all fail at the env-setup step with empty `CONDA_SH_PATH` because secrets aren't passed to fork-PR `pull_request` events. See PR #379 for an example — every test job failed in ~23s before any test ran.
- **Fix `bot-autolint` label not being removed after lint.** Add a top-level `permissions:` block (`contents: write`, `pull-requests: write`, `issues: write`) so the workflow can push lint fixes and call the labels API. Previously the remove-label step returned 403 `Resource not accessible by integration` and the `lint wanted` label stayed on the PR forever. Also adds `if: always()` so the label is cleared even when an earlier step fails.
- **Remove orphan `tools/scoring/dover/DOVER` gitlink.** It's a 160000-mode submodule entry with no matching `.gitmodules` URL, the directory on disk is empty, and `grep -r dover` finds zero references in the codebase. It produced `fatal: No url found for submodule path 'tools/scoring/dover/DOVER' in .gitmodules` warnings in every CI run.

## Security model for `pull_request_target`

`pull_request_target` runs the workflow definition from the **base branch** (main), so a fork PR cannot modify `ci.yaml` to exfiltrate secrets — that's the core safety property of this trigger. However, fork code is still executed on the runner via `environment_setup.sh`, test scripts, and `pip install -e .`. So the trust gate is human:

- The `run-tests` label is required to start any test job.
- Only users with **triage** permission or higher can add labels — external contributors cannot.
- **Maintainers must `gh pr diff <num>` review before applying `run-tests`** to confirm the PR doesn't introduce malicious setup / build steps that could read secrets at runtime.

Each checkout now sets `ref: \${{ github.event.pull_request.head.sha }}` (so we test PR code, not base) and `persist-credentials: false` (so we don't leave a token in `.git/config` for fork code to find).

## Caveat for `bot-autolint` on fork PRs

The `permissions:` fix lets the label be removed for internal-branch PRs. Fork PRs on a `pull_request` trigger still get a read-only `GITHUB_TOKEN` regardless of declared permissions, so auto-push + label removal will continue to fail there. Switching `bot-autolint` to `pull_request_target` would require rearchitecting it (we can't easily push fixes back to the fork from `pull_request_target`'s base-branch checkout). Out of scope for this PR.

## Test plan

- [ ] Merge to main.
- [ ] Add `run-tests` label on PR #379 (after a `gh pr diff 379` review) and confirm all six self-hosted runner jobs proceed past the env-setup step (i.e., secrets are now populated).
- [ ] Add `lint wanted` label on a small internal-branch PR and confirm the label is auto-removed after the lint workflow finishes.