### PR TITLE
Fix cross-warp race in fused GDN backward

### DIFF
--- a/diffusion/model/ops/fused_gdn.py
+++ b/diffusion/model/ops/fused_gdn.py
@@ -1247,10 +1247,14 @@ def _fused_gdn_bwd_kernel(
             # Store dQ_rot temporarily to dqkv[Q] at normal d positions.
             dq_ptrs = dqkv_bh + n_idx[:, None] * stride_n + 0 * stride_3 + offs_d[None, :] * stride_d
             tl.store(dq_ptrs, dQ_rot.to(tl.bfloat16), mask=mask_sd)
+            # The XOR-paired channel can be owned by another warp. Synchronize
+            # both sides of the scratch roundtrip before dqkv is overwritten.
+            tl.debug_barrier()
 
             # Load dQ_rot at paired positions.
             dq_pair_ptrs = dqkv_bh + n_idx[:, None] * stride_n + 0 * stride_3 + offs_d_pair[None, :] * stride_d
             dQ_rot_pair = tl.load(dq_pair_ptrs, mask=mask_sd_pair, other=0.0).to(tl.float32)
+            tl.debug_barrier()
 
             # RoPE inverse: dQ = dQ_rot * Cos - dQ_rot_pair * Sin.
             dQ = dQ_rot * Cos - dQ_rot_pair * Sin + dQ_from_den
@@ -1377,8 +1381,12 @@ def _fused_gdn_bwd_kernel(
                 # ---- RoPE inverse for K ----
                 dk_ptrs = dqkv_bh + n_idx[:, None] * stride_n + 1 * stride_3 + offs_d[None, :] * stride_d
                 tl.store(dk_ptrs, dK_rot.to(tl.bfloat16), mask=mask_sd)
+                # Match the dQ synchronization: all temporary values must be
+                # visible before paired loads and consumed before overwrites.
+                tl.debug_barrier()
                 dk_pair_ptrs = dqkv_bh + n_idx[:, None] * stride_n + 1 * stride_3 + offs_d_pair[None, :] * stride_d
                 dK_rot_pair = tl.load(dk_pair_ptrs, mask=mask_sd_pair, other=0.0).to(tl.float32)
+                tl.debug_barrier()
 
                 dK_from_kv = dK_rot * Cos - dK_rot_pair * Sin
                 dK_total = dK_from_kv + dK_z


### PR DESCRIPTION
## Summary

- synchronize the dQ/dK RoPE scratch exchange in the fused GDN backward kernel
- prevent nondeterministic cross-warp gradients without changing the forward path, public API, or checkpoint schema

## Root cause

`_fused_gdn_bwd_kernel` temporarily stores raw dQ/dK values in `dqkv`, loads each paired rotary channel, and then overwrites the current channel with the inverse-RoPE result. In a multi-warp program the paired channel can be produced by another warp. Without CTA-wide synchronization, the paired load can race both the initial store and another warp's overwrite.

## Fix

Add a CTA barrier after each temporary dQ/dK store and another after each paired load. This completes the scratch-buffer exchange before the buffer is reused in place.

## Validation

- A production-kernel regression exercises both `REVERSE_BWD` directions over repeated multi-warp launches.
- The unpatched public kernel failed both directions on GB200; the patched kernel passed both tests.
- Additional H100 coverage passed 79/79 focused cases and 31/31 real-scale cases.
- A focused before/after benchmark showed no measurable performance regression.