### PR TITLE
Add LTX2 distilled pipeline support

### DIFF
--- a/python/sglang/multimodal_gen/configs/sample/ltx_2.py
+++ b/python/sglang/multimodal_gen/configs/sample/ltx_2.py
@@ -92,6 +92,33 @@ class LTX23SamplingParams(LTX2SamplingParams):
 
 
 @dataclasses.dataclass
+class LTX23DistilledSamplingParams(LTX23SamplingParams):
+    """Sampling parameters matching official LTX-2.3 two-stage distilled defaults."""
+
+    seed: int = 10
+    guidance_scale: float = 1.0
+    num_inference_steps: int = 8
+
+    video_cfg_scale: float = 1.0
+    video_stg_scale: float = 0.0
+    video_rescale_scale: float = 0.0
+    video_modality_scale: float = 1.0
+    video_skip_step: int = 0
+    video_stg_blocks: list[int] = field(default_factory=list)
+
+    audio_cfg_scale: float = 1.0
+    audio_stg_scale: float = 0.0
+    audio_rescale_scale: float = 0.0
+    audio_modality_scale: float = 1.0
+    audio_skip_step: int = 0
+    audio_stg_blocks: list[int] = field(default_factory=list)
+
+    def build_request_extra(self) -> dict[str, Any]:
+        # Official distilled uses a positive-only SimpleDenoiser by default.
+        return SamplingParams.build_request_extra(self)
+
+
+@dataclasses.dataclass
 class LTX23HQSamplingParams(LTX23SamplingParams):
     """Sampling parameters matching official LTX-2.3 HQ two-stage defaults."""
 

--- a/python/sglang/multimodal_gen/registry.py
+++ b/python/sglang/multimodal_gen/registry.py
@@ -111,6 +111,7 @@ from sglang.multimodal_gen.configs.sample.hunyuan3d import Hunyuan3DSamplingPara
 from sglang.multimodal_gen.configs.sample.joy_image import JoyImageEditSamplingParams
 from sglang.multimodal_gen.configs.sample.ltx_2 import (
     LTX2SamplingParams,
+    LTX23DistilledSamplingParams,
     LTX23HQSamplingParams,
     LTX23SamplingParams,
 )
@@ -645,6 +646,11 @@ def _register_configs():
         model_detectors=[
             lambda path: "ltx-2.3" in path.lower(),
         ],
