### PR TITLE
Test HF-hosted Sana video asset link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center" style="border-radius: 10px">
-  <img src="asset/logo.png" width="35%" alt="logo"/>
+  <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/logo.png" width="35%" alt="logo"/>
 </p>
 
 <h3 align="center">
@@ -115,7 +115,7 @@ We introduce **SANA**, a series of efficient diffusion models for high-resolutio
 **In summary**, SANA is a fully open-source framework integrating **efficient training, fast inference, and flexible deployment** for both image and video generation. Deployable on laptop GPUs with **< 8GB VRAM** via 4-bit quantization.
 
 <p align="center" border-raduis="10px">
-  <img src="asset/all.png" width="90%" alt="teaser_page2"/>
+  <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/all.png" width="90%" alt="teaser_page2"/>
 </p>
 
 ## Quick Start
@@ -243,7 +243,7 @@ Thanks [Paper2Video](https://showlab.github.io/Paper2Video/) for generating Jeas
 
 <div align="center">
   <a href="https://showlab.github.io/Paper2Video/assets/huang/huang.mp4" target="_blank">
-    <img src="asset/paper2video.jpg" alt="Presenting Video of SANA" style="width: 60%; margin: 0 auto; display: block">
+    <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/paper2video.jpg" alt="Presenting Video of SANA" style="width: 60%; margin: 0 auto; display: block">
   </a>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
   <img src="asset/logo.png" width="35%" alt="logo"/>
 </p>
 
+<p align="center">
+  <video src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/Video/refiner/sana_ori.mp4" controls muted width="50%"></video>
+</p>
+
 <h3 align="center">
 <a href="https://nvlabs.github.io/Sana/docs/"><b>📚 Docs</b></a> | <a href="https://nvlabs.github.io/Sana/"><b>SANA</b></a> | <a href="https://nvlabs.github.io/Sana/Sana-1.5/"><b>SANA-1.5</b></a> | <a href="https://nvlabs.github.io/Sana/Sprint/"><b>SANA-Sprint</b></a> | <a href="https://nvlabs.github.io/Sana/Video/"><b>SANA-Video</b></a> | <a href="https://nvlabs.github.io/Sana/WM/"><b>SANA-WM</b></a> | <a href="https://nvlabs.github.io/Sana/Sol-RL/"><b>Sol-RL</b></a>
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
   <img src="asset/logo.png" width="35%" alt="logo"/>
 </p>
 
-<p align="center">
-  <a href="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/Video/refiner/sana_ori.mp4">SANA refiner sample video hosted on Hugging Face</a>
-</p>
-
 <h3 align="center">
 <a href="https://nvlabs.github.io/Sana/docs/"><b>📚 Docs</b></a> | <a href="https://nvlabs.github.io/Sana/"><b>SANA</b></a> | <a href="https://nvlabs.github.io/Sana/Sana-1.5/"><b>SANA-1.5</b></a> | <a href="https://nvlabs.github.io/Sana/Sprint/"><b>SANA-Sprint</b></a> | <a href="https://nvlabs.github.io/Sana/Video/"><b>SANA-Video</b></a> | <a href="https://nvlabs.github.io/Sana/WM/"><b>SANA-WM</b></a> | <a href="https://nvlabs.github.io/Sana/Sol-RL/"><b>Sol-RL</b></a>
 
@@ -33,7 +29,7 @@
 Join our [Discord](https://discord.gg/rde6eaE5Ta) to engage in discussions with the community! If you have any questions, run into issues, or are interested in contributing, don't hesitate to reach out!
 
 <p align="center" border-radius="10px">
-  <img src="asset/Sana.jpg" width="90%" alt="teaser_page1"/>
+  <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/Sana.jpg" width="90%" alt="teaser_page1"/>
 </p>
 
 ## News

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <video src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/Video/refiner/sana_ori.mp4" controls muted width="50%"></video>
+  <a href="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/Video/refiner/sana_ori.mp4">SANA refiner sample video hosted on Hugging Face</a>
 </p>
 
 <h3 align="center">

--- a/docs/ComfyUI/comfyui.md
+++ b/docs/ComfyUI/comfyui.md
@@ -25,16 +25,16 @@ python main.py
 
 [Sana workflow](Sana_FlowEuler.json)
 
-![Sana](https://raw.githubusercontent.com/NVlabs/Sana/refs/heads/page/asset/content/comfyui/sana.jpg)
+![Sana](https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/content/comfyui/sana.jpg)
 
 ### A sample for T2I(Sana) + I2V(CogVideoX)
 
 [Sana + CogVideoX workflow](Sana_CogVideoX.json)
 
-[![Sample T2I + I2V](https://raw.githubusercontent.com/NVlabs/Sana/refs/heads/page/asset/content/comfyui/sana-cogvideox.jpg)](https://nvlabs.github.io/Sana/asset/content/comfyui/Sana_CogVideoX_Fun.mp4)
+[![Sample T2I + I2V](https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/content/comfyui/sana-cogvideox.jpg)](https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/content/comfyui/Sana_CogVideoX_Fun.mp4)
 
 ### A sample workflow for Sana 4096x4096 image (18GB GPU is needed)
 
 [Sana workflow](Sana_FlowEuler_4K.json)
 
-![Sana](https://raw.githubusercontent.com/NVlabs/Sana/refs/heads/page/asset/content/comfyui/Sana_4K_workflow.jpg)
+![Sana](https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/content/comfyui/Sana_4K_workflow.jpg)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 <p align="center" style="border-radius: 10px">
-  <img src="https://raw.githubusercontent.com/NVlabs/Sana/refs/heads/main/asset/logo.png" width="50%" alt="Sana Logo"/>
+  <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/logo.png" width="50%" alt="Sana Logo"/>
 </p>
 
 <h3 align="center"><b>⚡️ Efficient High-Resolution Image & Video Generation</b></h3>

--- a/docs/inference_scaling/inference_scaling.md
+++ b/docs/inference_scaling/inference_scaling.md
@@ -1,10 +1,10 @@
 ## Inference Time Scaling for SANA-1.5
 
-![results](results.jpg)
+![results](https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/docs/inference_scaling/results.jpg)
 
 We trained a specialized [NVILA-2B](https://huggingface.co/Efficient-Large-Model/NVILA-Lite-2B-Verifier) model to score images, which we named VISA (VIla as SAna verifier). By selecting the top 4 images from 2,048 candidates, we enhanced the GenEval performance of SD1.5 and SANA-1.5-4.8B v2, increasing their scores from 42 to 87 and 81 to 96, respectively.
 
-![curve](scaling_curve.jpg)
+![curve](https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/docs/inference_scaling/scaling_curve.jpg)
 
 Even for smaller number of candidates, like 32, we can also push the performance over 90% for SANA-1.5-4.8B v2 in the GenEval.
 

--- a/docs/longsana.md
+++ b/docs/longsana.md
@@ -1,5 +1,5 @@
 <p align="center" style="border-radius: 10px">
-  <img src="https://nvlabs.github.io/Sana/Video/logo.svg" width="70%" alt="SANA-Sprint Logo"/>
+  <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/Video/logo.svg" width="70%" alt="SANA-Sprint Logo"/>
 </p>
 
 # 🎬 LongSANA: SANA-Video + [LongLive](https://github.com/NVlabs/LongLive)

--- a/docs/sana.md
+++ b/docs/sana.md
@@ -1,5 +1,5 @@
 <p align="center" style="border-radius: 10px">
-  <img src="https://raw.githubusercontent.com/NVlabs/Sana/refs/heads/main/asset/logo.png" width="40%" alt="Sana Logo"/>
+  <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/logo.png" width="40%" alt="Sana Logo"/>
 </p>
 
 # ⚡️ Sana: Efficient High-Resolution Image Synthesis with Linear Diffusion Transformer

--- a/docs/sana_controlnet.md
+++ b/docs/sana_controlnet.md
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0 -->
 We incorporate a ControlNet-like(https://github.com/lllyasviel/ControlNet) module enables fine-grained control over text-to-image diffusion models. We implement a ControlNet-Transformer architecture, specifically tailored for Transformers, achieving explicit controllability alongside high-quality image generation.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/NVlabs/Sana/refs/heads/page/asset/content/controlnet/sana_controlnet.jpg"  height=480>
+  <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/content/controlnet/sana_controlnet.jpg"  height=480>
 </p>
 
 ## Inference of `Sana + ControlNet`
@@ -33,7 +33,7 @@ python app/app_sana_controlnet_hed.py \
 ```
 
 <p align="center" border-raduis="10px">
-  <img src="https://nvlabs.github.io/Sana/asset/content/controlnet/controlnet_app.jpg" width="90%" alt="teaser_page2"/>
+  <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/content/controlnet/controlnet_app.jpg" width="90%" alt="teaser_page2"/>
 </p>
 
 ### 2). Inference with JSON file

--- a/docs/sana_cosmos_rl.md
+++ b/docs/sana_cosmos_rl.md
@@ -1,5 +1,5 @@
 <p align="center" style="border-radius: 10px">
-  <img src="https://nvlabs.github.io/Sana/assets/cosmos-rl/sana-cosmos-rl-logo.png" width="90%" alt="SANA × Cosmos-RL Logo"/>
+  <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/assets/cosmos-rl/sana-cosmos-rl-logo.png" width="90%" alt="SANA × Cosmos-RL Logo"/>
 </p>
 
 # SANA × Cosmos-RL: Post-Training (SFT/RL) for Image & Video Diffusion Models
@@ -12,7 +12,7 @@
 We have partnered with [Cosmos-RL](https://github.com/nvidia-cosmos/cosmos-rl) to provide a complete RL infrastructure for SANA. This document summarizes how to post-train (SFT/RL) SANA-Image or SANA-Video on Cosmos-RL.
 
 <p align="center" style="border-radius: 10px">
-  <img src="https://nvlabs.github.io/Sana/assets/cosmos-rl/teaser.png" width="90%" alt="SANA × Cosmos-RL Teaser"/>
+  <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/assets/cosmos-rl/teaser.png" width="90%" alt="SANA × Cosmos-RL Teaser"/>
 </p>
 
 ## Overview

--- a/docs/sana_lora_dreambooth.md
+++ b/docs/sana_lora_dreambooth.md
@@ -132,13 +132,13 @@ Refer to the [official documentation](https://huggingface.co/docs/diffusers/main
 We show some samples during Sana-LoRA fine-tuning process below.
 
 <p align="center" border-raduis="10px">
-  <img src="https://nvlabs.github.io/Sana/asset/content/dreambooth/step0.jpg" width="90%" alt="sana-lora-step0"/>
+  <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/content/dreambooth/step0.jpg" width="90%" alt="sana-lora-step0"/>
   <br>
   <em> training samples at step=0 </em>
 </p>
 
 <p align="center" border-raduis="10px">
-  <img src="https://nvlabs.github.io/Sana/asset/content/dreambooth/step500.jpg" width="90%" alt="sana-lora-step500"/>
+  <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/content/dreambooth/step500.jpg" width="90%" alt="sana-lora-step500"/>
   <br>
   <em> training samples at step=500 </em>
 </p>

--- a/docs/sana_sprint.md
+++ b/docs/sana_sprint.md
@@ -1,5 +1,5 @@
 <p align="center" style="border-radius: 10px">
-  <img src="https://nvlabs.github.io/Sana/Sprint/asset/SANA-Sprint.png" width="60%" alt="SANA-Sprint Logo"/>
+  <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/Sprint/asset/SANA-Sprint.png" width="60%" alt="SANA-Sprint Logo"/>
 </p>
 
 # 🏃SANA-Sprint: One-Step Diffusion with Continuous-Time Consistency Distillation

--- a/docs/sana_video.md
+++ b/docs/sana_video.md
@@ -217,7 +217,7 @@ python app/sana_video_refiner_pipeline_diffusers.py \
 
 <div style="display: flex; gap: 16px; margin: 20px 0; width: 100%;">
   <div style="flex: 1; min-width: 0; text-align: center;">
-    <video src="https://nvlabs.github.io/Sana/Video/refiner/sana_ori.mp4" autoplay muted loop playsinline style="width: 100%; border-radius: 8px; display: block;"></video>
+    <video src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/Video/refiner/sana_ori.mp4" autoplay muted loop playsinline style="width: 100%; border-radius: 8px; display: block;"></video>
     <p style="margin-top: 8px; font-size: 14px; color: #666;"><strong>Stage 1:</strong> SANA-Video Base (720p)</p>
   </div>
   <div style="flex: 1; min-width: 0; text-align: center;">

--- a/docs/sana_video.md
+++ b/docs/sana_video.md
@@ -221,7 +221,7 @@ python app/sana_video_refiner_pipeline_diffusers.py \
     <p style="margin-top: 8px; font-size: 14px; color: #666;"><strong>Stage 1:</strong> SANA-Video Base (720p)</p>
   </div>
   <div style="flex: 1; min-width: 0; text-align: center;">
-    <video src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/Video/refiner/sana_refiner.mp4" autoplay muted loop playsinline style="width: 100%; border-radius: 8px; display: block;"></video>
+    <video src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/Video/refiner/sana_ltx2_refined.mp4" autoplay muted loop playsinline style="width: 100%; border-radius: 8px; display: block;"></video>
     <p style="margin-top: 8px; font-size: 14px; color: #666;"><strong>Stage 2:</strong> LTX2 Refined (2K)</p>
   </div>
 </div>

--- a/docs/sana_video.md
+++ b/docs/sana_video.md
@@ -1,5 +1,5 @@
 <p align="center" style="border-radius: 10px">
-  <img src="https://nvlabs.github.io/Sana/Video/logo.svg" width="70%" alt="SANA-Sprint Logo"/>
+  <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/Video/logo.svg" width="70%" alt="SANA-Sprint Logo"/>
 </p>
 
 # 🎬 SANA-Video: Efficient Video Generation with Block Linear Diffusion Transformer
@@ -116,7 +116,7 @@ negative_prompt = "A chaotic sequence with misshapen, deformed limbs eavy motion
 motion_prompt = f" motion score: {motion_score}."
 prompt = prompt + motion_prompt
 
-image = load_image("https://raw.githubusercontent.com/NVlabs/Sana//heads/main/asset/samples/i2v-1.png")
+image = load_image("https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/samples/i2v-1.png")
 
 output = pipe(
     image=image,
@@ -221,7 +221,7 @@ python app/sana_video_refiner_pipeline_diffusers.py \
     <p style="margin-top: 8px; font-size: 14px; color: #666;"><strong>Stage 1:</strong> SANA-Video Base (720p)</p>
   </div>
   <div style="flex: 1; min-width: 0; text-align: center;">
-    <video src="https://nvlabs.github.io/Sana/Video/refiner/sana_refiner.mp4" autoplay muted loop playsinline style="width: 100%; border-radius: 8px; display: block;"></video>
+    <video src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/Video/refiner/sana_refiner.mp4" autoplay muted loop playsinline style="width: 100%; border-radius: 8px; display: block;"></video>
     <p style="margin-top: 8px; font-size: 14px; color: #666;"><strong>Stage 2:</strong> LTX2 Refined (2K)</p>
   </div>
 </div>

--- a/docs/sana_wm.md
+++ b/docs/sana_wm.md
@@ -1,5 +1,5 @@
 <p align="center" style="border-radius: 10px">
-  <img src="https://raw.githubusercontent.com/NVlabs/Sana/refs/heads/main/asset/sana-wm-logo.png" width="70%" alt="SANA-WM Logo"/>
+  <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/sana-wm-logo.png" width="70%" alt="SANA-WM Logo"/>
 </p>
 
 # 🌍 SANA-WM: Efficient Minute-Scale World Modeling with Hybrid Linear Diffusion Transformer
@@ -11,7 +11,7 @@
 </div>
 
 <div align="center">
-  <video src="https://nvlabs.github.io/Sana/WM/media/videos/hero_reel_v9.mp4#t=1" autoplay playsinline controls muted loop width="90%" onloadedmetadata="this.currentTime=1;this.playbackRate=2"></video>
+  <video src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/WM/media/videos/hero_reel_v9.mp4#t=1" autoplay playsinline controls muted loop width="90%" onloadedmetadata="this.currentTime=1;this.playbackRate=2"></video>
 </div>
 
 ## 📽️ About SANA-WM

--- a/docs/sglang.md
+++ b/docs/sglang.md
@@ -1,5 +1,5 @@
 <p align="center" style="border-radius: 10px">
-  <img src="https://raw.githubusercontent.com/NVlabs/Sana/refs/heads/main/asset/logo.png" width="40%" alt="Sana Logo"/>
+  <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/logo.png" width="40%" alt="Sana Logo"/>
 </p>
 
 # 🚀 SGLang: High-Performance Serving for SANA

--- a/docs/sol_rl.md
+++ b/docs/sol_rl.md
@@ -1,5 +1,5 @@
 <p align="center" style="border-radius: 10px">
-  <img src="https://nvlabs.github.io/Sana/Sol-RL/asset/sol-rl_logo.png" width="82%" alt="Sol-RL Logo"/>
+  <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/Sol-RL/asset/sol-rl_logo.png" width="82%" alt="Sol-RL Logo"/>
 </p>
 
 # Sol-RL: FP4 Explore, BF16 Train for SANA, FLUX.1, and SD3.5-L

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,8 +37,8 @@ theme:
     - content.code.annotate
   icon:
     repo: fontawesome/brands/github
-  logo: https://raw.githubusercontent.com/NVlabs/Sana/refs/heads/main/asset/logo.png
-  favicon: https://raw.githubusercontent.com/NVlabs/Sana/refs/heads/main/asset/logo.png
+  logo: https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/logo.png
+  favicon: https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/logo.png
 plugins:
   - search
   - mkdocstrings:


### PR DESCRIPTION
## Summary
- Replace one SANA-Video refiner sample video URL with the corresponding Hugging Face Dataset `resolve/main` URL.
- This is intentionally limited to one link to validate GitHub rendering before bulk asset URL migration.

## Validation
- Uploaded `Video/refiner/sana_ori.mp4` to `Efficient-Large-Model/Sana-assets`.
- Verified the HF URL returns `200 OK` with `Content-Type: video/mp4` and `Content-Disposition: inline`.
- Checked GitHub Markdown API keeps the `<video src="...">` tag for the HF URL.

HF asset commit: https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/commit/dbd032bc1fc979c66eafca05dadef83dbecc2d33