### PR TITLE
fix(sana-wm): add public benchmark eval scripts

### DIFF
--- a/docs/sana-wm-bench.md
+++ b/docs/sana-wm-bench.md
@@ -68,6 +68,32 @@ The rest of this guide assumes:
 BENCH=data/SANA-WM-Bench
 ```
 
+## Evaluation Dependencies
+
+Run the benchmark from a Sana-WM runtime environment with the extra evaluation
+packages installed:
+
+```bash
+python -m pip install vbench decord lpips pyiqa==0.1.10 facexlib==0.3.0
+```
+
+Camera pose accuracy additionally requires Pi3 to be importable:
+
+```bash
+python - <<'PY'
+from pi3.models.pi3 import Pi3
+print("Pi3 OK")
+PY
+```
+
+If the inference environment has strict package pins, keep the VBench/LPIPS
+extras in a separate evaluation environment or user site and use the same
+repository checkout and result directory.
+
+The first VBench/LPIPS run downloads the official evaluation weights into the
+user cache, including DINO, AMT, ViCLIP, and AlexNet checkpoints. Make sure the
+evaluation job has network access or a pre-populated cache.
+
 ## Run One Scene
 
 Download or point `BENCH` at the release directory:
@@ -237,7 +263,7 @@ conventions:
 - `TransErr` and `CamMC`: means of `TransErr_rel` and `CamMC_rel`.
 - `Delta IQ`: `temporal_degradation.json["trend"]["imaging_quality"]["degradation"]`.
 
-Use the evaluator scripts from your evaluation environment together with
+Use the bundled evaluator scripts under `tools/metrics/sana_wm/` together with
 this result layout:
 
 ```text
@@ -262,7 +288,7 @@ explicitly:
 ```bash
 BENCH=data/SANA-WM-Bench
 METHOD_DIR=results/sana_wm_bidirectional_refined
-PYTHONPATH="$PWD:${PYTHONPATH:-}" python /path/to/eval_unified.py \
+PYTHONPATH="$PWD:${PYTHONPATH:-}" python tools/metrics/sana_wm/eval_unified.py \
   --method_dir "$METHOD_DIR" \
   --split simple_60s \
   --benchmark_meta "$BENCH/benchmark_v2_smooth_60s/scene_trajectories_v2.json" \
@@ -275,7 +301,7 @@ PYTHONPATH="$PWD:${PYTHONPATH:-}" python /path/to/eval_unified.py \
   --window_sec 10 \
   --skip_first_frame auto
 
-PYTHONPATH="$PWD:${PYTHONPATH:-}" python /path/to/eval_unified.py \
+PYTHONPATH="$PWD:${PYTHONPATH:-}" python tools/metrics/sana_wm/eval_unified.py \
   --method_dir "$METHOD_DIR" \
   --split hard_60s \
   --benchmark_meta "$BENCH/benchmark_v2_hard_60s/scene_trajectories_v2.json" \
@@ -290,9 +316,8 @@ PYTHONPATH="$PWD:${PYTHONPATH:-}" python /path/to/eval_unified.py \
 ```
 
 Camera accuracy is GPU-backed and should be run as a separate 8-GPU Slurm job.