+    )
+    # register dedicated sampling params for LTX2DistilledPipeline
+    _PIPELINE_CONFIG_REGISTRY.setdefault(
+        "LTX2DistilledPipeline",
+        (LTX2PipelineConfig, LTX23DistilledSamplingParams),
     )
     # register dedicated sampling params for LTX2TwoStageHQPipeline
     _PIPELINE_CONFIG_REGISTRY.setdefault(

--- a/python/sglang/multimodal_gen/runtime/pipelines/ltx_2_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/ltx_2_pipeline.py
@@ -10,7 +10,10 @@ from sglang.multimodal_gen.configs.pipeline_configs.ltx_2 import (
     is_ltx23_native_variant,
     sync_ltx23_runtime_vae_markers,
 )
-from sglang.multimodal_gen.configs.sample.ltx_2 import LTX23HQSamplingParams
+from sglang.multimodal_gen.configs.sample.ltx_2 import (
+    LTX23DistilledSamplingParams,
+    LTX23HQSamplingParams,
+)
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
 from sglang.multimodal_gen.runtime.loader.component_loaders.component_loader import (
     PipelineComponentLoader,
@@ -57,10 +60,23 @@ logger = init_logger(__name__)
 
 BASE_SHIFT_ANCHOR = 1024
 MAX_SHIFT_ANCHOR = 4096
+LTX2_DISTILLED_SIGMA_VALUES = [
+    1.0,
+    0.99375,
+    0.9875,
+    0.98125,
+    0.975,
+    0.909375,
+    0.725,
+    0.421875,
+]
 
 
 def _resolve_ltx2_two_stage_component_paths(
-    model_path: str, component_paths: dict[str, str]
+    model_path: str,
+    component_paths: dict[str, str],
+    *,
+    resolve_distilled_lora: bool = True,
 ) -> dict[str, str]:
     resolved = dict(component_paths)
     auto_resolved = []
@@ -78,12 +94,10 @@ def _resolve_ltx2_two_stage_component_paths(
                 auto_resolved.append(f"spatial_upsampler={candidate}")
                 break
 
-    if "distilled_lora" not in resolved:
+    if resolve_distilled_lora and "distilled_lora" not in resolved:
         distilled_lora_candidates = [
             os.path.join(model_path, "ltx-2.3-20b-distilled-lora-384.safetensors"),
-            os.path.join(
-                model_path, "ltx-2.3-22b-distilled-lora-384-1.1.safetensors"
-            ),
+            os.path.join(model_path, "ltx-2.3-22b-distilled-lora-384-1.1.safetensors"),
             os.path.join(model_path, "ltx-2.3-22b-distilled-lora-384.safetensors"),
             os.path.join(model_path, "ltx-2-19b-distilled-lora-384.safetensors"),
         ]
@@ -163,6 +177,9 @@ class LTX2SigmaPreparationStage(PipelineStage):
 
     def forward(self, batch: Req, server_args: ServerArgs) -> Req:
         batch.extra["ltx2_phase"] = "stage1"
+        if server_args.pipeline_class_name == "LTX2DistilledPipeline":
+            batch.sigmas = list(LTX2_DISTILLED_SIGMA_VALUES)
+            return batch
         if is_ltx23_native_variant(server_args.pipeline_config.vae_config.arch_config):
             # Gate on pipeline class to mirror the three official entry points:
             # - HQ (`ti2vid_two_stages_hq.py:164`) calls
@@ -767,8 +784,7 @@ class LTX2TwoStageResidencyController:
     def enter_phase(self, phase: str) -> bool:
         """Switch active two-stage DiT with minimal transfer/sync overhead."""
         if not (
-            self.should_use_premerged
-            or self.pipeline._use_explicit_stage2_transformer
+            self.should_use_premerged or self.pipeline._use_explicit_stage2_transformer
         ):
             return False
         if phase == self._active_phase:
@@ -793,6 +809,7 @@ class LTX2TwoStagePipeline(_BaseLTX2Pipeline):
     STAGE_2_DISTILLED_LORA_STRENGTH = 1.0
     STAGE_1_DENOISING_SAMPLER_NAME = "euler"
     STAGE_2_DENOISING_SAMPLER_NAME = "euler"
+    REQUIRE_DISTILLED_LORA = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -833,7 +850,9 @@ class LTX2TwoStagePipeline(_BaseLTX2Pipeline):
     def initialize_pipeline(self, server_args: ServerArgs):
         super().initialize_pipeline(server_args)
         server_args.component_paths = _resolve_ltx2_two_stage_component_paths(
-            self.model_path, server_args.component_paths
+            self.model_path,
+            server_args.component_paths,
+            resolve_distilled_lora=self.REQUIRE_DISTILLED_LORA,
         )
 
         upsampler_path = server_args.component_paths.get("spatial_upsampler")
@@ -852,7 +871,7 @@ class LTX2TwoStagePipeline(_BaseLTX2Pipeline):
         self.memory_usages["spatial_upsampler"] = memory_usage
 
         distilled_lora_path = server_args.component_paths.get("distilled_lora")
-        if not distilled_lora_path:
+        if not distilled_lora_path and self.REQUIRE_DISTILLED_LORA:
             raise ValueError(
                 f"{self.pipeline_name} requires --distilled-lora-path "
                 "(component_paths['distilled_lora'])."
@@ -924,10 +943,7 @@ class LTX2TwoStagePipeline(_BaseLTX2Pipeline):
                 distilled_lora_strength = self._get_stage_distilled_lora_strength(
                     phase, batch
                 )
-                if (
-                    distilled_lora_strength
-                    != self.STAGE_2_DISTILLED_LORA_STRENGTH
-                ):
+                if distilled_lora_strength != self.STAGE_2_DISTILLED_LORA_STRENGTH:
                     raise ValueError(
                         "Explicit transformer_2 is assumed to already include the "
                         "default stage-2 distilled LoRA. Per-request stage-2 "
@@ -1154,6 +1170,26 @@ class LTX2TwoStagePipeline(_BaseLTX2Pipeline):
         _add_ltx2_decoding_stage(self)
 
 
+class LTX2DistilledPipeline(LTX2TwoStagePipeline):
+    """Two-stage LTX-2 distilled pipeline using a merged distilled checkpoint."""
+
+    pipeline_name = "LTX2DistilledPipeline"
+    pipeline_config_cls = LTX2PipelineConfig
+    sampling_params_cls = LTX23DistilledSamplingParams
+    STAGE_1_DISTILLED_LORA_STRENGTH = 0.0
+    STAGE_2_DISTILLED_LORA_STRENGTH = 0.0
+    REQUIRE_DISTILLED_LORA = False
+
+    @staticmethod
+    def _should_merge_stage2_distilled_lora(server_args: ServerArgs) -> bool:
+        return False
+
+    def _get_stage_distilled_lora_strength(
+        self, phase: str, batch: Req | None
+    ) -> float:
+        return 0.0
+
+
 class LTX2TwoStageHQPipeline(LTX2TwoStagePipeline):
     pipeline_name = "LTX2TwoStageHQPipeline"
     pipeline_config_cls = LTX2PipelineConfig
@@ -1164,4 +1200,9 @@ class LTX2TwoStageHQPipeline(LTX2TwoStagePipeline):
     STAGE_2_DENOISING_SAMPLER_NAME = "res2s"
 
 
-EntryClass = [LTX2Pipeline, LTX2TwoStagePipeline, LTX2TwoStageHQPipeline]
+EntryClass = [
+    LTX2Pipeline,
+    LTX2TwoStagePipeline,
+    LTX2DistilledPipeline,
+    LTX2TwoStageHQPipeline,
+]

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -74,7 +74,11 @@ from sglang.multimodal_gen.utils import (
 logger = init_logger(__name__)
 
 LTX2_TWO_STAGE_DEVICE_MODES = ("original", "snapshot", "resident")
-LTX2_TWO_STAGE_PIPELINE_NAMES = ("LTX2TwoStagePipeline", "LTX2TwoStageHQPipeline")
+LTX2_TWO_STAGE_PIPELINE_NAMES = (
+    "LTX2TwoStagePipeline",
+    "LTX2DistilledPipeline",
+    "LTX2TwoStageHQPipeline",
+)
 # H200-class GPUs (>=130 GiB total) can usually keep both LTX2 DiTs resident.
 LTX2_RESIDENT_AUTO_ENABLE_MEM_GB = 130
 LORA_MERGE_MODES = ("auto", "merge", "dynamic")

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -808,6 +808,30 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertFalse(args.vae_cpu_offload)
         self.assertIsNone(args.layerwise_offload_components)
 
+    def test_auto_high_memory_ltx23_distilled_resident_mode(self):
+        args = self._from_dict_with_pipeline_config(
+            LTX2PipelineConfig(),
+            memory_gb=140,
+            available_memory_gb=134,
+            kwargs={
+                "model_path": "Lightricks/LTX-2.3",
+                "pipeline_class_name": "LTX2DistilledPipeline",
+                "transformer_weights_path": "/models/ltx-2.3-distilled.safetensors",
+                "component_paths": {
+                    "spatial_upsampler": "/models/upsampler.safetensors"
+                },
+            },
+        )
+
+        self.assertEqual(args.ltx2_two_stage_device_mode, "resident")
+        self.assertFalse(args.dit_cpu_offload)
+        self.assertFalse(args.text_encoder_cpu_offload)
+        self.assertFalse(args.image_encoder_cpu_offload)
+        self.assertIsNone(args.layerwise_offload_components)
+        self.assertEqual(
+            args.transformer_weights_path, "/models/ltx-2.3-distilled.safetensors"
+        )
+
     def test_auto_high_memory_ltx23_original_keeps_default_layerwise_components(self):
         args = self._from_dict_with_pipeline_config(
             LTX2PipelineConfig(),


### PR DESCRIPTION
## Summary
- Add `LTX2DistilledPipeline` for official LTX-2.3 distilled two-stage inference.
- Register distilled sampling params with the official 8-step stage-1 sigma schedule and `guidance_scale=1.0`.
- Allow merged distilled checkpoint usage through `transformer_weights_path` without requiring a separate `distilled_lora`.

## Tests
- `python -m py_compile ...`
- `python -m unittest sglang.multimodal_gen.test.unit.test_server_args.TestOffloadDefaults.test_auto_high_memory_ltx23_distilled_resident_mode`
- Ran a one-sample generation smoke test with `LTX2DistilledPipeline` and the official distilled merged checkpoint.

## Scope
This PR adds baseline distilled pipeline support. Fullopt/cache/NVFP4 optimizations are intentionally left for follow-up PRs.