-Because the release manifest stores dataset-relative `camera_path` entries, run
-the pose script from the dataset root while using absolute result and output
-paths:
+Run the pose script from the repository root and point it at the downloaded
+benchmark manifest:
 
 ```bash
 cat > run_sana_wm_pose_eval.sbatch <<'EOF'
@@ -309,17 +334,18 @@ set -euo pipefail
 
 PY=/path/to/python
 ACCEL=/path/to/accelerate
+REPO=/path/to/Sana
 BENCH=data/SANA-WM-Bench
 METHOD_DIR=/path/to/results/sana_wm_bidirectional_refined
 
-cd "$BENCH"
+cd "$REPO"
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 
 run_pose() {
   local split="$1"
   local split_dir="$2"
   "$ACCEL" launch --num_processes=8 --mixed_precision=bf16 \
-    /path/to/eval_benchmark_poses.py \
+    tools/metrics/sana_wm/eval_benchmark_poses.py \
     --result_folder "$METHOD_DIR/$split" \
     --manifest "$BENCH/$split_dir/sanawm_export_v2/run_manifest.jsonl" \
     --interval 4 \
@@ -331,7 +357,7 @@ run_pose() {
 run_pose simple_60s benchmark_v2_smooth_60s
 run_pose hard_60s benchmark_v2_hard_60s
 
-"$PY" /path/to/aggregate_results.py \
+"$PY" tools/metrics/sana_wm/aggregate_results.py \
   --results_root "$(dirname "$METHOD_DIR")" \
   --json_out "$METHOD_DIR/metrics_80scene/aggregate_results.json" \
   --md_out "$METHOD_DIR/metrics_80scene/aggregate_results.md"

--- a/tools/metrics/sana_wm/aggregate_results.py
+++ b/tools/metrics/sana_wm/aggregate_results.py
@@ -1,0 +1,405 @@
+"""Aggregate SANA-WM benchmark results into a comparison table.
+
+Walks `results/<method>/{eval/<split>/summary.json,
+<split>/eval_poses.json, eval/<split>/temporal_degradation.json}` and emits
+markdown and JSON summaries.
+
+Columns (per method × split):
+  VBench Total / Quality / Semantic
+  Revisit PSNR / SSIM / LPIPS
+  Camera RotErr° / TransErr_rel / CamMC_rel
+  Temporal degradation (first → last imaging_quality)
+
+Usage:
+  python tools/metrics/sana_wm/aggregate_results.py \
+      --results_root results \
+      --md_out results/sana_wm_benchmark.md \
+      --json_out results/sana_wm_benchmark.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+from typing import Any
+
+RESULTS_ROOT = "results"
+OUT_MD = os.path.join("results", "sana_wm_benchmark.md")
+OUT_JSON = os.path.join("results", "sana_wm_benchmark.json")
+
+
+def _safe_load(path: str) -> dict | None:
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _rot_errors_as_degrees(rows: list[dict[str, Any]]) -> list[float]:
+    """Return RotErr values in degrees, supporting old rad-valued JSON files."""
+    out: list[float] = []
+    for row in rows:
+        value = float(row["RotErr"])
+        unit = str(row.get("RotErr_unit", "")).lower()
+        if unit == "deg":
+            out.append(value)
+        elif unit == "rad" or abs(value) <= math.pi + 1e-6:
+            out.append(value * 180.0 / math.pi)
+        else:
+            out.append(value)
+    return out
+
+
+# Mirrors VBENCH_DIM_WEIGHTS / NORMALIZE_DIC / compute_vbench_total in
+# eval_unified.py. Kept local to avoid heavy torch imports during aggregation.
+_VBENCH_QUALITY_DIMS = [
+    "subject_consistency",
+    "background_consistency",
+    "temporal_flickering",
+    "motion_smoothness",
+    "aesthetic_quality",
+    "imaging_quality",
+    "dynamic_degree",
+]
+_VBENCH_SEMANTIC_DIMS = [
+    "object_class",
+    "multiple_objects",
+    "human_action",
+    "color",
+    "spatial_relationship",
+    "scene",
+    "appearance_style",
+    "temporal_style",
+    "overall_consistency",
+]
+_VBENCH_DIM_WEIGHTS = {d: 1.0 for d in _VBENCH_QUALITY_DIMS + _VBENCH_SEMANTIC_DIMS}
+_VBENCH_DIM_WEIGHTS["dynamic_degree"] = 0.5
+_NORMALIZE_DIC = {
+    "subject_consistency": (0.1462, 1.0),
+    "background_consistency": (0.2615, 1.0),
+    "temporal_flickering": (0.6293, 1.0),
+    "motion_smoothness": (0.7060, 0.9975),
+    "dynamic_degree": (0.0, 1.0),
+    "aesthetic_quality": (0.0, 1.0),
+    "imaging_quality": (0.0, 1.0),
+    "object_class": (0.0, 1.0),
+    "multiple_objects": (0.0, 1.0),
+    "human_action": (0.0, 1.0),
+    "color": (0.0, 1.0),
+    "spatial_relationship": (0.0, 1.0),
+    "scene": (0.0, 1.0),
+    "appearance_style": (0.0, 1.0),
+    "temporal_style": (0.0, 1.0),
+    "overall_consistency": (0.0, 1.0),
+}
+
+
+def _normalize_score(dim: str, raw: float) -> float:
+    if dim not in _NORMALIZE_DIC:
+        return raw
+    mn, mx = _NORMALIZE_DIC[dim]
+    if mx - mn < 1e-8:
+        return raw
+    return max(0.0, min(1.0, (raw - mn) / (mx - mn)))
+
+
+def _compute_vbench_total_local(scores: dict[str, float]) -> dict[str, float]:
+    norm = {d: _normalize_score(d, s) for d, s in scores.items()}
+    q_dims = [d for d in _VBENCH_QUALITY_DIMS if d in norm]
+    if q_dims:
+        q_w = sum(_VBENCH_DIM_WEIGHTS.get(d, 1.0) for d in q_dims)
+        quality = sum(norm[d] * _VBENCH_DIM_WEIGHTS.get(d, 1.0) for d in q_dims) / q_w
+    else:
+        quality = 0.0
+    s_dims = [d for d in _VBENCH_SEMANTIC_DIMS if d in norm]
+    if s_dims:
+        s_w = sum(_VBENCH_DIM_WEIGHTS.get(d, 1.0) for d in s_dims)
+        semantic = sum(norm[d] * _VBENCH_DIM_WEIGHTS.get(d, 1.0) for d in s_dims) / s_w
+    else:
+        semantic = 0.0
+    total = (4.0 * quality + 1.0 * semantic) / 5.0
+    return {
+        "quality_score": round(quality, 4),
+        "semantic_score": round(semantic, 4),
+        "total_score": round(total, 4),
+    }
+
+
+def _recompute_vbench_from_raw(eval_dir: str) -> dict[str, float]:
+    """Recover per-dimension VBench scores from raw eval_<dim>_eval_results.json files.
+
+    Used as a fallback when summary.json was overwritten without a `vbench` block
+    (e.g. by a later metric run such as LPIPS revisit).
+    """
+    scores: dict[str, float] = {}
+    if not os.path.isdir(eval_dir):
+        return scores
+    import math
+
+    for fname in os.listdir(eval_dir):
+        if not fname.startswith("eval_") or not fname.endswith("_eval_results.json"):
+            continue
+        path = os.path.join(eval_dir, fname)
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            continue
+        for dim, payload in data.items():
+            if dim in scores:
+                continue
+            if not isinstance(payload, list) or len(payload) == 0:
+                continue
+            try:
+                val = float(payload[0])
+            except (TypeError, ValueError):
+                continue
+            if math.isnan(val):
+                continue
+            scores[dim] = val
+    return scores
+
+
+def _gather_one(results_root: str, method: str, split: str) -> dict[str, Any]:
+    """Collect every available metric for one (method, split)."""
+    base = os.path.join(results_root, method)
+    rec: dict[str, Any] = {"method": method, "split": split}
+
+    # method_info
+    mi = _safe_load(os.path.join(base, "method_info.json"))
+    if mi:
+        rec["method_info"] = {
+            "model": mi.get("model"),
+            "variant": mi.get("variant"),
+            "fps": mi.get("fps"),
+            "resolution": mi.get("resolution"),
+        }
+
+    # summary.json (vbench + revisit)
+    summary = _safe_load(os.path.join(base, "eval", split, "summary.json"))
+    eval_dir = os.path.join(base, "eval", split)
+    if summary and "vbench" in summary:
+        v = summary["vbench"]
+        rec["vbench"] = {
+            "total": v.get("total_score"),
+            "quality": v.get("quality_score"),
+            "semantic": v.get("semantic_score"),
+        }
+    else:
+        # Fallback: load vbench_scores.json if present
+        vs = _safe_load(os.path.join(eval_dir, "vbench_scores.json"))
+        if vs:
+            rec["vbench"] = {
+                "total": vs.get("total_score"),
+                "quality": vs.get("quality_score"),
+                "semantic": vs.get("semantic_score"),
+            }
+        else:
+            # Deepest fallback: recompute from raw eval_*_eval_results.json
+            scores = _recompute_vbench_from_raw(eval_dir)
+            if scores:
+                total = _compute_vbench_total_local(scores)
+                rec["vbench"] = {
+                    "total": total["total_score"],
+                    "quality": total["quality_score"],
+                    "semantic": total["semantic_score"],
+                }
+
+    # revisit (might be in summary, or in revisit_consistency.json)
+    revisit = _safe_load(os.path.join(base, "eval", split, "revisit_consistency.json"))
+    if revisit and "summary" in revisit:
+        s = revisit["summary"]
+        rec["revisit"] = {
+            "psnr": s.get("overall_mean_psnr"),
+            "ssim": s.get("overall_mean_ssim"),
+            "lpips": s.get("overall_mean_lpips"),
+            "n_pairs": s.get("n_total_pairs"),
+            "per_category": s.get("per_category"),
+        }
+    elif summary and "revisit" in summary:
+        s = summary["revisit"]
+        rec["revisit"] = {
+            "psnr": s.get("overall_mean_psnr"),
+            "ssim": s.get("overall_mean_ssim"),
+            "lpips": s.get("overall_mean_lpips"),
+        }
+
+    # camera (eval_poses.json sits in result_folder = base/split). The schema is
+    # a flat dict {scene_id: {"RotErr": ..., "TransErr_rel": ..., "CamMC_rel": ...,
+    # "scene_type": ..., "n_frames": ...}, ...}. Aggregate here.
+    poses = _safe_load(os.path.join(base, split, "eval_poses.json"))
+    if poses:
+        import numpy as _np
+
+        rows: list[dict[str, Any]] = []
+        trn, cmc = [], []
+        per_cat: dict[str, dict[str, list[float]]] = {}
+        for scene_id, v in poses.items():
+            if not isinstance(v, dict) or "RotErr" not in v:
+                continue
+            rows.append(v)
+            trn.append(float(v.get("TransErr_rel", 0.0)))
+            cmc.append(float(v.get("CamMC_rel", 0.0)))
+            cat = v.get("scene_type", "unknown")
+            per_cat.setdefault(cat, {"rot": [], "trn": [], "cmc": []})
+            per_cat[cat]["trn"].append(trn[-1])
+            per_cat[cat]["cmc"].append(cmc[-1])
+        rot_deg = _rot_errors_as_degrees(rows)
+        for row, rot in zip(rows, rot_deg):
+            cat = row.get("scene_type", "unknown")
+            per_cat[cat]["rot"].append(rot)
+        if rot_deg:
+            rec["camera"] = {
+                "rot_err_deg": float(_np.mean(rot_deg)),
+                "trans_err_rel": float(_np.mean(trn)),
+                "cam_mc_rel": float(_np.mean(cmc)),
+                "n_scenes": len(rot_deg),
+                "per_category": {
+                    cat: {
+                        "rot_err_deg": float(_np.mean(d["rot"])),
+                        "trans_err_rel": float(_np.mean(d["trn"])),
+                        "cam_mc_rel": float(_np.mean(d["cmc"])),
+                        "n_scenes": len(d["rot"]),
+                    }
+                    for cat, d in per_cat.items()
+                },
+            }
+
+    # temporal degradation. Schema: {"windows": {wname: {dim: score}}, "trend": {dim: {...}}}
+    temp = _safe_load(os.path.join(base, "eval", split, "temporal_degradation.json"))
+    if temp:
+        trend = temp.get("trend", {})
+        windows = temp.get("windows", {})
+        iq = trend.get("imaging_quality", {})
+        rec["temporal"] = {
+            "n_windows": len(windows),
+            "imaging_quality_first": iq.get("first_window"),
+            "imaging_quality_last": iq.get("last_window"),
+            "imaging_quality_drop": iq.get("degradation"),
+            "trend": trend,
+        }
+
+    return rec
+
+
+def _format_cell(value: Any, fmt: str = "{:.3f}") -> str:
+    if value is None:
+        return "—"
+    try:
+        return fmt.format(value)
+    except (ValueError, TypeError):
+        return str(value)
+
+
+def _build_md(records: list[dict[str, Any]]) -> str:
+    lines = []
+    lines.append("# SANA-WM Benchmark Evaluation Results\n")
+    lines.append("Auto-generated by `tools/metrics/sana_wm/aggregate_results.py`.\n")
+    lines.append("")
+
+    # Split into per-split tables
+    for split in ("simple_60s", "hard_60s"):
+        sub = [r for r in records if r["split"] == split]
+        if not sub:
+            continue
+        lines.append(f"## Split: `{split}`\n")
+        lines.append(
+            "| Method | VBench Total | Quality | Semantic | "
+            "Revisit PSNR↑ | SSIM↑ | LPIPS↓ | "
+            "RotErr°↓ | TransErr_rel↓ | CamMC_rel↓ | "
+            "Temp IQ first | last | drop |"
+        )
+        lines.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+        for r in sorted(sub, key=lambda x: x["method"]):
+            v = r.get("vbench", {})
+            rv = r.get("revisit", {})
+            cm = r.get("camera", {})
+            tm = r.get("temporal", {})
+            lines.append(
+                f"| `{r['method']}` "
+                f"| {_format_cell(v.get('total'), '{:.4f}')} "
+                f"| {_format_cell(v.get('quality'), '{:.4f}')} "
+                f"| {_format_cell(v.get('semantic'), '{:.4f}')} "
+                f"| {_format_cell(rv.get('psnr'), '{:.2f}')} "
+                f"| {_format_cell(rv.get('ssim'), '{:.4f}')} "
+                f"| {_format_cell(rv.get('lpips'), '{:.4f}')} "
+                f"| {_format_cell(cm.get('rot_err_deg'), '{:.2f}')} "
+                f"| {_format_cell(cm.get('trans_err_rel'), '{:.4f}')} "
+                f"| {_format_cell(cm.get('cam_mc_rel'), '{:.4f}')} "
+                f"| {_format_cell(tm.get('imaging_quality_first'), '{:.4f}')} "
+                f"| {_format_cell(tm.get('imaging_quality_last'), '{:.4f}')} "
+                f"| {_format_cell(tm.get('imaging_quality_drop'), '{:+.4f}')} |"
+            )
+        lines.append("")
+
+    # Per-category revisit breakdown (if available)
+    cat_rows: list[str] = []
+    for r in records:
+        rv = r.get("revisit", {}) or {}
+        per_cat = rv.get("per_category") or {}
+        for cat, cs in per_cat.items():
+            cat_rows.append(
+                f"| `{r['method']}` | {r['split']} | {cat} "
+                f"| {_format_cell(cs.get('mean_psnr'), '{:.2f}')} "
+                f"| {_format_cell(cs.get('mean_ssim'), '{:.4f}')} "
+                f"| {_format_cell(cs.get('mean_lpips'), '{:.4f}')} "
+                f"| {cs.get('n_scenes', '—')} |"
+            )
+    if cat_rows:
+        lines.append("## Revisit per-category breakdown\n")
+        lines.append("| Method | Split | Category | PSNR↑ | SSIM↑ | LPIPS↓ | N scenes |")
+        lines.append("|---|---|---|---:|---:|---:|---:|")
+        lines.extend(cat_rows)
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results_root", default=RESULTS_ROOT, help="Root containing method/ subdirs")
+    parser.add_argument("--md_out", default=OUT_MD)
+    parser.add_argument("--json_out", default=OUT_JSON)
+    args = parser.parse_args()
+
+    methods = sorted(d for d in os.listdir(args.results_root) if os.path.isdir(os.path.join(args.results_root, d)))
+
+    records: list[dict[str, Any]] = []
+    for method in methods:
+        for split in ("simple_60s", "hard_60s", "simple", "hard"):
+            video_dir = os.path.join(args.results_root, method, split)
+            if not os.path.isdir(video_dir):
+                continue
+            # Skip `eval` subdir as a split
+            if split == "eval":
+                continue
+            rec = _gather_one(args.results_root, method, split)
+            # Only keep if any metric present
+            if any(k in rec for k in ("vbench", "revisit", "camera", "temporal")):
+                records.append(rec)
+
+    json_dir = os.path.dirname(args.json_out)
+    if json_dir:
+        os.makedirs(json_dir, exist_ok=True)
+    with open(args.json_out, "w") as f:
+        json.dump({"records": records}, f, indent=2)
+
+    md = _build_md(records)
+    md_dir = os.path.dirname(args.md_out)
+    if md_dir:
+        os.makedirs(md_dir, exist_ok=True)
+    with open(args.md_out, "w") as f:
+        f.write(md)
+
+    print(f"Wrote {len(records)} records:")
+    print(f"  Markdown: {args.md_out}")
+    print(f"  JSON:     {args.json_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/metrics/sana_wm/eval_benchmark_poses.py
+++ b/tools/metrics/sana_wm/eval_benchmark_poses.py
@@ -1,0 +1,392 @@
+"""Evaluate camera pose accuracy for the SANA-WM benchmark.
+
+Runs Pi3 on generated videos and compares estimated poses with GT poses
+from the benchmark NPZ files. This does not require GT videos -- only GT
+pose trajectories from the benchmark manifest.
+
+Usage:
+    accelerate launch --num_processes=8 --mixed_precision=bf16 \
+        tools/metrics/sana_wm/eval_benchmark_poses.py \
+        --result_folder output/wm_benchmark/scale_30/ \
+        --manifest data/SANA-WM-Bench/benchmark_v2_smooth_60s/sanawm_export_v2/run_manifest.jsonl
+"""
+
+import argparse
+import json
+import os
+import sys
+from glob import glob
+from typing import Dict
+
+import numpy as np
+import torch
+from accelerate import Accelerator
+from tqdm import tqdm
+
+# Add Pi3 to path
+pi3_path = os.path.join(os.path.dirname(__file__), "Pi3")
+if os.path.exists(pi3_path):
+    sys.path.append(pi3_path)
+
+try:
+    from .pose_utils import metric, relative_pose, run_pi3_inference_batch
+except ImportError:
+    from pose_utils import metric, relative_pose, run_pi3_inference_batch
+
+
+def load_manifest(manifest_path: str) -> Dict[str, dict]:
+    """Load benchmark manifest, keyed by scene_id."""
+    scenes = {}
+    with open(manifest_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            entry = json.loads(line)
+            scenes[entry["id"]] = entry
+    return scenes
+
+
+def _dataset_root_from_manifest(manifest_path: str) -> str:
+    """Return the dataset root for a SANA-WM manifest path."""
+    export_dir = os.path.dirname(os.path.abspath(manifest_path))
+    split_dir = os.path.dirname(export_dir)
+    return os.path.dirname(split_dir)
+
+
+def _resolve_camera_path(camera_path: str, dataset_root: str) -> str:
+    """Resolve dataset-relative camera paths from `run_manifest.jsonl`."""
+    if os.path.isabs(camera_path):
+        return camera_path
+    return os.path.join(dataset_root, camera_path)
+
+
+def load_gt_poses(camera_path: str, num_frames: int = 961) -> torch.Tensor:
+    """Load GT c2w poses from sanawm NPZ.
+
+    Returns:
+        (T, 4, 4) float32 tensor of camera-to-world poses, relativized to first frame.
+    """
+    data = np.load(camera_path)
+    c2w = data["c2w"][:num_frames].astype(np.float32)  # (T, 4, 4)
+    poses = torch.from_numpy(c2w).float()
+    # Relativize to first frame
+    poses = relative_pose(poses, "left")
+    return poses
+
+
+def _auto_detect_manifest(result_folder: str) -> str:
+    """Infer the matching benchmark manifest from a result_folder path.
+
+    Looks at the trailing path component (split name) and maps to the
+    correct sanawm export directory.
+
+    Args:
+        result_folder: e.g. ".../results/sana_wm_bidirectional/simple_60s"
+
+    Returns:
+        Path to the run_manifest.jsonl for that split.
+    """
+    split_to_bench = {
+        "simple": "benchmark_v2_smooth",
+        "simple_60s": "benchmark_v2_smooth_60s",
+        "hard": "benchmark_v2_hard",
+        "hard_60s": "benchmark_v2_hard_60s",
+    }
+    split = os.path.basename(os.path.normpath(result_folder))
+    bench_dir = split_to_bench.get(split)
+    if bench_dir is None:
+        # Fallback: default to smooth_60s
+        bench_dir = "benchmark_v2_smooth_60s"
+    return os.path.join("data", "SANA-WM-Bench", bench_dir, "sanawm_export_v2", "run_manifest.jsonl")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Benchmark camera control evaluation")
+    parser.add_argument("--result_folder", type=str, required=True, help="Folder with scene_id_generated.mp4 files")
+    parser.add_argument(
+        "--manifest",
+        type=str,
+        default=None,
+        help="Path to run_manifest.jsonl. If unset, auto-detected from result_folder split name.",
+    )
+    parser.add_argument("--pi3_ckpt", type=str, default="yyfz233/Pi3")
+    parser.add_argument("--interval", type=int, default=4, help="Frame sampling interval for Pi3")
+    parser.add_argument("--batch_size", type=int, default=4)
+    parser.add_argument("--output", type=str, default=None, help="Output JSON (default: result_folder/eval_poses.json)")
+    parser.add_argument(
+        "--dump_trajectories",
+        action="store_true",
+        help="Also dump raw aligned Pi3 / GT trajectories as NPZ (under <result_folder>/trajectories/).",
+    )
+    parser.add_argument(
+        "--scenes",
+        type=str,
+        default=None,
+        help=(
+            "Optional comma-separated scene IDs to restrict the evaluation "
+            "(e.g. 'game_style_001,indoor_003'). Forces re-evaluation of "
+            "just those scenes even if already in the cache."
+        ),
+    )
+    parser.add_argument(
+        "--skip_first_frame",
+        type=str,
+        default="auto",
+        choices=["auto", "yes", "no"],
+        help=(
+            "Drop frame 0 of every video (and its corresponding GT pose) "
+            "before computing pose-error metrics. Refiner methods only "
+            "refine frames 1..T-1 -- frame 0 is a verbatim copy of the "
+            "input image so its rotation/translation are trivially correct "
+            "and would optimistically inflate the score. ``auto`` enables "
+            "this whenever ``method_info.json`` (sibling of result_folder, "
+            "i.e. ``<result_folder>/../method_info.json``) contains a "
+            "``refiner`` key."
+        ),
+    )
+    args = parser.parse_args()
+    if args.manifest is None:
+        args.manifest = _auto_detect_manifest(args.result_folder)
+    return args
+
+
+def _resolve_skip_first_frame(arg_val: str, result_folder: str) -> bool:
+    """Resolve ``--skip_first_frame {auto,yes,no}`` against ``method_info.json``.
+
+    Pose evaluation runs over a per-split subdir (e.g.
+    ``.../sana_wm_bidirectional_refined/simple_60s``) but ``method_info.json``
+    lives at the *parent* method directory. ``auto`` enables stripping iff
+    that file is present and contains a ``refiner`` key.
+    """
+    if arg_val == "yes":
+        return True
+    if arg_val == "no":
+        return False
+    method_info_path = os.path.join(os.path.dirname(os.path.normpath(result_folder)), "method_info.json")
+    if not os.path.exists(method_info_path):
+        return False
+    try:
+        with open(method_info_path) as _f:
+            method_info = json.load(_f)
+    except (json.JSONDecodeError, OSError):
+        return False
+    return bool(method_info.get("refiner"))
+
+
+def main():
+    args = parse_args()
+    accelerator = Accelerator()
+    device = accelerator.device
+    rank = accelerator.process_index
+
+    skip_first_frame = _resolve_skip_first_frame(args.skip_first_frame, args.result_folder)
+    if accelerator.is_main_process:
+        print(f"Skip frame 0: {skip_first_frame} (--skip_first_frame={args.skip_first_frame})")
+
+    # ---- Load manifest ----
+    manifest = load_manifest(args.manifest)
+    dataset_root = _dataset_root_from_manifest(args.manifest)
+
+    # ---- Find generated videos ----
+    gen_videos = sorted(glob(os.path.join(args.result_folder, "*_generated.mp4")))
+    pairs = []
+    for vpath in gen_videos:
+        basename = os.path.basename(vpath).replace("_generated.mp4", "")
+        if basename in manifest:
+            pairs.append((basename, vpath, _resolve_camera_path(manifest[basename]["camera_path"], dataset_root)))
+
+    if not pairs:
+        print(f"No matching scenes found in {args.result_folder}")
+        return
+
+    if accelerator.is_main_process:
+        print(f"Found {len(pairs)} scenes to evaluate")
+
+    # ---- Load Pi3 model ----
+    try:
+        from pi3.models.pi3 import Pi3
+    except ImportError:
+        if accelerator.is_main_process:
+            print("Error: Pi3 not found. Install Pi3 or place it on PYTHONPATH.")
+        return
+    pi3_model = Pi3.from_pretrained(args.pi3_ckpt).to(device)
+    pi3_model.requires_grad_(False)
+
+    # ---- Load existing cache ----
+    output_path = args.output or os.path.join(args.result_folder, "eval_poses.json")
+    cache = {}
+    if os.path.exists(output_path):
+        with open(output_path) as f:
+            cache = json.load(f)
+        # Cache entries record both the frame-0 mode and RotErr unit. Legacy
+        # entries lack ``RotErr_unit`` and used radians, while current summaries
+        # and paper tables expect degrees. Drop mismatched cache records so we
+        # never silently mix radians with degree-labeled outputs.
+        before = len(cache)
+        cache = {
+            sid: rec
+            for sid, rec in cache.items()
+            if (
+                not isinstance(rec, dict)
+                or (bool(rec.get("skip_first_frame", False)) == skip_first_frame and rec.get("RotErr_unit") == "deg")
+            )
+        }
+        invalidated = before - len(cache)
+        if invalidated and accelerator.is_main_process:
+            print(
+                f"Invalidated {invalidated}/{before} cached entries "
+                f"(skip_first_frame mismatch or RotErr unit is not degrees)"
+            )
+
+    # Optional explicit scene filter (forces re-eval of just those)
+    if args.scenes:
+        keep = {s.strip() for s in args.scenes.split(",") if s.strip()}
+        pairs = [(sid, vp, cp) for sid, vp, cp in pairs if sid in keep]
+        # Don't skip via cache when forcing re-eval
+        pairs_to_run = pairs
+        if accelerator.is_main_process:
+            print(f"Restricting to {len(pairs_to_run)} explicitly requested scenes: {sorted(keep)}")
+    else:
+        # Filter out already-cached scenes
+        pairs_to_run = [(sid, vp, cp) for sid, vp, cp in pairs if sid not in cache]
+        if accelerator.is_main_process:
+            print(f"Skipping {len(pairs) - len(pairs_to_run)} cached, evaluating {len(pairs_to_run)}")
+
+    if args.dump_trajectories and accelerator.is_main_process:
+        os.makedirs(os.path.join(args.result_folder, "trajectories"), exist_ok=True)
+
+    # ---- Distribute across GPUs ----
+    local_results = {}
+    dtype = (
+        torch.bfloat16 if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 8 else torch.float16
+    )
+
+    with accelerator.split_between_processes(pairs_to_run) as my_pairs:
+        for i in tqdm(range(0, len(my_pairs), args.batch_size), desc=f"GPU {rank}", disable=rank != 0):
+            batch = my_pairs[i : i + args.batch_size]
+            video_paths = [vp for _, vp, _ in batch]
+
+            # Run Pi3 on generated videos
+            pi3_results = run_pi3_inference_batch(pi3_model, video_paths, device, interval=args.interval)
+
+            for (scene_id, vpath, cam_path), pi3_res in zip(batch, pi3_results):
+                if pi3_res is None:
+                    print(f"Pi3 failed for {scene_id}, skipping")
+                    continue
+
+                try:
+                    # Estimated poses from Pi3 (c2w)
+                    poses_est = pi3_res["pose"].float()  # (N_sampled, 4, 4)
+
+                    # Refiners only modify frames 1..T-1; frame 0 is a verbatim
+                    # copy of the input image so its pose error is trivially
+                    # zero and would optimistically inflate the metric. Drop
+                    # the first sampled pose (and the matching GT pose) before
+                    # relativization so the reported error reflects only the
+                    # refined frames.
+                    if skip_first_frame:
+                        poses_est = poses_est[1:]
+                    poses_est = relative_pose(poses_est, "left")
+
+                    # GT poses from benchmark NPZ
+                    poses_gt_full = load_gt_poses(cam_path)
+
+                    # Subsample GT to match Pi3's interval sampling
+                    gt_indices = list(range(0, len(poses_gt_full), args.interval))
+                    if skip_first_frame:
+                        gt_indices = gt_indices[1:]
+                    # Ensure same length
+                    n = min(len(poses_est), len(gt_indices))
+                    poses_est = poses_est[:n]
+                    poses_gt = poses_gt_full[gt_indices[:n]].to(device)
+                    if skip_first_frame:
+                        # Re-relativize GT to its (new) first kept frame to
+                        # match the relativization above on the est side.
+                        poses_gt = relative_pose(poses_gt, "left")
+
+                    # Compute metrics
+                    rot_err, trans_err, cammc = metric(poses_gt, poses_est)
+
+                    local_results[scene_id] = {
+                        "RotErr": rot_err,
+                        "RotErr_unit": "deg",
+                        "TransErr_rel": trans_err,
+                        "CamMC_rel": cammc,
+                        "scene_type": manifest[scene_id].get("scene_type", "unknown"),
+                        "n_frames": n,
+                    }
+
+                    if args.dump_trajectories:
+                        # Save raw (relativized) trajectories as NPZ for
+                        # external 3D plotting; no further alignment applied
+                        # here so that downstream figures can decide their
+                        # own normalization.
+                        traj_dir = os.path.join(args.result_folder, "trajectories")
+                        os.makedirs(traj_dir, exist_ok=True)
+                        np.savez(
+                            os.path.join(traj_dir, f"{scene_id}_pi3.npz"),
+                            est=poses_est.detach().cpu().numpy(),
+                            gt=poses_gt.detach().cpu().numpy(),
+                            interval=args.interval,
+                            n_frames=n,
+                        )
+                except Exception as e:
+                    print(f"Error evaluating {scene_id}: {e}")
+
+    # ---- Gather results from all GPUs ----
+    from accelerate.utils import gather_object
+
+    all_results_list = gather_object([local_results])
+
+    if accelerator.is_main_process:
+        # Merge all results
+        merged = dict(cache)
+        for r in all_results_list:
+            merged.update(r)
+        # Tag every per-scene record with the eval mode so downstream code
+        # (eval_unified.py) can tell whether frame 0 was excluded.
+        for _v in merged.values():
+            if isinstance(_v, dict):
+                _v.setdefault("skip_first_frame", skip_first_frame)
+
+        # Save full results
+        with open(output_path, "w") as f:
+            json.dump(merged, f, indent=2)
+        print(f"Saved {len(merged)} results to {output_path}")
+
+        # ---- Print summary per scene_type ----
+        categories = {}
+        for scene_id, m in merged.items():
+            cat = m.get("scene_type", "unknown")
+            if cat not in categories:
+                categories[cat] = {"RotErr": [], "TransErr_rel": [], "CamMC_rel": []}
+            categories[cat]["RotErr"].append(m["RotErr"])
+            categories[cat]["TransErr_rel"].append(m["TransErr_rel"])
+            categories[cat]["CamMC_rel"].append(m["CamMC_rel"])
+
+        print("\n" + "=" * 70)
+        print(f"{'Category':<20} {'N':>4} {'RotErr(deg)':>12} {'TransErr':>10} {'CamMC':>10}")
+        print("-" * 70)
+
+        all_rot, all_trans, all_cammc = [], [], []
+        for cat in sorted(categories.keys()):
+            n = len(categories[cat]["RotErr"])
+            rot = np.mean(categories[cat]["RotErr"])
+            trans = np.mean(categories[cat]["TransErr_rel"])
+            cammc = np.mean(categories[cat]["CamMC_rel"])
+            print(f"{cat:<20} {n:>4} {rot:>12.4f} {trans:>10.4f} {cammc:>10.4f}")
+            all_rot.extend(categories[cat]["RotErr"])
+            all_trans.extend(categories[cat]["TransErr_rel"])
+            all_cammc.extend(categories[cat]["CamMC_rel"])
+
+        print("-" * 70)
+        total_n = len(all_rot)
+        print(
+            f"{'OVERALL':<20} {total_n:>4} {np.mean(all_rot):>12.4f} {np.mean(all_trans):>10.4f} {np.mean(all_cammc):>10.4f}"
+        )
+        print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/metrics/sana_wm/eval_unified.py
+++ b/tools/metrics/sana_wm/eval_unified.py
@@ -1,0 +1,1379 @@
+"""Unified evaluation script for world-model benchmark.
+
+Evaluates generated videos across multiple metrics:
+1. VBench visual quality (benchmark custom-input dimensions + total score)
+2. Camera accuracy summary if Pi3 pose results already exist
+3. Revisit frame consistency (PSNR/SSIM between evaluation pairs)
+4. Temporal degradation (VBench on sliding windows)
+
+## Expected Directory Structure
+
+Each method produces results in this layout:
+```
+results/
+├── <method_name>/
+│   ├── simple_60s/
+│   │   ├── game_style_001_generated.mp4
+│   │   ├── indoor_001_generated.mp4
+│   │   └── ...
+│   ├── hard_60s/
+│   │   ├── game_style_001_generated.mp4
+│       └── ...
+```
+
+Evaluation results are saved to:
+```
+results/<method_name>/eval/
+├── <split>/
+│   ├── camera_accuracy.json         # Pi3 pose metrics per scene, if present
+│   ├── vbench_scores.json           # VBench dimensions + total score
+│   ├── revisit_consistency.json     # PSNR/SSIM per evaluation pair
+│   ├── temporal_degradation.json    # VBench per 10s window
+│   └── summary.json                 # Aggregated summary
+```
+
+## Usage
+
+```bash
+# Evaluate everything (requires GPU)
+python tools/metrics/sana_wm/eval_unified.py \\
+    --method_dir results/sana_wm_v1 \\
+    --split simple_60s
+
+# Specific metrics only
+python tools/metrics/sana_wm/eval_unified.py \\
+    --method_dir results/sana_wm_v1 \\
+    --split simple_60s \\
+    --metrics vbench revisit
+```
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import math
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+
+def _manifest_path_from_meta(meta_path: str) -> str | None:
+    """Infer the matching run_manifest.jsonl path from scene_trajectories_v2.json."""
+    candidate = Path(meta_path).parent / "sanawm_export_v2" / "run_manifest.jsonl"
+    if candidate.exists():
+        return str(candidate)
+    return None
+
+
+def _load_manifest_prompts(manifest_path: str | None) -> dict[str, str]:
+    """Load scene prompts from a SANA-WM run manifest."""
+    prompts: dict[str, str] = {}
+    if not manifest_path or not os.path.exists(manifest_path):
+        return prompts
+    with open(manifest_path, encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            scene_id = row.get("id")
+            prompt = row.get("prompt")
+            if scene_id and prompt:
+                prompts[scene_id] = prompt
+    return prompts
+
+
+def _resolve_vbench_info_path(vbench_module) -> str:
+    """Find VBench_full_info.json for either source-tree or pip-installed VBench."""
+    candidates = [
+        Path(PROJECT_ROOT) / "local_libs" / "VBench" / "vbench" / "VBench_full_info.json",
+        Path(vbench_module.__file__).resolve().parent / "VBench_full_info.json",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+    raise FileNotFoundError("Could not find VBench_full_info.json. Install VBench or provide local_libs/VBench.")
+
+
+# ============================================================================
+# VBench dimension definitions (all 16 from VBench 1.0)
+# ============================================================================
+
+VBENCH_QUALITY_DIMS = [
+    "subject_consistency",
+    "background_consistency",
+    "temporal_flickering",
+    "motion_smoothness",
+    "aesthetic_quality",
+    "imaging_quality",
+    "dynamic_degree",
+]
+
+VBENCH_SEMANTIC_DIMS = [
+    "object_class",
+    "multiple_objects",
+    "human_action",
+    "color",
+    "spatial_relationship",
+    "scene",
+    "appearance_style",
+    "temporal_style",
+    "overall_consistency",
+]
+
+VBENCH_ALL_DIMS = VBENCH_QUALITY_DIMS + VBENCH_SEMANTIC_DIMS
+
+# I2V-specific dimensions
+VBENCH_I2V_DIMS = [
+    "i2v_subject",
+    "i2v_background",
+]
+
+# Official weights (from VBench constant.py)
+VBENCH_DIM_WEIGHTS = {d: 1.0 for d in VBENCH_ALL_DIMS}
+VBENCH_DIM_WEIGHTS["dynamic_degree"] = 0.5
+QUALITY_WEIGHT = 4.0
+SEMANTIC_WEIGHT = 1.0
+
+# Normalization bounds (from VBench constant.py)
+NORMALIZE_DIC = {
+    "subject_consistency": {"Min": 0.1462, "Max": 1.0},
+    "background_consistency": {"Min": 0.2615, "Max": 1.0},
+    "temporal_flickering": {"Min": 0.6293, "Max": 1.0},
+    "motion_smoothness": {"Min": 0.7060, "Max": 0.9975},
+    "dynamic_degree": {"Min": 0.0, "Max": 1.0},
+    "aesthetic_quality": {"Min": 0.0, "Max": 1.0},
+    "imaging_quality": {"Min": 0.0, "Max": 1.0},
+    "object_class": {"Min": 0.0, "Max": 1.0},
+    "multiple_objects": {"Min": 0.0, "Max": 1.0},
+    "human_action": {"Min": 0.0, "Max": 1.0},
+    "color": {"Min": 0.0, "Max": 1.0},
+    "spatial_relationship": {"Min": 0.0, "Max": 1.0},
+    "scene": {"Min": 0.0, "Max": 1.0},
+    "appearance_style": {"Min": 0.0, "Max": 1.0},
+    "temporal_style": {"Min": 0.0, "Max": 1.0},
+    "overall_consistency": {"Min": 0.0, "Max": 1.0},
+    "i2v_subject": {"Min": 0.0, "Max": 1.0},
+    "i2v_background": {"Min": 0.0, "Max": 1.0},
+}
+
+
+def normalize_score(dim: str, raw: float) -> float:
+    """Normalize a raw VBench score to [0, 1] using official bounds."""
+    if dim not in NORMALIZE_DIC:
+        return raw
+    mn = NORMALIZE_DIC[dim]["Min"]
+    mx = NORMALIZE_DIC[dim]["Max"]
+    if mx - mn < 1e-8:
+        return raw
+    return max(0.0, min(1.0, (raw - mn) / (mx - mn)))
+
+
+def compute_vbench_total(scores: dict[str, float]) -> dict[str, float]:
+    """Compute VBench quality, semantic, and total scores.
+
+    Follows the official VBench formula:
+      Quality = weighted_avg(7 quality dims, dynamic_degree weight=0.5)
+      Semantic = avg(9 semantic dims)
+      Total = (4 * Quality + 1 * Semantic) / 5
+
+    Args:
+        scores: Dict mapping dimension name to raw score.
+
+    Returns:
+        Dict with quality_score, semantic_score, total_score (all normalized).
+    """
+    norm = {d: normalize_score(d, s) for d, s in scores.items()}
+
+    q_dims = [d for d in VBENCH_QUALITY_DIMS if d in norm]
+    if q_dims:
+        q_total_w = sum(VBENCH_DIM_WEIGHTS.get(d, 1.0) for d in q_dims)
+        quality = sum(norm[d] * VBENCH_DIM_WEIGHTS.get(d, 1.0) for d in q_dims) / q_total_w
+    else:
+        quality = 0.0
+
+    s_dims = [d for d in VBENCH_SEMANTIC_DIMS if d in norm]
+    if s_dims:
+        s_total_w = sum(VBENCH_DIM_WEIGHTS.get(d, 1.0) for d in s_dims)
+        semantic = sum(norm[d] * VBENCH_DIM_WEIGHTS.get(d, 1.0) for d in s_dims) / s_total_w
+    else:
+        semantic = 0.0
+
+    total = (QUALITY_WEIGHT * quality + SEMANTIC_WEIGHT * semantic) / (QUALITY_WEIGHT + SEMANTIC_WEIGHT)
+
+    return {
+        "quality_score": round(quality, 4),
+        "semantic_score": round(semantic, 4),
+        "total_score": round(total, 4),
+        "normalized_per_dim": {d: round(v, 4) for d, v in norm.items()},
+    }
+
+
+# ============================================================================
+# Metric: Revisit frame consistency (PSNR / SSIM)
+# ============================================================================
+
+
+def _psnr(img1: np.ndarray, img2: np.ndarray) -> float:
+    """Compute PSNR between two uint8 images."""
+    mse = np.mean((img1.astype(np.float64) - img2.astype(np.float64)) ** 2)
+    if mse < 1e-10:
+        return 100.0
+    return float(10 * np.log10(255.0**2 / mse))
+
+
+def _ssim_channel(c1: np.ndarray, c2: np.ndarray) -> float:
+    """Compute SSIM for a single channel (uint8)."""
+    from scipy.ndimage import uniform_filter
+
+    c1 = c1.astype(np.float64)
+    c2 = c2.astype(np.float64)
+    k = 11
+
+    mu1 = uniform_filter(c1, k)
+    mu2 = uniform_filter(c2, k)
+    mu1_sq = mu1**2
+    mu2_sq = mu2**2
+    mu1_mu2 = mu1 * mu2
+
+    sigma1_sq = uniform_filter(c1**2, k) - mu1_sq
+    sigma2_sq = uniform_filter(c2**2, k) - mu2_sq
+    sigma12 = uniform_filter(c1 * c2, k) - mu1_mu2
+
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+
+    ssim_map = ((2 * mu1_mu2 + C1) * (2 * sigma12 + C2)) / ((mu1_sq + mu2_sq + C1) * (sigma1_sq + sigma2_sq + C2))
+    return float(ssim_map.mean())
+
+
+def compute_ssim(img1: np.ndarray, img2: np.ndarray) -> float:
+    """Compute SSIM between two uint8 RGB images."""
+    ssim_vals = []
+    for c in range(min(img1.shape[2], 3)):
+        ssim_vals.append(_ssim_channel(img1[:, :, c], img2[:, :, c]))
+    return float(np.mean(ssim_vals))
+
+
+def _remap_frame_index(frame_idx: int, ref_fps: float, video_fps: float, n_video_frames: int) -> int:
+    """Convert a frame index from reference FPS to video FPS via time mapping.
+
+    Evaluation pairs are stored at ref_fps (16fps). If the video was generated
+    at a different FPS, we map through time: time = frame / ref_fps, then
+    video_frame = round(time * video_fps).
+
+    Args:
+        frame_idx: Frame index at ref_fps.
+        ref_fps: FPS used when computing evaluation pairs (typically 16).
+        video_fps: Actual FPS of the generated video.
+        n_video_frames: Total frames in the video (for clamping).
+
+    Returns:
+        Corresponding frame index in the video.
+    """
+    if abs(ref_fps - video_fps) < 0.1:
+        return min(frame_idx, n_video_frames - 1)
+    time_sec = frame_idx / ref_fps
+    target = round(time_sec * video_fps)
+    return min(max(target, 0), n_video_frames - 1)
+
+
+def _detect_video_fps(video_path: str) -> float:
+    """Detect FPS from a video file."""
+    try:
+        from decord import VideoReader
+
+        vr = VideoReader(video_path)
+        return float(vr.get_avg_fps())
+    except Exception:
+        pass
+    try:
+        import cv2
+
+        cap = cv2.VideoCapture(video_path)
+        fps = cap.get(cv2.CAP_PROP_FPS)
+        cap.release()
+        if fps > 0:
+            return float(fps)
+    except Exception:
+        pass
+    return 16.0  # Default fallback
+
+
+def _frame_to_numpy(frame) -> np.ndarray:
+    """Convert a decord/imageio/torch frame object to a numpy array."""
+    if hasattr(frame, "asnumpy"):
+        return frame.asnumpy()
+    if isinstance(frame, np.ndarray):
+        return frame
+    if hasattr(frame, "detach") and hasattr(frame, "cpu"):
+        return frame.detach().cpu().numpy()
+    if hasattr(frame, "numpy"):
+        return frame.numpy()
+    return np.asarray(frame)
+
+
+@contextlib.contextmanager
+def _vbench_torch_load_compat():
+    """Allow official VBench checkpoints to load under PyTorch 2.6+.
+
+    PyTorch 2.6 changed ``torch.load`` to default to ``weights_only=True``.
+    Some official VBench checkpoints still serialize plain Python containers
+    that are rejected by that safer default. During VBench's own model loading,
+    opt back into the pre-2.6 behavior for those trusted public checkpoints.
+    """
+    import torch
+
+    original_load = torch.load
+
+    def compat_load(*args, **kwargs):
+        kwargs.setdefault("weights_only", False)
+        return original_load(*args, **kwargs)
+
+    torch.load = compat_load
+    try:
+        yield
+    finally:
+        torch.load = original_load
+
+
+_LPIPS_MODEL = None
+
+
+def _get_lpips_model(device: str = "cuda"):
+    """Lazily load the LPIPS AlexNet model (singleton)."""
+    global _LPIPS_MODEL
+    if _LPIPS_MODEL is None:
+        import lpips as lpips_pkg
+
+        _LPIPS_MODEL = lpips_pkg.LPIPS(net="alex", verbose=False).to(device).eval()
+        for p in _LPIPS_MODEL.parameters():
+            p.requires_grad_(False)
+    return _LPIPS_MODEL
+
+
+def compute_lpips(img1: np.ndarray, img2: np.ndarray, device: str = "cuda") -> float:
+    """Compute LPIPS (AlexNet) between two uint8 RGB images."""
+    import torch as _torch
+
+    model = _get_lpips_model(device)
+    # Convert to [-1, 1] tensors of shape (1, 3, H, W)
+    t1 = _torch.from_numpy(img1).permute(2, 0, 1).float().unsqueeze(0) / 127.5 - 1.0
+    t2 = _torch.from_numpy(img2).permute(2, 0, 1).float().unsqueeze(0) / 127.5 - 1.0
+    t1 = t1.to(device)
+    t2 = t2.to(device)
+    with _torch.no_grad():
+        d = model(t1, t2)
+    return float(d.item())
+
+
+def eval_revisit_consistency(
+    video_dir: str,
+    benchmark_meta: dict,
+    max_pairs_per_scene: int = 5,
+    ref_fps: float = 16.0,
+    cache_dir: str | None = None,
+    use_lpips: bool = False,
+    device: str = "cuda",
+) -> dict[str, Any]:
+    """Evaluate revisit frame consistency using PSNR, SSIM, and (optionally) LPIPS.
+
+    For each scene, extracts the evaluation frame pairs (where camera revisits
+    the same viewpoint) and computes pixel-level similarity metrics.
+
+    FPS-aware: evaluation pairs are stored at ref_fps (16fps). If the video
+    was generated at a different FPS, frame indices are remapped through time
+    to ensure we compare the correct timestamps.
+
+    Supports resume: per-scene results are cached in cache_dir. Cache entries
+    that lack LPIPS are upgraded in-place when use_lpips=True (they are
+    re-evaluated only for the LPIPS column, preserving prior PSNR/SSIM).
+
+    Args:
+        video_dir: Directory containing {scene_id}_generated.mp4 files.
+        benchmark_meta: Parsed scene_trajectories_v2.json.
+        max_pairs_per_scene: Max evaluation pairs to use per scene.
+        ref_fps: FPS at which evaluation pairs were computed.
+        cache_dir: Directory for per-scene intermediate results. None = no caching.
+        use_lpips: If True, also compute LPIPS (AlexNet) per pair.
+        device: CUDA device for LPIPS model.
+
+    Returns:
+        Dict with per-scene and aggregate PSNR/SSIM/LPIPS scores.
+    """
+    try:
+        from decord import VideoReader
+    except ImportError:
+        import imageio.v3 as iio
+
+        VideoReader = None
+
+    scenes = benchmark_meta.get("scenes", [])
+    results = {}
+    all_psnr, all_ssim, all_lpips = [], [], []
+
+    # Resume support: per-scene cache
+    if cache_dir:
+        os.makedirs(cache_dir, exist_ok=True)
+    n_cached = 0
+    n_lpips_upgraded = 0
+
+    for si, scene in enumerate(scenes):
+        scene_id = scene["scene_id"]
+        video_path = os.path.join(video_dir, f"{scene_id}_generated.mp4")
+        if not os.path.exists(video_path):
+            continue
+
+        eval_pairs = scene.get("evaluation_pairs", [])
+        if not eval_pairs:
+            continue
+
+        # Check per-scene cache
+        cache_file = os.path.join(cache_dir, f"{scene_id}.json") if cache_dir else None
+        if cache_file and os.path.exists(cache_file):
+            try:
+                with open(cache_file) as f:
+                    cached = json.load(f)
+                # If LPIPS requested but not cached, upgrade in place
+                pairs_cached = cached.get("pairs", [])
+                needs_lpips = use_lpips and pairs_cached and any("lpips" not in p for p in pairs_cached)
+                if not needs_lpips:
+                    results[scene_id] = cached
+                    all_psnr.extend([p["psnr"] for p in pairs_cached])
+                    all_ssim.extend([p["ssim"] for p in pairs_cached])
+                    if use_lpips:
+                        all_lpips.extend([p["lpips"] for p in pairs_cached if "lpips" in p])
+                    n_cached += 1
+                    continue
+                # Need LPIPS upgrade: read video frames to compute LPIPS for cached pairs
+                try:
+                    if VideoReader is not None:
+                        vr_local = VideoReader(video_path)
+                        n_frames_local = len(vr_local)
+                    else:
+                        frames_local = iio.imread(video_path)
+                        n_frames_local = frames_local.shape[0]
+                except Exception:
+                    print(f"  WARNING: corrupted video {scene_id}, skipping LPIPS upgrade")
+                    results[scene_id] = cached
+                    all_psnr.extend([p["psnr"] for p in pairs_cached])
+                    all_ssim.extend([p["ssim"] for p in pairs_cached])
+                    n_cached += 1
+                    continue
+
+                upgraded_pairs = []
+                scene_lpips_local = []
+                for p in pairs_cached:
+                    fa = min(p["frame_a"], n_frames_local - 1)
+                    fb = min(p["frame_b"], n_frames_local - 1)
+                    if "lpips" in p:
+                        upgraded_pairs.append(p)
+                        scene_lpips_local.append(p["lpips"])
+                        continue
+                    if VideoReader is not None:
+                        img_a = _frame_to_numpy(vr_local[fa])
+                        img_b = _frame_to_numpy(vr_local[fb])
+                    else:
+                        img_a = frames_local[fa]
+                        img_b = frames_local[fb]
+                    lp = compute_lpips(img_a, img_b, device=device)
+                    p2 = dict(p)
+                    p2["lpips"] = round(lp, 4)
+                    upgraded_pairs.append(p2)
+                    scene_lpips_local.append(lp)
+
+                cached["pairs"] = upgraded_pairs
+                if scene_lpips_local:
+                    cached["mean_lpips"] = round(float(np.mean(scene_lpips_local)), 4)
+                results[scene_id] = cached
+                all_psnr.extend([p["psnr"] for p in upgraded_pairs])
+                all_ssim.extend([p["ssim"] for p in upgraded_pairs])
+                all_lpips.extend([p["lpips"] for p in upgraded_pairs if "lpips" in p])
+                n_lpips_upgraded += 1
+                with open(cache_file, "w") as f:
+                    json.dump(cached, f, indent=2)
+                continue
+            except (json.JSONDecodeError, KeyError):
+                pass  # Corrupted, re-evaluate
+
+        pairs = sorted(eval_pairs, key=lambda p: p.get("quality_score", 999))[:max_pairs_per_scene]
+
+        try:
+            if VideoReader is not None:
+                vr = VideoReader(video_path)
+                n_frames = len(vr)
+            else:
+                frames_all = iio.imread(video_path)
+                n_frames = frames_all.shape[0]
+        except Exception:
+            print(f"  WARNING: corrupted video {scene_id}, skipping")
+            continue
+
+        # Detect video FPS for frame index remapping
+        video_fps = _detect_video_fps(video_path)
+
+        scene_psnr, scene_ssim, scene_lpips = [], [], []
+        scene_pairs = []
+
+        for pair in pairs:
+            # Remap frame indices from ref_fps to video_fps
+            fa = _remap_frame_index(pair["frame_a"], ref_fps, video_fps, n_frames)
+            fb = _remap_frame_index(pair["frame_b"], ref_fps, video_fps, n_frames)
+            if fa == fb:
+                continue  # Degenerate after remap
+
+            if VideoReader is not None:
+                img_a = _frame_to_numpy(vr[fa])
+                img_b = _frame_to_numpy(vr[fb])
+            else:
+                img_a = frames_all[fa]
+                img_b = frames_all[fb]
+
+            p = _psnr(img_a, img_b)
+            s = compute_ssim(img_a, img_b)
+            pair_record = {
+                "frame_a": fa,
+                "frame_b": fb,
+                "psnr": round(p, 2),
+                "ssim": round(s, 4),
+                "distance_m": pair.get("distance_m"),
+                "angle_diff_deg": pair.get("angle_diff_deg"),
+            }
+            scene_psnr.append(p)
+            scene_ssim.append(s)
+            if use_lpips:
+                lp = compute_lpips(img_a, img_b, device=device)
+                pair_record["lpips"] = round(lp, 4)
+                scene_lpips.append(lp)
+            scene_pairs.append(pair_record)
+
+        if scene_psnr:
+            scene_result = {
+                "mean_psnr": round(float(np.mean(scene_psnr)), 2),
+                "mean_ssim": round(float(np.mean(scene_ssim)), 4),
+                "n_pairs": len(scene_psnr),
+                "pairs": scene_pairs,
+            }
+            if use_lpips and scene_lpips:
+                scene_result["mean_lpips"] = round(float(np.mean(scene_lpips)), 4)
+            results[scene_id] = scene_result
+            all_psnr.extend(scene_psnr)
+            all_ssim.extend(scene_ssim)
+            if use_lpips:
+                all_lpips.extend(scene_lpips)
+
+            # Save per-scene cache
+            if cache_file:
+                with open(cache_file, "w") as f:
+                    json.dump(scene_result, f, indent=2)
+
+        if (si + 1) % 20 == 0:
+            print(f"  Revisit: {si+1}/{len(scenes)} scenes ({n_cached} cached, {n_lpips_upgraded} lpips-upgraded)")
+
+    # Per-category breakdown
+    categories: dict[str, list] = {}
+    for sid, r in results.items():
+        cat = "_".join(sid.split("_")[:-1])
+        categories.setdefault(cat, []).append(r)
+
+    per_category = {}
+    for cat, rs in sorted(categories.items()):
+        cat_psnr = [r["mean_psnr"] for r in rs]
+        cat_ssim = [r["mean_ssim"] for r in rs]
+        cat_lpips = [r["mean_lpips"] for r in rs if "mean_lpips" in r]
+        entry = {
+            "mean_psnr": round(float(np.mean(cat_psnr)), 2),
+            "mean_ssim": round(float(np.mean(cat_ssim)), 4),
+            "n_scenes": len(rs),
+        }
+        if cat_lpips:
+            entry["mean_lpips"] = round(float(np.mean(cat_lpips)), 4)
+        per_category[cat] = entry
+
+    summary = {
+        "overall_mean_psnr": round(float(np.mean(all_psnr)), 2) if all_psnr else 0.0,
+        "overall_mean_ssim": round(float(np.mean(all_ssim)), 4) if all_ssim else 0.0,
+        "n_scenes_evaluated": len(results),
+        "n_total_pairs": len(all_psnr),
+        "per_category": per_category,
+    }
+    if all_lpips:
+        summary["overall_mean_lpips"] = round(float(np.mean(all_lpips)), 4)
+        summary["n_lpips_pairs"] = len(all_lpips)
+
+    return {"summary": summary, "per_scene": results}
+
+
+# ============================================================================
+# Metric: VBench evaluation
+# ============================================================================
+
+
+def _build_stripped_video_dir(video_dir: str, output_dir: str) -> str:
+    """Re-encode every ``*_generated.mp4`` in ``video_dir`` with frame 0 dropped.
+
+    Refiner methods (e.g. SANA-WM + LTX-2 sink-bidirectional refiner) only
+    refine frames 1..T-1; frame 0 is a verbatim copy of the input image and
+    looks visually mismatched ("flickering") relative to the rest of the
+    clip. To compare apples-to-apples with non-refiner methods at evaluation
+    time we drop that first frame *online*, never modifying the raw outputs.
+
+    The stripped clips are cached at ``{output_dir}/_stripped_videos/`` and
+    rebuilt only when the source mtime is newer than the cached copy. The
+    returned path can be used as a drop-in replacement for ``video_dir`` by
+    any downstream tool that scans ``*_generated.mp4`` files (notably
+    VBench's ``custom_input`` mode).
+    """
+    import imageio.v3 as iio
+
+    try:
+        from decord import VideoReader
+
+        _have_decord = True
+    except ImportError:
+        VideoReader = None  # type: ignore[assignment]
+        _have_decord = False
+
+    src_dir = Path(video_dir)
+    dst_dir = Path(output_dir) / "_stripped_videos"
+    dst_dir.mkdir(parents=True, exist_ok=True)
+
+    n_built = 0
+    n_cached = 0
+    for src in sorted(src_dir.glob("*_generated.mp4")):
+        dst = dst_dir / src.name
+        if dst.exists() and dst.stat().st_mtime >= src.stat().st_mtime:
+            n_cached += 1
+            continue
+        try:
+            if _have_decord:
+                vr = VideoReader(str(src))
+                frames = _frame_to_numpy(vr[1:])
+            else:
+                frames_all = iio.imread(str(src))
+                frames = frames_all[1:]
+            fps = _detect_video_fps(str(src))
+            iio.imwrite(str(dst), frames, fps=int(round(fps)))
+            n_built += 1
+        except Exception as e:
+            print(f"  WARNING: failed to strip first frame of {src.name}: {e}")
+    if n_built or n_cached:
+        print(f"  Stripped first frame: {n_built} re-encoded, {n_cached} cached -> {dst_dir}")
+    return str(dst_dir)
+
+
+def eval_vbench(
+    video_dir: str,
+    output_dir: str,
+    dimensions: list[str] | None = None,
+    device: str = "cuda",
+    benchmark_meta: dict | None = None,
+    benchmark_manifest: str | None = None,
+    skip_first_frame: bool = False,
+) -> dict[str, float]:
+    """Run VBench evaluation on all videos in a directory.
+
+    Args:
+        video_dir: Directory containing *_generated.mp4 files.
+        output_dir: Where to save VBench results.
+        dimensions: List of dimensions to evaluate. None = default 9.
+        device: CUDA device.
+        benchmark_meta: Parsed scene_trajectories_v2.json for real text prompts.
+            Used by CLIP-based dims (overall_consistency, temporal_style).
+        benchmark_manifest: Matching run_manifest.jsonl for prompt text.
+        skip_first_frame: If True, evaluate on copies with frame 0 removed
+            (relevant for refiner methods that only refine frames 1..T-1).
+
+    Returns:
+        Dict mapping dimension name to overall score.
+    """
+    vbench_root = os.path.join(PROJECT_ROOT, "local_libs", "VBench")
+    sys.path.insert(0, vbench_root)
+
+    try:
+        import vbench as vbench_module
+        from vbench import VBench
+    except ImportError:
+        print("ERROR: VBench not importable. Ensure local_libs/VBench is available.")
+        return {}
+    try:
+        vbench_info_path = _resolve_vbench_info_path(vbench_module)
+    except FileNotFoundError as exc:
+        print(f"ERROR: {exc}")
+        return {}
+
+    if dimensions is None:
+        # Dims that work in custom_input mode (no detectron2/T2V prompts needed)
+        # Not supported in custom_input: object_class, multiple_objects, color,
+        # spatial_relationship, scene, appearance_style (need VBench built-in prompts)
+        dimensions = [
+            "subject_consistency",
+            "background_consistency",
+            "temporal_flickering",
+            "motion_smoothness",
+            "aesthetic_quality",
+            "imaging_quality",
+            "dynamic_degree",
+            "overall_consistency",
+            "temporal_style",
+        ]
+
+    # VBench discovers videos via ``os.listdir(videos_path)``, so any other mp4
+    # in the directory (e.g. ``{scene}_combined.mp4`` written by the inference
+    # script) doubles the video count and triggers a "Number of prompts should
+    # match with number of videos" failure. Sidecars (combined.mp4, prompt.txt,
+    # first_frame.png, trajectory.png, camera_motion.txt) get relocated into a
+    # ``_sidecars/`` subdir so that ``video_dir`` only exposes
+    # ``*_generated.mp4`` to VBench. Idempotent: noop if all sidecars are
+    # already inside ``_sidecars/``.
+    sidecar_dir = Path(video_dir) / "_sidecars"
+    sidecar_suffixes = (
+        "_combined.mp4",
+        "_first_frame.png",
+        "_trajectory.png",
+        "_camera_motion.txt",
+        "_prompt.txt",
+    )
+    moved = 0
+    for entry in Path(video_dir).iterdir():
+        if not entry.is_file():
+            continue
+        if entry.name.endswith("_generated.mp4"):
+            continue
+        if any(entry.name.endswith(s) for s in sidecar_suffixes):
+            sidecar_dir.mkdir(exist_ok=True)
+            target = sidecar_dir / entry.name
+            if target.exists():
+                target.unlink()
+            entry.rename(target)
+            moved += 1
+    if moved:
+        print(f"  Moved {moved} sidecar file(s) to {sidecar_dir} (VBench cleanup)")
+
+    # If requested (refiner methods), point VBench at copies with frame 0 dropped.
+    if skip_first_frame:
+        video_dir = _build_stripped_video_dir(video_dir, output_dir)
+
+    videos = sorted(Path(video_dir).glob("*_generated.mp4"))
+    if not videos:
+        print(f"No *_generated.mp4 files found in {video_dir}")
+        return {}
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Build prompt_list for custom_input mode
+    # Real text prompts are needed for CLIP-based dims (overall_consistency, temporal_style)
+    scene_prompts = _load_manifest_prompts(benchmark_manifest)
+    if benchmark_meta:
+        for scene in benchmark_meta.get("scenes", []):
+            sid = scene.get("scene_id", "")
+            # Try to get prompt from scene metadata or linked prompts
+            prompt = scene.get("prompt", sid)
+            if sid and sid not in scene_prompts:
+                scene_prompts[sid] = prompt if prompt else sid
+
+    # Also try loading public manifests directly.
+    if not scene_prompts:
+        for candidate in [
+            "data/SANA-WM-Bench/benchmark_v2_smooth_60s/sanawm_export_v2/run_manifest.jsonl",
+            "data/SANA-WM-Bench/benchmark_v2_hard_60s/sanawm_export_v2/run_manifest.jsonl",
+        ]:
+            if os.path.exists(candidate):
+                with open(candidate, encoding="utf-8") as f:
+                    for line in f:
+                        row = json.loads(line.strip())
+                        scene_prompts[row["id"]] = row.get("prompt", row["id"])
+                break
+
+    prompt_list = {}
+    for v in videos:
+        sid = v.stem.replace("_generated", "")
+        prompt_list[v.name] = scene_prompts.get(sid, sid)
+
+    # Resume: load existing per-dimension results (skip NaN/invalid)
+    # In custom_input mode, VBench saves to {name}_eval_results.json (not {name}_{dim}_...)
+    scores = {}
+    skipped = 0
+    for dim in dimensions:
+        # Check both naming patterns (custom_input vs standard)
+        for pattern in [f"eval_{dim}_eval_results.json", f"eval_{dim}_{dim}_eval_results.json"]:
+            result_file = os.path.join(output_dir, pattern)
+            if os.path.exists(result_file):
+                try:
+                    with open(result_file) as f:
+                        data = json.load(f)
+                    if dim in data and len(data[dim]) > 0:
+                        val = float(data[dim][0])
+                        if not np.isnan(val) and len(data[dim]) > 1 and len(data[dim][1]) > 0:
+                            scores[dim] = val
+                            skipped += 1
+                            break
+                        else:
+                            os.remove(result_file)
+                except (json.JSONDecodeError, KeyError, ValueError):
+                    os.remove(result_file)
+
+    remaining = [d for d in dimensions if d not in scores]
+    print(f"  {len(videos)} videos, {len(dimensions)} dimensions " f"({skipped} cached, {len(remaining)} to evaluate)")
+
+    for i, dim in enumerate(remaining):
+        print(f"  [{skipped+i+1}/{len(dimensions)}] {dim} ...", end=" ", flush=True)
+        t0 = time.time()
+        try:
+            bench = VBench(device, vbench_info_path, output_dir)
+            with _vbench_torch_load_compat():
+                bench.evaluate(
+                    videos_path=str(video_dir),
+                    name=f"eval_{dim}",
+                    dimension_list=[dim],
+                    mode="custom_input",
+                    prompt_list=prompt_list,
+                    local=(dim == "subject_consistency"),
+                )
+
+            # Check both naming patterns
+            result_file = None
+            for pat in [f"eval_{dim}_eval_results.json", f"eval_{dim}_{dim}_eval_results.json"]:
+                candidate = os.path.join(output_dir, pat)
+                if os.path.exists(candidate):
+                    result_file = candidate
+                    break
+
+            if result_file:
+                with open(result_file) as f:
+                    data = json.load(f)
+                if dim in data and len(data[dim]) > 0:
+                    val = float(data[dim][0])
+                    if not np.isnan(val):
+                        scores[dim] = val
+                        print(f"{val:.4f} ({time.time()-t0:.1f}s)")
+                    else:
+                        print(f"NaN ({time.time()-t0:.1f}s)")
+                        os.remove(result_file)
+                else:
+                    print(f"no results ({time.time()-t0:.1f}s)")
+            else:
+                print(f"result file not found ({time.time()-t0:.1f}s)")
+        except Exception as e:
+            print(f"FAILED: {e}")
+
+    missing = [dim for dim in dimensions if dim not in scores]
+    if missing:
+        raise RuntimeError(f"VBench failed for requested dimension(s): {', '.join(missing)}")
+
+    return scores
+
+
+# ============================================================================
+# Metric: Camera accuracy (Pi3X)
+# ============================================================================
+
+
+def eval_camera_accuracy(
+    video_dir: str,
+    benchmark_meta: dict,
+    output_path: str,
+    device: str = "cuda",
+    benchmark_manifest: str | None = None,
+) -> dict[str, Any]:
+    """Evaluate camera pose accuracy using Pi3X.
+
+    Checks for existing results first. If not found, prints the command
+    to run separately (requires accelerate launch for multi-GPU).
+
+    Args:
+        video_dir: Directory with generated videos.
+        benchmark_meta: Benchmark metadata with GT poses.
+        output_path: Where to save results.
+        device: CUDA device.
+
+    Returns:
+        Dict with per-scene pose metrics, or empty if not yet evaluated.
+    """
+    # Check if results already exist
+    existing = os.path.join(video_dir, "eval_poses.json")
+    if os.path.exists(existing):
+        print(f"  Loading existing results: {existing}")
+        with open(existing) as f:
+            return json.load(f)
+
+    eval_script = os.path.join(PROJECT_ROOT, "tools", "metrics", "sana_wm", "eval_benchmark_poses.py")
+    print(f"  Camera accuracy requires multi-GPU accelerate launch.")
+    print(f"  Run separately:")
+    print("    accelerate launch --num_processes=8 --mixed_precision=bf16 \\")
+    cmd = f"      {eval_script} --result_folder {video_dir}"
+    if benchmark_manifest:
+        cmd += f" --manifest {benchmark_manifest}"
+    print(cmd)
+    return {}
+
+
+def _ensure_roterr_degrees(camera_results: dict[str, Any]) -> dict[str, Any]:
+    """Normalize per-scene RotErr values to degrees.
+
+    Current eval_benchmark_poses.py writes degree-valued RotErr with
+    ``RotErr_unit='deg'``. Older caches omitted the unit and stored radians.
+    """
+    rows = [v for v in camera_results.values() if isinstance(v, dict) and "RotErr" in v]
+    if not rows:
+        return camera_results
+    for v in rows:
+        unit = str(v.get("RotErr_unit", "")).lower()
+        if unit == "rad" or (unit != "deg" and abs(float(v["RotErr"])) <= math.pi + 1e-6):
+            v["RotErr"] = float(v["RotErr"]) * 180.0 / math.pi
+        v["RotErr_unit"] = "deg"
+    return camera_results
+
+
+# ============================================================================
+# Metric: Temporal degradation
+# ============================================================================
+
+
+def eval_temporal_degradation(
+    video_dir: str,
+    output_dir: str,
+    window_sec: float = 10.0,
+    fps: float = 16.0,
+    dimensions: list[str] | None = None,
+    skip_first_frame: bool = False,
+) -> dict[str, Any]:
+    """Evaluate VBench metrics on sliding time windows to measure degradation.
+
+    Splits each video into N-second windows, evaluates VBench on each,
+    and reports how quality changes over time.
+
+    Args:
+        video_dir: Directory with generated videos.
+        output_dir: Where to save window clips and results.
+        window_sec: Window size in seconds.
+        fps: Video frame rate.
+        dimensions: VBench dimensions to evaluate per window.
+        skip_first_frame: If True, evaluate on copies with frame 0 removed
+            (relevant for refiner methods that only refine frames 1..T-1).
+            Equivalent to shifting all window boundaries one frame later.
+
+    Returns:
+        Dict with per-window quality scores and degradation trend.
+    """
+    if dimensions is None:
+        dimensions = [
+            "subject_consistency",
+            "background_consistency",
+            "temporal_flickering",
+            "imaging_quality",
+        ]
+
+    try:
+        from decord import VideoReader
+    except ImportError:
+        print("WARNING: decord not available for temporal degradation.")
+        return {}
+
+    import imageio.v3 as iio
+
+    if skip_first_frame:
+        video_dir = _build_stripped_video_dir(video_dir, output_dir)
+
+    videos = sorted(Path(video_dir).glob("*_generated.mp4"))
+    if not videos:
+        return {}
+
+    window_frames = int(window_sec * fps)
+    print(f"  Windows: {window_sec}s ({window_frames} frames), {len(dimensions)} dims")
+
+    # Split videos into windows
+    window_dirs = {}
+    for video_path in videos:
+        scene_id = video_path.stem.replace("_generated", "")
+        vr = VideoReader(str(video_path))
+        n_frames = len(vr)
+        n_windows = max(1, n_frames // window_frames)
+
+        for w in range(n_windows):
+            start = w * window_frames
+            end = min(start + window_frames, n_frames)
+            if end - start < 16:
+                continue
+
+            window_name = f"w{w}_{int(w*window_sec)}s-{int((w+1)*window_sec)}s"
+            window_dir = os.path.join(output_dir, "temporal_windows", window_name)
+            os.makedirs(window_dir, exist_ok=True)
+
+            clip_path = os.path.join(window_dir, f"{scene_id}_generated.mp4")
+            if not os.path.exists(clip_path):
+                frames = _frame_to_numpy(vr[start:end])
+                iio.imwrite(clip_path, frames, fps=int(fps))
+
+            window_dirs.setdefault(window_name, window_dir)
+
+    # Evaluate each window
+    results = {}
+    for window_name, window_dir in sorted(window_dirs.items()):
+        print(f"  Window: {window_name}")
+        result_dir = os.path.join(output_dir, "temporal_results", window_name)
+        scores = eval_vbench(window_dir, result_dir, dimensions=dimensions)
+        if scores:
+            results[window_name] = scores
+
+    # Compute degradation trend
+    if results:
+        windows = sorted(results.keys())
+        trend = {}
+        for dim in dimensions:
+            vals = [results[w].get(dim, 0) for w in windows]
+            if len(vals) >= 2:
+                trend[dim] = {
+                    "first_window": round(vals[0], 4),
+                    "last_window": round(vals[-1], 4),
+                    "degradation": round(vals[0] - vals[-1], 4),
+                    "per_window": [round(v, 4) for v in vals],
+                }
+
+        return {"windows": results, "trend": trend}
+
+    return {}
+
+
+# ============================================================================
+# Main orchestrator
+# ============================================================================
+
+AVAILABLE_METRICS = ["vbench", "revisit", "camera", "temporal"]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Unified evaluation for world-model benchmark.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--method_dir",
+        type=str,
+        required=True,
+        help="Method directory (e.g., results/sana_wm_v1)",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="simple",
+        help="Benchmark split: simple, hard, simple_60s, hard_60s",
+    )
+    parser.add_argument(
+        "--benchmark_meta",
+        type=str,
+        default=None,
+        help="Path to scene_trajectories_v2.json (auto-detected from split).",
+    )
+    parser.add_argument(
+        "--metrics",
+        nargs="+",
+        default=AVAILABLE_METRICS,
+        choices=AVAILABLE_METRICS,
+        help="Which metrics to evaluate. Default: all.",
+    )
+    parser.add_argument(
+        "--vbench_dims",
+        nargs="+",
+        default=None,
+        help=(
+            "VBench dimensions. Default: benchmark custom-input dimensions "
+            "(7 quality dims plus overall_consistency and temporal_style)."
+        ),
+    )
+    parser.add_argument("--window_sec", type=float, default=10.0)
+    parser.add_argument("--max_pairs", type=int, default=5)
+    parser.add_argument("--device", type=str, default="cuda")
+    parser.add_argument(
+        "--ref_fps",
+        type=float,
+        default=16.0,
+        help="FPS at which evaluation pairs were computed (default: 16). "
+        "Video FPS is auto-detected; frame indices are remapped via time.",
+    )
+    parser.add_argument(
+        "--revisit_lpips",
+        action="store_true",
+        help="Also compute LPIPS (AlexNet) for revisit pairs. Upgrades existing PSNR/SSIM cache in-place.",
+    )
+    parser.add_argument(
+        "--skip_first_frame",
+        type=str,
+        default="auto",
+        choices=["auto", "yes", "no"],
+        help=(
+            "Drop frame 0 of every generated video before VBench / temporal "
+            "degradation evaluation. Refiner methods only refine frames "
+            "1..T-1 (frame 0 is a verbatim copy of the input image), so "
+            "including frame 0 introduces a flicker/seam that biases visual "
+            "metrics. ``auto`` enables this whenever ``method_info.json`` "
+            "contains a ``refiner`` key. Revisit pairs never reference frame "
+            "0 in our benchmark, so PSNR/SSIM/LPIPS are unaffected."
+        ),
+    )
+    args = parser.parse_args()
+
+    method_dir = Path(args.method_dir)
+    video_dir = str(method_dir / args.split)
+    eval_dir = str(method_dir / "eval" / args.split)
+    os.makedirs(eval_dir, exist_ok=True)
+
+    if not os.path.isdir(video_dir):
+        print(f"ERROR: Video directory not found: {video_dir}")
+        print(f"Expected: {method_dir}/<split>/*_generated.mp4")
+        sys.exit(1)
+
+    n_videos = len(list(Path(video_dir).glob("*_generated.mp4")))
+
+    # Load method_info.json if present (describes the model variant)
+    method_info_path = method_dir / "method_info.json"
+    method_info = {}
+    if method_info_path.exists():
+        with open(method_info_path) as f:
+            method_info = json.load(f)
+
+    # Resolve --skip_first_frame: ``auto`` -> True iff this method_info
+    # advertises a refiner (refiners only modify frames 1..T-1).
+    if args.skip_first_frame == "yes":
+        skip_first_frame = True
+    elif args.skip_first_frame == "no":
+        skip_first_frame = False
+    else:
+        skip_first_frame = bool(method_info.get("refiner"))
+
+    print(f"Method:  {method_dir.name}")
+    if method_info:
+        print(f"  Model:   {method_info.get('model', 'unknown')}")
+        print(f"  Variant: {method_info.get('variant', 'unknown')}")
+        print(f"  FPS:     {method_info.get('fps', 'auto-detect')}")
+    print(f"Split:   {args.split}")
+    print(f"Videos:  {n_videos}")
+    print(f"Metrics: {args.metrics}")
+    print(f"Output:  {eval_dir}")
+    print(f"Skip frame 0: {skip_first_frame} (--skip_first_frame={args.skip_first_frame})")
+
+    # Auto-detect benchmark metadata
+    benchmark_meta = None
+    benchmark_manifest = None
+    if args.benchmark_meta:
+        with open(args.benchmark_meta) as f:
+            benchmark_meta = json.load(f)
+        benchmark_manifest = _manifest_path_from_meta(args.benchmark_meta)
+    else:
+        split_to_dir = {
+            "simple": "benchmark_v2_smooth",
+            "hard": "benchmark_v2_hard",
+            "simple_60s": "benchmark_v2_smooth_60s",
+            "hard_60s": "benchmark_v2_hard_60s",
+        }
+        bench_dir = split_to_dir.get(args.split, "benchmark_v2_smooth")
+        meta_path = os.path.join("data", "SANA-WM-Bench", bench_dir, "scene_trajectories_v2.json")
+        if os.path.exists(meta_path):
+            with open(meta_path) as f:
+                benchmark_meta = json.load(f)
+            benchmark_manifest = _manifest_path_from_meta(meta_path)
+            print(f"Metadata: {meta_path}")
+
+    t_start = time.time()
+    # Preserve any prior metric blocks (e.g. vbench from a previous run) so a
+    # narrower invocation (--metrics revisit) does not erase them.
+    summary_path = os.path.join(eval_dir, "summary.json")
+    summary: dict[str, Any] = {}
+    if os.path.exists(summary_path):
+        try:
+            with open(summary_path) as f:
+                summary = json.load(f) or {}
+        except (json.JSONDecodeError, OSError):
+            summary = {}
+    summary.update(
+        {
+            "method": method_dir.name,
+            "method_info": method_info if method_info else summary.get("method_info"),
+            "split": args.split,
+            "n_videos": n_videos,
+            "skip_first_frame": skip_first_frame,
+        }
+    )
+
+    # ---- 1. VBench ----
+    if "vbench" in args.metrics:
+        print(f"\n{'='*60}")
+        print("VBench Visual Quality (benchmark custom-input dimensions + total score)")
+        print(f"{'='*60}")
+        vbench_results = eval_vbench(
+            video_dir,
+            eval_dir,
+            dimensions=args.vbench_dims,
+            device=args.device,
+            benchmark_meta=benchmark_meta,
+            benchmark_manifest=benchmark_manifest,
+            skip_first_frame=skip_first_frame,
+        )
+
+        if vbench_results:
+            total = compute_vbench_total(vbench_results)
+            vbench_output = {
+                "raw_scores": {d: round(s, 4) for d, s in vbench_results.items()},
+                **total,
+            }
+            with open(os.path.join(eval_dir, "vbench_scores.json"), "w") as f:
+                json.dump(vbench_output, f, indent=2)
+            summary["vbench"] = {
+                "quality_score": total["quality_score"],
+                "semantic_score": total["semantic_score"],
+                "total_score": total["total_score"],
+                "n_dimensions": len(vbench_results),
+            }
+            print(
+                f"\nVBench Total: {total['total_score']:.4f} "
+                f"(Quality={total['quality_score']:.4f}, Semantic={total['semantic_score']:.4f})"
+            )
+
+    # ---- 2. Revisit consistency ----
+    if "revisit" in args.metrics and benchmark_meta:
+        print(f"\n{'='*60}")
+        print("Revisit Frame Consistency (PSNR / SSIM)")
+        print(f"{'='*60}")
+        revisit_results = eval_revisit_consistency(
+            video_dir,
+            benchmark_meta,
+            max_pairs_per_scene=args.max_pairs,
+            ref_fps=args.ref_fps,
+            cache_dir=os.path.join(eval_dir, "revisit_cache"),
+            use_lpips=args.revisit_lpips,
+            device=args.device,
+        )
+        with open(os.path.join(eval_dir, "revisit_consistency.json"), "w") as f:
+            json.dump(revisit_results, f, indent=2)
+        s = revisit_results["summary"]
+        summary["revisit"] = s
+        lpips_str = f", LPIPS={s['overall_mean_lpips']:.4f}" if "overall_mean_lpips" in s else ""
+        print(
+            f"\nRevisit: PSNR={s['overall_mean_psnr']:.2f} dB, "
+            f"SSIM={s['overall_mean_ssim']:.4f}{lpips_str} ({s['n_total_pairs']} pairs)"
+        )
+        if "per_category" in s:
+            for cat, cs in s["per_category"].items():
+                cat_lpips = f", LPIPS={cs['mean_lpips']:.4f}" if "mean_lpips" in cs else ""
+                print(f"  {cat}: PSNR={cs['mean_psnr']:.2f}, SSIM={cs['mean_ssim']:.4f}{cat_lpips}")
+
+    # ---- 3. Camera accuracy ----
+    if "camera" in args.metrics and benchmark_meta:
+        print(f"\n{'='*60}")
+        print("Camera Pose Accuracy (Pi3X)")
+        print(f"{'='*60}")
+        camera_results = eval_camera_accuracy(
+            video_dir,
+            benchmark_meta,
+            output_path=os.path.join(eval_dir, "camera_accuracy.json"),
+            device=args.device,
+            benchmark_manifest=benchmark_manifest,
+        )
+        if camera_results:
+            camera_results = _ensure_roterr_degrees(camera_results)
+            with open(os.path.join(eval_dir, "camera_accuracy.json"), "w") as f:
+                json.dump(camera_results, f, indent=2)
+            rot_errs = [v.get("RotErr", 0) for v in camera_results.values() if isinstance(v, dict)]
+            trans_errs = [v.get("TransErr_rel", 0) for v in camera_results.values() if isinstance(v, dict)]
+            if rot_errs:
+                summary["camera"] = {
+                    "mean_rot_err_deg": round(float(np.mean(rot_errs)), 3),
+                    "mean_trans_err_rel": round(float(np.mean(trans_errs)), 3),
+                    "n_scenes": len(rot_errs),
+                }
+                print(
+                    f"\nCamera: RotErr={summary['camera']['mean_rot_err_deg']:.3f}°, "
+                    f"TransErr={summary['camera']['mean_trans_err_rel']:.3f}"
+                )
+
+    # ---- 4. Temporal degradation ----
+    if "temporal" in args.metrics:
+        print(f"\n{'='*60}")
+        print(f"Temporal Degradation ({args.window_sec}s windows)")
+        print(f"{'='*60}")
+        temporal_results = eval_temporal_degradation(
+            video_dir,
+            os.path.join(eval_dir, "temporal"),
+            window_sec=args.window_sec,
+            skip_first_frame=skip_first_frame,
+        )
+        if temporal_results:
+            with open(os.path.join(eval_dir, "temporal_degradation.json"), "w") as f:
+                json.dump(temporal_results, f, indent=2)
+            if "trend" in temporal_results:
+                summary["temporal_degradation"] = temporal_results["trend"]
+                for dim, trend in temporal_results["trend"].items():
+                    print(
+                        f"  {dim}: {trend['first_window']:.4f} → {trend['last_window']:.4f} "
+                        f"(degradation={trend['degradation']:+.4f})"
+                    )
+
+    # ---- Save summary ----
+    # Re-read summary.json just before writing: another eval job (e.g. vbench)
+    # may have concurrently added its metric block since we loaded the file
+    # at the start of this run. Merge their updates under any keys we didn't
+    # touch in this invocation (vbench/revisit/camera/temporal_degradation/
+    # method_info). Without this, a long-running temporal job can clobber a
+    # vbench block that completed meanwhile.
+    summary["eval_time_sec"] = round(time.time() - t_start, 1)
+    summary_path = os.path.join(eval_dir, "summary.json")
+    metrics_evaluated = set(args.metrics)
+    preserve_keys = set()
+    if "vbench" not in metrics_evaluated:
+        preserve_keys.add("vbench")
+    if "revisit" not in metrics_evaluated:
+        preserve_keys.add("revisit")
+    if "camera" not in metrics_evaluated:
+        preserve_keys.add("camera")
+    if "temporal" not in metrics_evaluated:
+        preserve_keys.add("temporal_degradation")
+    if os.path.exists(summary_path):
+        try:
+            with open(summary_path) as _f:
+                disk = json.load(_f) or {}
+            for _k in preserve_keys:
+                if _k in disk and _k not in summary:
+                    summary[_k] = disk[_k]
+            # Always prefer disk method_info if ours is empty (never overwrite a valid one).
+            if not summary.get("method_info") and disk.get("method_info"):
+                summary["method_info"] = disk["method_info"]
+        except (json.JSONDecodeError, OSError):
+            pass
+    with open(summary_path, "w") as f:
+        json.dump(summary, f, indent=2)
+
+    print(f"\n{'='*60}")
+    print(f"EVALUATION COMPLETE ({summary['eval_time_sec']:.1f}s)")
+    print(f"{'='*60}")
+    print(f"Results: {eval_dir}/")
+
+    # Print final summary table
+    print(f"\n{'Metric':<30} {'Score':>10}")
+    print("-" * 42)
+    if "vbench" in summary:
+        v = summary["vbench"]
+        print(f"{'VBench Total':<30} {v['total_score']:>10.4f}")
+        print(f"{'  Quality Score':<30} {v['quality_score']:>10.4f}")
+        print(f"{'  Semantic Score':<30} {v['semantic_score']:>10.4f}")
+    if "revisit" in summary:
+        r = summary["revisit"]
+        print(f"{'Revisit PSNR (dB)':<30} {r['overall_mean_psnr']:>10.2f}")
+        print(f"{'Revisit SSIM':<30} {r['overall_mean_ssim']:>10.4f}")
+        if "overall_mean_lpips" in r:
+            print(f"{'Revisit LPIPS':<30} {r['overall_mean_lpips']:>10.4f}")
+    if "camera" in summary:
+        c = summary["camera"]
+        print(f"{'Camera RotErr (deg)':<30} {c['mean_rot_err_deg']:>10.3f}")
+        print(f"{'Camera TransErr (rel)':<30} {c['mean_trans_err_rel']:>10.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/metrics/sana_wm/pose_utils.py
+++ b/tools/metrics/sana_wm/pose_utils.py
@@ -1,0 +1,183 @@
+"""Pose utility functions for SANA-WM benchmark camera accuracy."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import numpy as np
+import torch
+from torch import Tensor
+
+try:
+    from pi3.utils.basic import load_images_as_tensor
+except ImportError:
+    load_images_as_tensor = None
+
+
+def closed_form_inverse_se3(se3, R=None, T=None):
+    """Compute the inverse of each 4x4 or 3x4 SE3 matrix in a batch."""
+    is_numpy = isinstance(se3, np.ndarray)
+    if se3.shape[-2:] != (4, 4) and se3.shape[-2:] != (3, 4):
+        raise ValueError(f"se3 must have shape (N,4,4) or (N,3,4), got {se3.shape}.")
+    if R is None:
+        R = se3[:, :3, :3]
+    if T is None:
+        T = se3[:, :3, 3:]
+    if is_numpy:
+        r_transposed = np.transpose(R, (0, 2, 1))
+        top_right = -np.matmul(r_transposed, T)
+        inverted_matrix = np.tile(np.eye(4), (len(R), 1, 1))
+    else:
+        r_transposed = R.transpose(1, 2)
+        top_right = -torch.bmm(r_transposed, T)
+        inverted_matrix = torch.eye(4, 4, dtype=R.dtype, device=R.device)[None].repeat(len(R), 1, 1)
+    inverted_matrix[:, :3, :3] = r_transposed
+    inverted_matrix[:, :3, 3:] = top_right
+    return inverted_matrix
+
+
+def align_camera_extrinsics(
+    cameras_src: torch.Tensor,
+    cameras_tgt: torch.Tensor,
+    estimate_scale: bool = True,
+    eps: float = 1e-9,
+):
+    """Align source camera extrinsics to target extrinsics."""
+    r_src = cameras_src[:, :, :3]
+    r_tgt = cameras_tgt[:, :, :3]
+    rr_cov = torch.bmm(r_tgt.transpose(2, 1), r_src).mean(0)
+    u, _, v = torch.svd(rr_cov)
+    align_t_r = v @ u.t()
+
+    t_src = cameras_src[:, :, 3]
+    t_tgt = cameras_tgt[:, :, 3]
+    a = torch.bmm(t_src[:, None], r_src)[:, 0]
+    b = torch.bmm(t_tgt[:, None], r_src)[:, 0]
+    a_mu = a.mean(0, keepdim=True)
+    b_mu = b.mean(0, keepdim=True)
+    if estimate_scale and a.shape[0] > 1:
+        a_centered = a - a_mu
+        b_centered = b - b_mu
+        align_t_s = (a_centered * b_centered).mean() / (a_centered**2).mean().clamp(eps)
+    else:
+        align_t_s = 1.0
+    align_t_t = b_mu - align_t_s * a_mu
+    return align_t_r[None], align_t_t, align_t_s
+
+
+def apply_transformation(
+    cameras_src: torch.Tensor,
+    align_t_r: torch.Tensor,
+    align_t_t: torch.Tensor,
+    align_t_s: float,
+    return_extri: bool = True,
+) -> torch.Tensor:
+    """Apply camera alignment to source extrinsics."""
+    r_src = cameras_src[:, :, :3]
+    t_src = cameras_src[:, :, 3]
+    aligned_r = torch.bmm(r_src, align_t_r.expand(r_src.shape[0], 3, 3))
+    align_t_t_expanded = align_t_t[..., None].repeat(r_src.shape[0], 1, 1)
+    transformed_t = torch.bmm(r_src, align_t_t_expanded)[..., 0]
+    aligned_t = transformed_t + t_src * align_t_s
+    if return_extri:
+        return torch.cat([aligned_r, aligned_t.unsqueeze(-1)], dim=-1)
+    return aligned_r, aligned_t
+
+
+def calc_roterr_rad(r1: Tensor, r2: Tensor) -> Tensor:
+    """Return geodesic rotation error in radians."""
+    return (((r1.transpose(-1, -2) @ r2).diagonal(dim1=-1, dim2=-2).sum(-1) - 1) / 2).clamp(-1, 1).acos()
+
+
+def calc_roterr(r1: Tensor, r2: Tensor) -> Tensor:
+    """Return geodesic rotation error in degrees."""
+    return torch.rad2deg(calc_roterr_rad(r1, r2))
+
+
+def calc_transerr(t1: Tensor, t2: Tensor) -> Tensor:
+    return (t2 - t1).norm(p=2, dim=-1)
+
+
+def calc_cammc(rt1: Tensor, rt2: Tensor) -> Tensor:
+    return (rt2 - rt1).reshape(-1, 12).norm(p=2, dim=-1)
+
+
+def metric(c2w_1: Tensor, c2w_2: Tensor) -> tuple[float, float, float]:
+    """Compute aligned rotation, translation, and camera-motion errors."""
+    w2c_1 = closed_form_inverse_se3(c2w_1)
+    w2c_2 = closed_form_inverse_se3(c2w_2)
+    align_t_r, align_t_t, align_t_s = align_camera_extrinsics(w2c_2[:, :3, :4], w2c_1[:, :3, :4], estimate_scale=True)
+    r_tgt, t_tgt = apply_transformation(w2c_2[:, :3, :4], align_t_r, align_t_t, align_t_s, return_extri=False)
+    w2c_2_align = torch.cat([r_tgt, t_tgt.unsqueeze(-1)], dim=-1)
+    c2w_2 = closed_form_inverse_se3(w2c_2_align)
+
+    rot_err = calc_roterr(c2w_1[:, :3, :3], c2w_2[:, :3, :3]).mean().item()
+    trans_err_rel = calc_transerr(c2w_1[:, :3, 3], c2w_2[:, :3, 3]).mean().item()
+    cam_mc_rel = calc_cammc(c2w_1[:, :3, :4], c2w_2[:, :3, :4]).mean().item()
+    return rot_err, trans_err_rel, cam_mc_rel
+
+
+def relative_pose(rt: Tensor, mode: Literal["left", "right"]) -> Tensor:
+    if mode == "left":
+        return torch.cat([torch.eye(4, device=rt.device).unsqueeze(0), rt[:1].inverse() @ rt[1:]], dim=0)
+    if mode == "right":
+        return torch.cat([torch.eye(4, device=rt.device).unsqueeze(0), rt[1:] @ rt[:1].inverse()], dim=0)
+    raise ValueError(f"Unsupported relative pose mode: {mode}")
+
+
+def run_pi3_inference_batch(model, video_paths, device, interval=1):
+    """Run Pi3 on a batch of videos and return per-video pose outputs."""
+    if load_images_as_tensor is None:
+        raise ImportError("Pi3 image-loading utilities are unavailable. Install Pi3 or place it on PYTHONPATH.")
+
+    imgs_list = []
+    valid_indices = []
+    for i, video_path in enumerate(video_paths):
+        try:
+            img = load_images_as_tensor(video_path, interval=interval).to(device)
+            imgs_list.append(img)
+            valid_indices.append(i)
+        except Exception as exc:
+            print(f"Error loading {video_path}: {exc}")
+
+    if not valid_indices:
+        return [None] * len(video_paths)
+
+    first_shape = imgs_list[0].shape
+    can_batch = all(img.shape == first_shape for img in imgs_list)
+    results_map = {}
+    dtype = (
+        torch.bfloat16 if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 8 else torch.float16
+    )
+
+    if can_batch:
+        try:
+            batch_imgs = torch.stack(imgs_list)
+            with torch.no_grad():
+                with torch.amp.autocast("cuda", dtype=dtype):
+                    res = model(batch_imgs)
+            for idx_in_valid, (pose, points) in enumerate(zip(res["camera_poses"], res["points"])):
+                results_map[valid_indices[idx_in_valid]] = {
+                    "pose": pose,
+                    "points": points,
+                    "img": imgs_list[idx_in_valid],
+                }
+        except Exception as exc:
+            print(f"Batch inference failed, falling back to sequential: {exc}")
+            can_batch = False
+
+    if not can_batch:
+        for valid_index, img in zip(valid_indices, imgs_list):
+            try:
+                with torch.no_grad():
+                    with torch.amp.autocast("cuda", dtype=dtype):
+                        res = model(img[None])
+                results_map[valid_index] = {
+                    "pose": res["camera_poses"][0],
+                    "points": res["points"][0],
+                    "img": img,
+                }
+            except Exception as exc:
+                print(f"Error inferencing {video_paths[valid_index]}: {exc}")
+
+    return [results_map.get(i) for i in range(len(video_paths))]


### PR DESCRIPTION
Adds public SANA-WM benchmark evaluation scripts and updates the benchmark guide with reproducible evaluation commands and dependencies.

Includes:
- Unified VBench / revisit / temporal evaluation script
- Pi3 pose accuracy evaluation script
- Result aggregation script
- Pose utility helpers
- Documentation updates for public benchmark evaluation dependencies and metric conventions