### PR TITLE
[SANA-WM] Release ODE and self-forcing distillation training

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -262,6 +262,48 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           sana-run --pty -m ci -J test-training-sana-wm-stage1 bash tests/bash/training/test_training_sana_wm_stage1.sh
+  test-training-sana-wm-distill:
+    needs: pre-commit
+    if: |
+      github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' ||
+      github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'run-tests')
+    runs-on:
+      - self-hosted
+      - sana-runner
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - name: Clean Python caches
+        run: |
+          echo "Removing stale Python byte code files..."
+          find . -type d -name "__pycache__" -exec rm -rf {} +
+          find . -type f -name "*.pyc" -delete
+      - name: Set up the environment
+        env:
+          SANA_SLURM_ACCOUNT: ${{ secrets.SANA_SLURM_ACCOUNT }}
+          SANA_SLURM_PARTITION: ${{ secrets.SANA_SLURM_PARTITION }}
+          SKIP_ENV_SETUP: true
+        run: |
+          bash environment_setup.sh
+      - name: Update 'sana-run' command in the Runner's default env
+        env:
+          CONDA_SH_PATH: ${{ secrets.CONDA_SH_PATH }}
+          CONDA_ENV_NAME: ${{ secrets.CONDA_ENV_NAME }}
+        run: |
+          echo "--- Updating 'sana-run' command on the CI runner ---"
+          source "$CONDA_SH_PATH"
+          conda activate "$CONDA_ENV_NAME"
+          pip install -e .
+          echo "--- 'sana-run' command updated. ---"
+      - name: Run SANA-WM distillation training test
+        env:
+          CONDA_ENV_NAME: ${{ secrets.CONDA_ENV_NAME }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          sana-run --pty -m ci -J test-training-sana-wm-distill bash tests/bash/training/test_training_sana_wm_distill.sh
   test-training-longsana:
     needs: pre-commit
     if: |
@@ -347,7 +389,7 @@ jobs:
         run: |
           sana-run --pty -m ci -J test-training-sol-rl bash tests/bash/training/test_training_sol_rl.sh
   remove-label:
-    needs: [test-inference, test-training-vae, test-training-fsdp, test-training-video, test-training-sana-wm-stage1, test-training-longsana, test-training-sol-rl]
+    needs: [test-inference, test-training-vae, test-training-fsdp, test-training-video, test-training-sana-wm-stage1, test-training-sana-wm-distill, test-training-longsana, test-training-sol-rl]
     if: always() && github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/asset/docs/sana_wm.md
+++ b/asset/docs/sana_wm.md
@@ -1,5 +1,5 @@
 <p align="center" style="border-radius: 10px">
-  <img src="../sana-wm-logo.png" width="70%" alt="SANA-WM Logo"/>
+  <img src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/asset/sana-wm-logo.png" width="70%" alt="SANA-WM Logo"/>
 </p>
 
 # 🌍 SANA-WM: Efficient Minute-Scale World Modeling with Hybrid Linear Diffusion Transformer
@@ -11,7 +11,7 @@
 </div>
 
 <div align="center">
-  <video src="https://nvlabs.github.io/Sana/WM/media/videos/hero_reel_v9.mp4#t=1" autoplay playsinline controls muted loop width="90%" onloadedmetadata="this.currentTime=1;this.playbackRate=5"></video>
+  <video src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/WM/media/videos/hero_reel_v9.mp4#t=1" autoplay playsinline controls muted loop width="90%" onloadedmetadata="this.currentTime=1;this.playbackRate=2"></video>
 </div>
 
 ## 📽️ About SANA-WM
@@ -25,9 +25,14 @@ Core contributions:
 - **Two-Stage Generation Pipeline** — a long-video refiner stitched on top of Stage-1 latents improves quality and temporal consistency.
 - **Robust Annotation Pipeline** — metric-scale 6-DoF camera poses extracted from public corpora yield spatiotemporally consistent action supervision.
 
-SANA-WM completes pre-training in 15 days on 64 H100s and generates a 60s 720p clip on a single GPU; the distilled variant runs on an RTX 5090 with NVFP4 quantisation.
+SANA-WM completes pre-training in 15 days on 64 H100s and generates a 60s 720p clip on a single GPU.
 
-> **Note** This is the initial release and currently ships **bidirectional inference only**. More variants are on the way — stay tuned.
+> **Note** Building on the original **bidirectional** pipeline (full-sequence
+> Stage 1 + sink-bidirectional refiner), this release adds a new **streaming**
+> pipeline: a chunk-causal distilled Stage 1 + chunk-causal refiner + causal-VAE
+> decoder, overlapped on three CUDA streams and written progressively to MP4 so
+> you can watch the clip as it generates. Streaming weights are released under
+> [`SANA-WM_streaming`](https://huggingface.co/Efficient-Large-Model/SANA-WM_streaming).
 
 ## ⚙️ Environment Setup
 
@@ -49,18 +54,27 @@ fetched on first use from
 python inference_video_scripts/wm/inference_sana_wm.py \
   --image      asset/sana_wm/demo_0.png \
   --prompt     asset/sana_wm/demo_0.txt \
-  --action     "w-80,jw-40,w-40,lw-60,w-100" \
-  --translation_speed 0.055 \
-  --rotation_speed_deg 1.2 \
+  --action     "w-100,dw-60,w-100,aw-60" \
   --num_frames 321 \
   --output_dir results/sana_wm_demo
 ```
 
-Action DSL: each segment is `<keys>-<frames>` joined by commas. Movement keys
-`w` (forward), `a` (strafe left), `s` (back), `d` (strafe right) translate
-on the world horizontal plane; rotation keys `i` (pitch up), `k` (pitch
-down), `j` (yaw left), `l` (yaw right) act in the camera's local frame.
-`none-N` holds the pose for `N` frames.
+Action DSL: each segment is `<keys>-<frames>` joined by commas. The control
+scheme is: `w` / `s` forward / back
+(translation along the heading), `a` / `d` yaw left / right (turn),
+`i` / `k` pitch up / down, `j` / `l` strafe left / right. `none-N` holds the
+pose for `N` frames. Held keys ease in/out with light inertia (instant on a
+fresh press, gentle coast on release); default speeds are gentle
+(`--translation_speed 0.025`, `--rotation_speed_deg 0.6`).
+
+> **⚠️ Mapping update (breaking change vs the first release).** The `--action`
+> keys were remapped so the demo and CLI share one control scheme: **`a` / `d`
+> now yaw** (previously strafe) and **`j` / `l` now strafe** (previously yaw);
+> `w` / `s` (forward/back) and `i` / `k` (pitch) are unchanged, and the old
+> implicit a/d→steer coupling is gone. Motion is also smoothed now and the
+> default speeds are gentler. **If you have action strings from the earlier
+> release, swap `a`/`d` ↔ `j`/`l`** to reproduce the same motion (the CLI also
+> prints this notice once when `--action` is used).
 
 ### Example 2 — image + prompt + camera trajectory (`.npy`)
 
@@ -80,12 +94,277 @@ matrices); `--intrinsics` is `.npy` of shape `(3, 3)`, `(F, 3, 3)`, or
 omitted we estimate it from `--image` with Pi3X and abort if the
 resulting FOV is outside `[25°, 120°]`.
 
+### Example gallery
+
+The release ships five first-frame + prompt + camera examples under
+`asset/sana_wm/` — `demo_{0..4}.{png,txt}`, each with a rolled-out `_pose.npy`
+trajectory and an `_intrinsics.npy`. Swap `demo_0` for any of them in the
+commands above (works for both the bidirectional and streaming scripts). The
+actions are gentle by design — slow forward drift with light left/right
+look-around.
+
+| Example | Scene | `--action` |
+|---------|-------|------------|
+| `demo_0` | salt-desert / black supercar | `w-100,dw-60,w-100,aw-60` |
+| `demo_1` | bioluminescent cave | `w-35,aw-60,dw-100,aw-55,w-25,none-50` |
+| `demo_2` | mushroom forest / robot | `w-25,aw-60,dw-100,aw-55,none-85`  (+ `--translation_speed 0.015`) |
+| `demo_3` | salt flat / supercar | `w-70,none-40,dw-35,w-70,aw-35,none-72` |
+| `demo_4` | ice plain / portal | `w-95,aw-35,w-70,dw-35,none-87` |
+
+The `_pose.npy` files already bake in these actions (and `demo_2`'s slower
+speed), so `--camera asset/sana_wm/demo_N_pose.npy` reproduces the same motion
+as the matching `--action` string.
+
+### 80-scene benchmark
+
+For the fixed 80-scene, 60s SANA-WM benchmark release and reproducible
+bidirectional inference/evaluation workflow, see
+[SANA-WM benchmark guide](sana-wm-bench.md).
+
 ### Lower memory
 
 For tight VRAM budgets, opt in to lazy-load + CPU offload:
 
 ```bash
 ... --offload_vae --offload_refiner
+```
+
+### Streaming inference
+
+The streaming pipeline replaces all three full-sequence stages with chunk-causal
+variants and emits one decoded chunk per AR block straight into a progressive
+MP4. Stage 1 runs the 4-step distilled student (CFG-baked-in, runs at
+`cfg_scale=1`), the refiner runs chunk-causal AR with a sliding KV window, and
+the causal LTX-2 VAE decodes chunk-by-chunk.
+
+All streaming weights (DiT, causal VAE, refiner, and the Gemma text encoder)
+are fetched on first use from
+[`SANA-WM_streaming`](https://huggingface.co/Efficient-Large-Model/SANA-WM_streaming)
+— no manual download required, exactly like the bidirectional path. The
+inference YAML ships in-repo under `configs/sana_wm/`. Just run:
+
+```bash
+python inference_video_scripts/wm/inference_sana_wm_streaming.py \
+  --image       asset/sana_wm/demo_0.png \
+  --prompt      asset/sana_wm/demo_0.txt \
+  --action      "w-80,dw-40,w-80,aw-40" \
+  --num_frames  241 \
+  --output_dir  results/sana_wm_streaming
+```
+
+`--num_frames` defaults to **241 (~15s @ 16fps)**. It is snapped to
+`8·refiner_block_size·k + 1` so the VAE and refiner chunking divide evenly
+(241 = 24·10+1 needs no snap). Use a larger value (e.g. 961 for ~60s) for longer
+clips.
+
+Output lands at `results/sana_wm_streaming/<name>_streaming.mp4` and grows in
+place — you can watch it while inference continues. Reaches **~0.93× realtime
+on a single H100** after a one-time `torch.compile` warmup (~3 min cold, ~30 s
+warm cache; the warmup amortises across runs that reuse the same shapes).
+
+All speed-critical knobs are baked into the script as defaults — `torch.compile`
+on the **refiner transformer** (`max-autotune-no-cudagraphs` mode), flash-only
+SDPA, Inductor `coordinate_descent_tuning` + `epilogue_fusion`, cuDNN benchmark,
+and the expandable CUDA allocator. The causal VAE decoder is intentionally **not**
+compiled: `torch.compile` corrupts its cross-chunk causal cache (chunk 0 decodes
+fine but later chunks come out blank/gray), so it runs eager. There is no
+slow/fast toggle; the script is the fast config.
+
+Overrides for advanced use:
+
+- `--streaming_root <path>` — optional LOCAL bundle dir holding `sana_dit/`,
+  `ltx2_causal_vae/`, `refiner_diffusers/`, `gemma3_12b/`. Unset by default, in
+  which case each artefact is pulled from `hf://Efficient-Large-Model/SANA-WM_streaming`.
+- `--config / --model_path / --causal_vae_path / --refiner_root / --refiner_gemma_root` — point at non-default weight paths (local path or
+  `hf://` URI). `--config` defaults to the in-repo
+  `configs/sana_wm/sana_wm_streaming_1600m_720p.yaml`.
+- `--num_frame_per_block` (default 3, must match the checkpoint's
+  `chunk_size`), `--denoising_step_list` (default
+  `"1000,960,889,727,0"`), `--refiner_block_size` (3), `--refiner_kv_max_frames`
+  (11) — change the canonical recipe at your own quality risk.
+
+### ⚡ Quantized inference (fp8 / fp4)
+
+Streaming supports **per-component** low-precision compute to cut peak VRAM, set
+independently for the stage-1 DiT and the LTX-2 refiner:
+
+```bash
+python inference_video_scripts/wm/inference_sana_wm_streaming.py \
+  --image       asset/sana_wm/demo_0.png \
+  --prompt      asset/sana_wm/demo_0.txt \
+  --action      "w-80,dw-40,w-80,aw-40" \
+  --num_frames  241 \
+  --stage1_precision  fp4 \
+  --refiner_precision fp4 \
+  --output_dir  results/sana_wm_streaming
+```
+
+`--stage1_precision` / `--refiner_precision` each take `bf16` (default, any GPU),
+`fp8` (FP8 W8A8, Hopper **and** Blackwell), or `fp4` (NVFP4 W4A4, **Blackwell
+only** — sm_100/sm_120). Quantization touches only the linear GEMMs (self-attn,
+cross-attn, FFN), scoped **per transformer block** so the camera/action
+conditioning math stays in native precision and action-following is preserved.
+
+**Requirements.** fp8/fp4 need [NVIDIA Transformer Engine](https://github.com/NVIDIA/TransformerEngine)
+≥ 2.0, which `environment_setup.sh` installs by default. If you skipped it
+(`SANA_SKIP_TE=1`) the script exits with an install hint; bf16 needs nothing
+extra. fp4 additionally requires a Blackwell GPU (GB200, B200, RTX 50-series).
+
+Quantization is primarily a **memory** optimization — the GEMMs are
+latency-bound at these chunk sizes, so bf16 is already near the compute roofline
+and lower precision mainly buys VRAM headroom (and a modest GB200 speedup).
+
+Steady-state throughput and peak VRAM, **SANA-WM stages only** (excludes the
+one-time Pi3X intrinsics estimate and first-chunk `torch.compile` warmup),
+default `--refiner_kv_max_frames 11`:
+
+| stage-1 / refiner | peak VRAM | H100 (×realtime) | GB200 (×realtime) |
+|---|---|---|---|
+| bf16 / bf16 | 47.3 GB | 1.09× | 1.27× |
+| fp8 / fp8 | 35.4 GB | ~1.00× *(est.)* | 1.16× |
+| fp4 / fp4 | 29.4 GB | — (Blackwell only) | 1.16× |
+
+> 🎯 **Runs on a 32 GB RTX 5090:** `--stage1_precision fp4 --refiner_precision fp4` fits in **29.4 GB** (the bf16 default needs 47 GB). fp4 requires Blackwell,
+> which the 5090 is; the ×realtime figures above are measured on GB200/B200.
+
+A tighter KV window (`--refiner_kv_max_frames 2`) drops VRAM further and is
+faster, at a **quality cost** (more temporal flicker / drift — not recommended
+for final renders):
+
+| stage-1 / refiner | peak VRAM | H100 (×realtime) | GB200 (×realtime) |
+|---|---|---|---|
+| bf16 / bf16 | 37.4 GB | 1.26× | 1.57× |
+| fp8 / fp8 | 25.4 GB | — | 1.32× |
+| fp4 / fp4 | 25.0 GB | — | 1.25× |
+
+**Picking a precision:** bf16 for best quality on any GPU; **fp8** for Hopper
+(H100) users who want lower VRAM with no Blackwell requirement; **fp4** for
+Blackwell, the only setting that fits the 47 GB bf16 model onto a 32 GB card. You
+can mix (e.g. `--stage1_precision bf16 --refiner_precision fp8`).
+
+> **Note:** quantization does not change the intrinsic long-rollout drift of the
+> AR stage-1 backbone — very long clips slowly lose scene consistency regardless
+> of precision. This is a property of the autoregressive teacher, not the quant.
+
+## Chunk-Causal Stage-1 Teacher
+
+The chunk-causal Stage-1 teacher is an intermediate research checkpoint: only
+the Stage-1 Sana DiT is chunk-causal, while inference keeps the bidirectional
+LTX-2 VAE and refiner path enabled by default. It is released mainly so users
+can reproduce the CP/FSDP2 Stage-1 training path and experiment with future
+chunk-causal models. It may show severe artifacts, temporal flicker, or weaker
+camera adherence than the full bidirectional / streaming releases; keep the
+default refiner on for qualitative samples and use `--no_refiner` only for fast
+Stage-1 debugging.
+
+The public config sets `scheduler.vis_sampler: chunk_flow_euler`, so the CLI's
+default `--sampling_algo auto` selects the correct sampler:
+
+```bash
+python inference_video_scripts/wm/inference_sana_wm.py \
+  --config     hf://Efficient-Large-Model/SANA-WM_chunk_causal/config.yaml \
+  --model_path hf://Efficient-Large-Model/SANA-WM_chunk_causal/dit/sana_wm_chunk_causal_1600m_720p.safetensors \
+  --image      asset/sana_wm/demo_0.png \
+  --prompt     asset/sana_wm/demo_0.txt \
+  --action     "w-240,dw-120,w-120,aw-180,w-300" \
+  --num_frames 961 \
+  --offload_refiner \
+  --output_dir results/sana_wm_chunk_causal
+```
+
+`--offload_refiner` only changes model residency; the bidirectional refiner still
+runs unless `--no_refiner` is passed.
+
+`chunk_flow_euler` uses `interval_k = 1 / num_chunks` by default. Override it
+with `--chunk_interval_k` only for ablations.
+
+## Chunk-Causal Stage-1 Training on Sekai-Game
+
+This repo includes the minimal chunk-causal Stage-1 training path:
+
+- training script: `train_video_scripts/train_sana_wm_stage1.py`
+- training config: `configs/sana_wm/stage1/sana_wm_stage1_sekai_chunk_causal_cp2_fsdp2.yaml`
+- latent dataset loader: `diffusion/data/datasets/video/sana_wm_zip_latent_data.py`
+- CP2/FSDP2 smoke test: `tests/bash/training/test_training_sana_wm_stage1.sh`
+
+The example can run directly from the public HF dataset
+[`Efficient-Large-Model/SANA-WM-example-training-dataset`](https://huggingface.co/datasets/Efficient-Large-Model/SANA-WM-example-training-dataset).
+The config downloads the dataset on the main rank, waits for all ranks, and
+trains from the chunk-causal Stage-1 teacher checkpoint with FSDP2 and CP2:
+
+```bash
+torchrun --nproc_per_node=8 --master_port=29500 \
+  train_video_scripts/train_sana_wm_stage1.py \
+  --config_path configs/sana_wm/stage1/sana_wm_stage1_sekai_chunk_causal_cp2_fsdp2.yaml
+```
+
+The dataset repo is about 235 GB and is laid out so the config paths resolve to:
+
+```yaml
+data:
+  hf_dataset_repo: Efficient-Large-Model/SANA-WM-example-training-dataset
+  hf_dataset_revision: 4d965e94b9ea11b9c5ba085251ffa7a0345e006f
+  hf_dataset_local_dir: .
+  data_dir:
+    sekai_game: data/sekai_game_train_961frames_16fps_ovl640
+  vae_cache_dir: data/vae_cache/LTX2VAE_diffusers_704x1280/sekai_game_train_961frames_16fps_ovl640
+model:
+  load_from: hf://Efficient-Large-Model/SANA-WM_chunk_causal/dit/sana_wm_chunk_causal_1600m_720p.safetensors
+  attn_type: ChunkCausalGDNTriton
+  camctrl_type: ChunkCausalGDNUCPESinglePathLiteLABothTriton
+train:
+  use_fsdp: true
+  fsdp_version: 2
+  cp_size: 2
+```
+
+Set `data.hf_dataset_local_dir` to a shared filesystem path if you do not want
+the dataset under the repo checkout. Relative `data_dir` and `vae_cache_dir`
+entries are resolved under that directory after download.
+
+The Sekai-derived dataset is redistributed for non-commercial research use
+only. See the dataset card, `LICENSE`, and `NOTICE.md` in the HF dataset repo
+before training or redistributing derivatives.
+
+This public Stage-1 recipe matches the released model, 121-frame latent shape,
+CP2, three-frame chunking, and hybrid GDN/softmax settings. It intentionally
+uses only the redistributable Sekai camera-control data; the internal training
+curriculum also mixed separate video-only and no-camera data sources. Exact
+weight reproduction therefore requires the original data mixture.
+
+## ODE and Self-Forcing Distillation
+
+The implementation lives in
+`diffusion/longsana/trainer/sana_wm_distill.py` and is selected by
+`train_video_scripts/train_longsana.py` through `trainer: wm_ode` or
+`trainer: wm_self_forcing`. The three public configs provide the T43 ODE, T43
+self-forcing warmup, and T121 self-forcing/DMD stages with the released data
+and checkpoints:
+
+The CI smoke test at
+`tests/bash/training/test_training_sana_wm_distill.sh` follows the same three
+stages with deterministic synthetic trajectory/latent fixtures. It runs one
+optimizer step per stage and passes the saved ODE checkpoint into T43, then the
+saved generator/critic checkpoint into the T121 sink + sliding-cache stage.
+
+```bash
+# T43 ODE regression (FSDP2, no CP). Set data_path first.
+torchrun --nproc_per_node=8 \
+  train_video_scripts/train_longsana.py \
+  --config_path configs/sana_wm/distill/ode_t43.yaml \
+  --disable-wandb
+
+# T43 self-forcing warmup (8 GPUs, CP4 / DP2).
+torchrun --nproc_per_node=8 \
+  train_video_scripts/train_longsana.py \
+  --config_path configs/sana_wm/distill/self_forcing_t43.yaml \
+  --disable-wandb
+
+# T121 self-forcing + DMD (8 GPUs, CP4 / DP2).
+torchrun --nproc_per_node=8 \
+  train_video_scripts/train_longsana.py \
+  --config_path configs/sana_wm/distill/self_forcing_t121.yaml \
+  --disable-wandb
 ```
 
 ## 🎛️ Argument Reference
@@ -95,20 +374,24 @@ For tight VRAM budgets, opt in to lazy-load + CPU offload:
 | `--image` | First-frame RGB image. Aspect-preserving resized + center-cropped to 704×1280. |
 | `--prompt` | UTF-8 text file with the conditioning prompt. |
 | `--camera` | `(F, 4, 4)` `.npy` camera-to-world matrices. Mutually exclusive with `--action`. |
-| `--action` | WASD/IJKL DSL. Rolled out via `action_string_to_c2w` to a `(F+1, 4, 4)` trajectory. |
-| `--translation_speed` | Per-frame translation magnitude (default `0.05`). |
-| `--rotation_speed_deg` | Per-frame rotation magnitude in degrees (default `1.2`). |
+| `--action` | Control DSL (`w/s` move, `a/d` yaw, `i/k` pitch, `j/l` strafe). Rolled out via `action_string_to_c2w` (smoothed) to a `(F+1, 4, 4)` trajectory. |
+| `--translation_speed` | Per-frame translation magnitude (default `0.025`). |
+| `--rotation_speed_deg` | Per-frame rotation magnitude in degrees (default `0.6`). |
 | `--intrinsics` | Optional `.npy` of shape `(3, 3)`, `(F, 3, 3)`, or `(4,)`. Pi3X-estimated if omitted. |
-| `--num_frames` | Total frames to generate (default `161`; the demos above use `321`). |
+| `--num_frames` | Total frames to generate (default `161`; the streaming demo uses `241`; the chunk-causal Stage-1 teacher example uses `961`). |
 | `--fps` | Output mp4 frame rate (default `16`). |
 | `--step` | Stage-1 DiT sampling steps (default `60`). |
 | `--cfg_scale` | Classifier-free-guidance scale (default `5.0`). |
 | `--flow_shift` | Override the scheduler's `inference_flow_shift`. |
-| `--no_refiner` | Skip the LTX-2 refiner and decode Stage-1 latents with the Sana VAE (faster, lower quality). |
+| `--no_refiner` | The LTX-2 refiner is enabled by default. This flag skips it and decodes Stage-1 latents with the Sana VAE for fast, lower-quality debugging. |
 | `--refiner_root` | LTX-2 refiner root containing `transformer/` and `connectors/`. |
 | `--no_action_overlay` | Skip the WASD + joystick overlay on the output video. |
 | `--offload_vae` | Move the VAE to CPU between encode / decode steps. |
 | `--offload_refiner` | Lazy-load the LTX-2 refiner only when needed; release afterwards. |
+| `--stage1_precision` | Streaming only. Stage-1 DiT compute precision: `bf16` (default), `fp8` (Hopper+/Blackwell), `fp4` (Blackwell only). fp8/fp4 need Transformer Engine. |
+| `--refiner_precision` | Streaming only. LTX-2 refiner compute precision: `bf16` (default), `fp8`, `fp4`. See [Quantized inference](#-quantized-inference-fp8--fp4). |
+| `--sampling_algo` | `auto` (default). Uses `chunk_flow_euler` for chunk-causal teacher configs and `flow_euler_ltx` otherwise. For streaming use the dedicated `wm/inference_sana_wm_streaming.py`. |
+| `--chunk_interval_k` | Optional `chunk_flow_euler` interval override. Defaults to `1 / num_chunks`. |
 
 ## 📁 HF Repository Layout
 
@@ -122,19 +405,37 @@ For tight VRAM budgets, opt in to lazy-load + CPU offload:
 | Gemma text encoder for the refiner | `refiner/text_encoder/` | 46 GB |
 | Inference config | `config.yaml` | — |
 
+`Efficient-Large-Model/SANA-WM_streaming` (streaming variant):
+
+| Component | Path |
+|------------------------------------|----------------------------------------------|
+| Chunk-causal Sana DiT (distilled) | `sana_dit/model.pt` |
+| Causal LTX-2 VAE | `ltx2_causal_vae/` |
+| Chunk-causal LTX-2 refiner | `refiner_diffusers/{transformer,connectors}/` |
+| Gemma-3-12B text encoder (refiner) | `gemma3_12b/` |
+
+`Efficient-Large-Model/SANA-WM_chunk_causal` (Stage-1 teacher):
+
+| Component | Path |
+|------------------------------------|------------------------------------------------------------|
+| Chunk-causal Sana DiT (Stage 1) | `dit/sana_wm_chunk_causal_1600m_720p.safetensors` |
+| Inference config | `config.yaml` |
+
+The chunk-causal teacher repo intentionally contains only the Stage-1 config and
+DiT weights. The CLI resolves the bidirectional VAE, LTX-2 refiner, and refiner
+text encoder from `Efficient-Large-Model/SANA-WM_bidirectional` by default to
+avoid duplicating large immutable artifacts.
+
 The Sana text encoder (`gemma-2-2b-it`) is fetched separately from
 `Efficient-Large-Model/gemma-2-2b-it`.
 
 ## 📝 BibTeX
 
 ```bibtex
-@misc{zhu2026sanawm,
-      title={SANA-WM: Efficient Minute-Scale World Modeling with Hybrid Linear Diffusion Transformer},
-      author={Haoyi Zhu and Haozhe Liu and Yuyang Zhao and Tian Ye and Junsong Chen and Jincheng Yu and Tong He and Song Han and Enze Xie},
-      year={2026},
-      eprint={2605.15178},
-      archivePrefix={arXiv},
-      primaryClass={cs.CV},
-      url={https://arxiv.org/abs/2605.15178},
+@article{zhu2026sana,
+  title={Sana-wm: Efficient minute-scale world modeling with hybrid linear diffusion transformer},
+  author={Zhu, Haoyi and Liu, Haozhe and Zhao, Yuyang and Ye, Tian and Chen, Junsong and Yu, Jincheng and He, Tong and Han, Song and Xie, Enze},
+  journal={arXiv preprint arXiv:2605.15178},
+  year={2026}
 }
 ```

--- a/configs/sana_wm/distill/ode_t43.yaml
+++ b/configs/sana_wm/distill/ode_t43.yaml
@@ -1,0 +1,37 @@
+trainer: wm_ode
+work_dir: output/sana_wm_distill_ode_t43
+
+model_config: configs/sana_wm/sana_wm_chunk_causal_1600m_720p.yaml
+model_path: hf://Efficient-Large-Model/SANA-WM_chunk_causal/dit/sana_wm_chunk_causal_1600m_720p.safetensors
+
+# LMDB schema is documented by SanaWMOdeTrajectoryDataset. Replace this with
+# the local trajectory cache produced from the same five-step schedule.
+data_path: data/sana_wm_ode_t43
+max_samples: null
+num_latent_frames: 43
+denoising_step_list: [1000, 967, 908, 764, 0]
+
+optimizer:
+  lr: 2.0e-5
+  betas: [0.9, 0.999]
+  weight_decay: 0.01
+
+train:
+  seed: 42
+  batch_size: 1
+  num_workers: 0
+  # The self-forcing curriculum starts from the ODE step-3000 checkpoint.
+  max_steps: 3000
+  log_interval: 10
+  # A full FSDP2+optimizer checkpoint is large; save the final state by default.
+  save_model_steps: 3000
+  early_stop_hours: 0
+  gradient_accumulation_steps: 1
+  gradient_clip: 1.0
+  grad_checkpointing: true
+  use_fsdp: true
+  fsdp_version: 2
+
+resume_from: null
+report_to: none
+tracker_project_name: sana-wm-distill

--- a/configs/sana_wm/distill/ode_t43.yaml
+++ b/configs/sana_wm/distill/ode_t43.yaml
@@ -1,21 +1,17 @@
 trainer: wm_ode
 work_dir: output/sana_wm_distill_ode_t43
-
 model_config: configs/sana_wm/sana_wm_chunk_causal_1600m_720p.yaml
 model_path: hf://Efficient-Large-Model/SANA-WM_chunk_causal/dit/sana_wm_chunk_causal_1600m_720p.safetensors
-
 # LMDB schema is documented by SanaWMOdeTrajectoryDataset. Replace this with
 # the local trajectory cache produced from the same five-step schedule.
 data_path: data/sana_wm_ode_t43
 max_samples: null
 num_latent_frames: 43
 denoising_step_list: [1000, 967, 908, 764, 0]
-
 optimizer:
   lr: 2.0e-5
   betas: [0.9, 0.999]
   weight_decay: 0.01
-
 train:
   seed: 42
   batch_size: 1
@@ -31,7 +27,6 @@ train:
   grad_checkpointing: true
   use_fsdp: true
   fsdp_version: 2
-
 resume_from: null
 report_to: none
 tracker_project_name: sana-wm-distill

--- a/configs/sana_wm/distill/self_forcing_t121.yaml
+++ b/configs/sana_wm/distill/self_forcing_t121.yaml
@@ -1,6 +1,5 @@
 trainer: wm_self_forcing
 work_dir: output/sana_wm_distill_self_forcing_t121
-
 # Run self_forcing_t43.yaml first. T121 continues both its generator and
 # learned fake score model; the real score model stays the public teacher.
 model_config: configs/sana_wm/sana_wm_streaming_1600m_720p.yaml
@@ -9,7 +8,6 @@ fake_model_config: configs/sana_wm/sana_wm_1600m_720p.yaml
 fake_model_path: output/sana_wm_distill_self_forcing_t43/checkpoints/step_000700/model.pt
 real_model_config: configs/sana_wm/sana_wm_1600m_720p.yaml
 real_model_path: hf://Efficient-Large-Model/SANA-WM_bidirectional/dit/sana_wm_1600m_720p.safetensors
-
 data:
   hf_dataset_repo: Efficient-Large-Model/SANA-WM-example-training-dataset
   hf_dataset_revision: 4d965e94b9ea11b9c5ba085251ffa7a0345e006f
@@ -45,7 +43,6 @@ data:
   return_chunk_plucker: true
   vae_ratio: [8, 32]
   cam_sample_strategy: last
-
 num_latent_frames: 121
 num_cached_blocks: 2
 sink_token: true
@@ -58,7 +55,6 @@ min_score_timestep: 20
 max_score_timestep: 980
 real_guidance_scale: 3.0
 negative_prompt: A chaotic sequence with misshapen, deformed limbs in heavy motion blur, sudden disappearance, jump cuts, jerky movements, rapid shot changes, frames out of sync, inconsistent character shapes, temporal artifacts, jitter, and ghosting effects, creating a disorienting visual experience.
-
 optimizer:
   lr: 1.0e-5
   betas: [0.0, 0.999]
@@ -67,7 +63,6 @@ critic_optimizer:
   lr: 2.0e-6
   betas: [0.0, 0.999]
   weight_decay: 0.0
-
 train:
   seed: 0
   batch_size: 1
@@ -91,7 +86,6 @@ train:
       fsdp2:
         reshard_after_forward: true
         limit_all_gathers: false
-
 resume_from: null
 report_to: none
 tracker_project_name: sana-wm-distill

--- a/configs/sana_wm/distill/self_forcing_t121.yaml
+++ b/configs/sana_wm/distill/self_forcing_t121.yaml
@@ -1,0 +1,97 @@
+trainer: wm_self_forcing
+work_dir: output/sana_wm_distill_self_forcing_t121
+
+# Run self_forcing_t43.yaml first. T121 continues both its generator and
+# learned fake score model; the real score model stays the public teacher.
+model_config: configs/sana_wm/sana_wm_streaming_1600m_720p.yaml
+model_path: output/sana_wm_distill_self_forcing_t43/checkpoints/step_000700/model.pt
+fake_model_config: configs/sana_wm/sana_wm_1600m_720p.yaml
+fake_model_path: output/sana_wm_distill_self_forcing_t43/checkpoints/step_000700/model.pt
+real_model_config: configs/sana_wm/sana_wm_1600m_720p.yaml
+real_model_path: hf://Efficient-Large-Model/SANA-WM_bidirectional/dit/sana_wm_1600m_720p.safetensors
+
+data:
+  hf_dataset_repo: Efficient-Large-Model/SANA-WM-example-training-dataset
+  hf_dataset_revision: 4d965e94b9ea11b9c5ba085251ffa7a0345e006f
+  hf_dataset_local_dir: .
+  hf_dataset_allow_patterns: [data/**]
+  data_dir:
+    sekai_game: data/sekai_game_train_961frames_16fps_ovl640
+  external_caption_suffixes: [_LongSceneStaticCaption-Qwen3-VL-30B-A3B-Instruct]
+  caption_proportion:
+    sekai_game:
+      _LongSceneStaticCaption-Qwen3-VL-30B-A3B-Instruct: 100
+  data_repeat:
+    sekai_game: 16
+  external_data_filter:
+    sekai_game:
+      _vmafmotion: {min: 0.5, max: 50}
+      _unimatch: {min: 3.0, max: 80}
+      _dover: {min: 0.25, max: 1.0}
+      _vlm_entity_filter: {min: 0, max: 10}
+      _vlm_quality_filter: {min: 0.5, max: 1.5}
+  type: SanaWMZipLatentDataset
+  image_size: 720
+  aspect_ratio_type: ASPECT_RATIO_VIDEO_720_MS_DIV32
+  transform: default_train_video
+  load_text_feat: false
+  load_vae_feat: true
+  vae_cache_dir: data/vae_cache/LTX2VAE_diffusers_704x1280/sekai_game_train_961frames_16fps_ovl640
+  num_frames: 961
+  sort_dataset: false
+  # DistributedSampler owns shuffling. Dataset-local shuffling would give
+  # every DP rank a different index-to-sample mapping and duplicate samples.
+  shuffle_dataset: false
+  return_chunk_plucker: true
+  vae_ratio: [8, 32]
+  cam_sample_strategy: last
+
+num_latent_frames: 121
+num_cached_blocks: 2
+sink_token: true
+# The streaming generator keeps recurrent GDN states plus a sink+recent
+# K/V window for softmax blocks, matching inference-time cache semantics.
+denoising_step_list: [1000, 967, 908, 764, 0]
+generator_update_interval: 5
+timestep_shift: 10.0
+min_score_timestep: 20
+max_score_timestep: 980
+real_guidance_scale: 3.0
+negative_prompt: A chaotic sequence with misshapen, deformed limbs in heavy motion blur, sudden disappearance, jump cuts, jerky movements, rapid shot changes, frames out of sync, inconsistent character shapes, temporal artifacts, jitter, and ghosting effects, creating a disorienting visual experience.
+
+optimizer:
+  lr: 1.0e-5
+  betas: [0.0, 0.999]
+  weight_decay: 0.0
+critic_optimizer:
+  lr: 2.0e-6
+  betas: [0.0, 0.999]
+  weight_decay: 0.0
+
+train:
+  seed: 0
+  batch_size: 1
+  num_workers: 0
+  max_steps: 3000
+  log_interval: 10
+  # A full generator+critic checkpoint is large; save the final state by default.
+  save_model_steps: 3000
+  early_stop_hours: 0
+  gradient_accumulation_steps: 1
+  generator_gradient_clip: 10.0
+  critic_gradient_clip: 10.0
+  grad_checkpointing: true
+  use_fsdp: true
+  fsdp_version: 2
+  cp_size: 4
+  extra:
+    cp:
+      scan_backend: triton
+      triton_block_fusion: true
+      fsdp2:
+        reshard_after_forward: true
+        limit_all_gathers: false
+
+resume_from: null
+report_to: none
+tracker_project_name: sana-wm-distill

--- a/configs/sana_wm/distill/self_forcing_t43.yaml
+++ b/configs/sana_wm/distill/self_forcing_t43.yaml
@@ -1,6 +1,5 @@
 trainer: wm_self_forcing
 work_dir: output/sana_wm_distill_self_forcing_t43
-
 # Warm up self-forcing at T43 before extending the same generator/critic to
 # T121. The generator comes from ODE distillation; both score models start
 # from the public bidirectional teacher.
@@ -10,7 +9,6 @@ fake_model_config: configs/sana_wm/sana_wm_1600m_720p.yaml
 fake_model_path: hf://Efficient-Large-Model/SANA-WM_bidirectional/dit/sana_wm_1600m_720p.safetensors
 real_model_config: configs/sana_wm/sana_wm_1600m_720p.yaml
 real_model_path: hf://Efficient-Large-Model/SANA-WM_bidirectional/dit/sana_wm_1600m_720p.safetensors
-
 data:
   hf_dataset_repo: Efficient-Large-Model/SANA-WM-example-training-dataset
   hf_dataset_revision: 4d965e94b9ea11b9c5ba085251ffa7a0345e006f
@@ -44,7 +42,6 @@ data:
   return_chunk_plucker: true
   vae_ratio: [8, 32]
   cam_sample_strategy: last
-
 num_latent_frames: 43
 num_cached_blocks: -1
 sink_token: false
@@ -55,7 +52,6 @@ min_score_timestep: 20
 max_score_timestep: 980
 real_guidance_scale: 3.0
 negative_prompt: A chaotic sequence with misshapen, deformed limbs in heavy motion blur, sudden disappearance, jump cuts, jerky movements, rapid shot changes, frames out of sync, inconsistent character shapes, temporal artifacts, jitter, and ghosting effects, creating a disorienting visual experience.
-
 optimizer:
   lr: 1.0e-5
   betas: [0.0, 0.999]
@@ -64,7 +60,6 @@ critic_optimizer:
   lr: 2.0e-6
   betas: [0.0, 0.999]
   weight_decay: 0.0
-
 train:
   seed: 0
   batch_size: 1
@@ -87,7 +82,6 @@ train:
       fsdp2:
         reshard_after_forward: true
         limit_all_gathers: false
-
 resume_from: null
 report_to: none
 tracker_project_name: sana-wm-distill

--- a/configs/sana_wm/distill/self_forcing_t43.yaml
+++ b/configs/sana_wm/distill/self_forcing_t43.yaml
@@ -1,0 +1,93 @@
+trainer: wm_self_forcing
+work_dir: output/sana_wm_distill_self_forcing_t43
+
+# Warm up self-forcing at T43 before extending the same generator/critic to
+# T121. The generator comes from ODE distillation; both score models start
+# from the public bidirectional teacher.
+model_config: configs/sana_wm/sana_wm_streaming_1600m_720p.yaml
+model_path: output/sana_wm_distill_ode_t43/checkpoints/step_003000/model.pt
+fake_model_config: configs/sana_wm/sana_wm_1600m_720p.yaml
+fake_model_path: hf://Efficient-Large-Model/SANA-WM_bidirectional/dit/sana_wm_1600m_720p.safetensors
+real_model_config: configs/sana_wm/sana_wm_1600m_720p.yaml
+real_model_path: hf://Efficient-Large-Model/SANA-WM_bidirectional/dit/sana_wm_1600m_720p.safetensors
+
+data:
+  hf_dataset_repo: Efficient-Large-Model/SANA-WM-example-training-dataset
+  hf_dataset_revision: 4d965e94b9ea11b9c5ba085251ffa7a0345e006f
+  hf_dataset_local_dir: .
+  hf_dataset_allow_patterns: [data/**]
+  data_dir:
+    sekai_game: data/sekai_game_train_961frames_16fps_ovl640
+  external_caption_suffixes: [_LongSceneStaticCaption-Qwen3-VL-30B-A3B-Instruct]
+  caption_proportion:
+    sekai_game:
+      _LongSceneStaticCaption-Qwen3-VL-30B-A3B-Instruct: 100
+  data_repeat:
+    sekai_game: 16
+  external_data_filter:
+    sekai_game:
+      _vmafmotion: {min: 0.5, max: 50}
+      _unimatch: {min: 3.0, max: 80}
+      _dover: {min: 0.25, max: 1.0}
+      _vlm_entity_filter: {min: 0, max: 10}
+      _vlm_quality_filter: {min: 0.5, max: 1.5}
+  type: SanaWMZipLatentDataset
+  image_size: 720
+  aspect_ratio_type: ASPECT_RATIO_VIDEO_720_MS_DIV32
+  transform: default_train_video
+  load_text_feat: false
+  load_vae_feat: true
+  vae_cache_dir: data/vae_cache/LTX2VAE_diffusers_704x1280/sekai_game_train_961frames_16fps_ovl640
+  num_frames: 961
+  sort_dataset: false
+  shuffle_dataset: false
+  return_chunk_plucker: true
+  vae_ratio: [8, 32]
+  cam_sample_strategy: last
+
+num_latent_frames: 43
+num_cached_blocks: -1
+sink_token: false
+denoising_step_list: [1000, 967, 908, 764, 0]
+generator_update_interval: 5
+timestep_shift: 10.0
+min_score_timestep: 20
+max_score_timestep: 980
+real_guidance_scale: 3.0
+negative_prompt: A chaotic sequence with misshapen, deformed limbs in heavy motion blur, sudden disappearance, jump cuts, jerky movements, rapid shot changes, frames out of sync, inconsistent character shapes, temporal artifacts, jitter, and ghosting effects, creating a disorienting visual experience.
+
+optimizer:
+  lr: 1.0e-5
+  betas: [0.0, 0.999]
+  weight_decay: 0.0
+critic_optimizer:
+  lr: 2.0e-6
+  betas: [0.0, 0.999]
+  weight_decay: 0.0
+
+train:
+  seed: 0
+  batch_size: 1
+  num_workers: 0
+  max_steps: 700
+  log_interval: 10
+  save_model_steps: 700
+  early_stop_hours: 0
+  gradient_accumulation_steps: 1
+  generator_gradient_clip: 10.0
+  critic_gradient_clip: 10.0
+  grad_checkpointing: true
+  use_fsdp: true
+  fsdp_version: 2
+  cp_size: 4
+  extra:
+    cp:
+      scan_backend: triton
+      triton_block_fusion: true
+      fsdp2:
+        reshard_after_forward: true
+        limit_all_gathers: false
+
+resume_from: null
+report_to: none
+tracker_project_name: sana-wm-distill

--- a/diffusion/longsana/trainer/sana_wm_distill.py
+++ b/diffusion/longsana/trainer/sana_wm_distill.py
@@ -1,0 +1,1114 @@
+# Copyright 2024 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""ODE and self-forcing distillation trainer for SANA-WM.
+
+The trainer is selected by ``train_longsana.py`` through ``wm_ode`` or
+``wm_self_forcing``. Self-forcing uses the streaming student's recurrent
+KV cache; only the bidirectional score models shard their temporal input over
+the context-parallel group.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import os.path as osp
+import time
+from contextlib import nullcontext
+from dataclasses import asdict
+
+import lmdb
+import numpy as np
+import torch
+import torch.distributed as dist
+from accelerate import Accelerator, InitProcessGroupKwargs
+from omegaconf import DictConfig, OmegaConf
+from torch.utils.data import DataLoader, Dataset, DistributedSampler
+
+from diffusion.data.builder import build_dataset
+from diffusion.distributed.context_parallel import cp_reduce_loss, get_cp_group
+from diffusion.distributed.context_parallel.config import set_cp_runtime_config
+from diffusion.longsana.utils.lmdb import (
+    get_array_shape_from_lmdb,
+    retrieve_row_from_lmdb,
+)
+from diffusion.longsana.utils.model_wrapper import SanaTextEncoder
+from diffusion.model import nets as _nets  # noqa: F401
+from diffusion.model.builder import build_model
+from diffusion.model.utils import get_weight_dtype
+from diffusion.utils.camctrl_config import (
+    ModelVideoCamCtrlConfig,
+    model_video_camctrl_init_config,
+)
+from diffusion.utils.chunk_utils import chunk_index_from_chunk_size
+from diffusion.utils.config import AEConfig, SchedulerConfig, TextEncoderConfig
+from diffusion.utils.logger import get_root_logger
+from diffusion.utils.misc import init_random_seed, set_random_seed
+from tools.download import find_model
+from train_video_scripts.train_sana_wm_stage1 import (
+    _build_fsdp2_plugin,
+    _build_parallelism_config,
+    _prepare_hf_dataset,
+    _register_cp_group,
+    _remove_custom_module_call,
+    _resolve_cp_runtime_config,
+)
+
+
+class SanaWMOdeTrajectoryDataset(Dataset):
+    """Read sharded SANA-WM ODE trajectories.
+
+    Every LMDB shard stores ``latents`` as ``(N, K, T, C, H, W)`` plus
+    ``prompts``, ``camera_conditions`` (``N, T, 20``), and
+    ``chunk_plucker`` (``N, 48, T, H, W``). ``first_frame`` is optional; when
+    absent it is taken from the clean trajectory endpoint.
+    """
+
+    def __init__(self, data_path: str, num_frames: int | None = None, max_samples: int | None = None):
+        if os.path.isfile(os.path.join(data_path, "data.mdb")):
+            shard_paths = [data_path]
+        else:
+            shard_paths = [
+                os.path.join(data_path, name)
+                for name in sorted(os.listdir(data_path))
+                if os.path.isfile(os.path.join(data_path, name, "data.mdb"))
+            ]
+        if not shard_paths:
+            raise FileNotFoundError(f"No LMDB shard found under {data_path!r}.")
+
+        self.envs = [lmdb.open(path, readonly=True, lock=False, readahead=False, meminit=False) for path in shard_paths]
+        self.shapes = []
+        self.index = []
+        for shard_id, env in enumerate(self.envs):
+            shapes = {"latents": get_array_shape_from_lmdb(env, "latents")}
+            for name in ("camera_conditions", "chunk_plucker", "first_frame"):
+                try:
+                    shapes[name] = get_array_shape_from_lmdb(env, name)
+                except Exception:
+                    shapes[name] = None
+            if shapes["camera_conditions"] is None or shapes["chunk_plucker"] is None:
+                raise ValueError(
+                    f"SANA-WM ODE shard {shard_paths[shard_id]!r} must contain " "camera_conditions and chunk_plucker."
+                )
+            self.shapes.append(shapes)
+            self.index.extend((shard_id, row) for row in range(shapes["latents"][0]))
+
+        self.num_frames = None if num_frames is None else int(num_frames)
+        if max_samples is not None and int(max_samples) > 0:
+            self.index = self.index[: int(max_samples)]
+
+    def __len__(self) -> int:
+        return len(self.index)
+
+    def __getitem__(self, idx: int) -> dict[str, torch.Tensor | str]:
+        shard_id, row = self.index[idx]
+        env = self.envs[shard_id]
+        shapes = self.shapes[shard_id]
+
+        trajectory = torch.from_numpy(
+            retrieve_row_from_lmdb(env, "latents", np.float16, row, shape=shapes["latents"][1:]).copy()
+        ).float()
+        if trajectory.ndim == 4:
+            trajectory = trajectory.unsqueeze(0)
+        if trajectory.ndim != 5:
+            raise ValueError(f"Expected trajectory (K,T,C,H,W), got {tuple(trajectory.shape)}")
+
+        camera = torch.from_numpy(
+            retrieve_row_from_lmdb(
+                env,
+                "camera_conditions",
+                np.float16,
+                row,
+                shape=shapes["camera_conditions"][1:],
+            ).copy()
+        ).float()
+        plucker = torch.from_numpy(
+            retrieve_row_from_lmdb(
+                env,
+                "chunk_plucker",
+                np.float16,
+                row,
+                shape=shapes["chunk_plucker"][1:],
+            ).copy()
+        ).float()
+
+        if self.num_frames is not None:
+            trajectory = trajectory[:, : self.num_frames]
+            camera = camera[: self.num_frames]
+            plucker = plucker[:, : self.num_frames]
+
+        if shapes["first_frame"] is None:
+            first_frame = trajectory[-1, :1].permute(1, 0, 2, 3).contiguous()
+        else:
+            first_frame = torch.from_numpy(
+                retrieve_row_from_lmdb(
+                    env,
+                    "first_frame",
+                    np.float16,
+                    row,
+                    shape=shapes["first_frame"][1:],
+                ).copy()
+            ).float()
+
+        return {
+            "trajectory": trajectory,
+            "prompt": retrieve_row_from_lmdb(env, "prompts", str, row),
+            "camera_conditions": camera,
+            "chunk_plucker": plucker,
+            "first_frame": first_frame,
+        }
+
+
+class SanaWMDistillTrainer:
+    def __init__(self, config: DictConfig):
+        os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+        self.config = config
+        self.mode = str(config.mode).lower()
+        if self.mode not in {"ode", "self_forcing"}:
+            raise ValueError(f"mode must be 'ode' or 'self_forcing', got {self.mode!r}")
+        if int(config.train.gradient_accumulation_steps) != 1:
+            raise ValueError("SANA-WM distillation currently requires gradient_accumulation_steps=1.")
+
+        work_dir = str(config.get("logdir", "")).strip() or str(config.work_dir)
+        self.work_dir = osp.abspath(osp.expanduser(work_dir))
+        os.makedirs(self.work_dir, exist_ok=True)
+        self.logger = get_root_logger(osp.join(self.work_dir, "train_log.log"))
+        if not config.get("resume_from", None) and bool(config.get("auto_resume", False)):
+            checkpoint_root = osp.join(self.work_dir, "checkpoints")
+            if osp.isdir(checkpoint_root):
+                checkpoints = [
+                    osp.join(checkpoint_root, name)
+                    for name in os.listdir(checkpoint_root)
+                    if name.removeprefix("step_").isdigit()
+                    and osp.isfile(osp.join(checkpoint_root, name, "trainer_state.json"))
+                ]
+                if checkpoints:
+                    config.resume_from = max(
+                        checkpoints,
+                        key=lambda path: int(osp.basename(path).removeprefix("step_")),
+                    )
+
+        self.student_config = self._load_model_config(str(config.model_config))
+        self.student_config.train = config.train
+        self.student_config.work_dir = self.work_dir
+        self.student_config.model.use_autograd_kernel = True
+
+        self.cp_size = 1 if self.mode == "ode" else max(1, int(config.train.cp_size))
+        if self.mode == "self_forcing":
+            set_cp_runtime_config(_resolve_cp_runtime_config(self.student_config))
+        fsdp_version = int(config.train.fsdp_version)
+        if bool(config.train.use_fsdp) and fsdp_version != 2:
+            raise ValueError("SANA-WM distillation supports FSDP2 only.")
+
+        init_handler = InitProcessGroupKwargs(timeout=datetime.timedelta(seconds=5400))
+        # The model already checkpoints each transformer block. Do not wrap
+        # the same blocks in a second FSDP activation-checkpoint layer.
+        fsdp_config = OmegaConf.create(OmegaConf.to_container(self.student_config, resolve=False))
+        fsdp_config.train.grad_checkpointing = False
+        fsdp_plugin = (
+            _build_fsdp2_plugin(fsdp_config, self.cp_size, self.logger) if bool(config.train.use_fsdp) else None
+        )
+        parallelism_config = _build_parallelism_config(self.student_config, self.cp_size)
+        report_to = config.get("report_to", "none")
+        if bool(config.get("disable_wandb", False)) and report_to == "wandb":
+            report_to = "none"
+        tracking_dir = (
+            str(config.get("wandb_save_dir", "./wandb")) if report_to == "wandb" else osp.join(self.work_dir, "logs")
+        )
+        if report_to == "wandb":
+            os.makedirs(tracking_dir, exist_ok=True)
+        self.accelerator = Accelerator(
+            # The models are cast explicitly below. Accelerate's FSDP2 path
+            # otherwise upcasts BF16 master parameters and Adam states to FP32.
+            mixed_precision="no",
+            gradient_accumulation_steps=1,
+            log_with=None if report_to in {None, "none", "None"} else report_to,
+            project_dir=tracking_dir,
+            kwargs_handlers=[init_handler],
+            fsdp_plugin=fsdp_plugin,
+            parallelism_config=parallelism_config,
+        )
+        self.rank = int(self.accelerator.process_index)
+        self.world_size = int(self.accelerator.num_processes)
+        if self.world_size % self.cp_size:
+            raise ValueError(f"WORLD_SIZE={self.world_size} must be divisible by cp_size={self.cp_size}")
+        self.dp_size = self.world_size // self.cp_size
+        self.dp_rank = self.rank // self.cp_size
+
+        seed = init_random_seed(int(config.train.seed))
+        self.config.train.seed = seed
+        set_random_seed(seed + self.dp_rank)
+        self.dtype = get_weight_dtype(str(self.student_config.model.mixed_precision))
+
+        self.student = self._build_model(
+            self.student_config,
+            str(config.model_path),
+            trainable=True,
+            checkpoint_key="generator",
+        )
+        self.fake_score = self.real_score = None
+        if self.mode == "self_forcing":
+            self.fake_config = self._load_model_config(str(config.fake_model_config))
+            self.fake_config.work_dir = self.work_dir
+            self.fake_config.model.use_autograd_kernel = True
+            self.real_config = self._load_model_config(str(config.real_model_config))
+            self.real_config.work_dir = self.work_dir
+            self.real_config.model.use_autograd_kernel = False
+            self.fake_score = self._build_model(
+                self.fake_config,
+                str(config.fake_model_path),
+                trainable=True,
+                checkpoint_key="critic",
+            )
+            self.real_score = self._build_model(
+                self.real_config,
+                str(config.real_model_path),
+                trainable=False,
+            )
+
+        self.student_optimizer = torch.optim.AdamW(
+            self.student.parameters(),
+            lr=float(config.optimizer.lr),
+            betas=tuple(config.optimizer.betas),
+            weight_decay=float(config.optimizer.weight_decay),
+        )
+        if self.mode == "ode":
+            self.student, self.student_optimizer = self.accelerator.prepare(
+                self.student,
+                self.student_optimizer,
+            )
+        else:
+            self.fake_optimizer = torch.optim.AdamW(
+                self.fake_score.parameters(),
+                lr=float(config.critic_optimizer.lr),
+                betas=tuple(config.critic_optimizer.betas),
+                weight_decay=float(config.critic_optimizer.weight_decay),
+            )
+            self.student, self.student_optimizer = self.accelerator.prepare(
+                self.student,
+                self.student_optimizer,
+            )
+            self.fake_score, self.fake_optimizer = self.accelerator.prepare(
+                self.fake_score,
+                self.fake_optimizer,
+            )
+            # Accelerate FSDP2 supports one model per prepare() call.  The
+            # frozen teacher needs neither sharding nor checkpoint state.
+            self.real_score = self.real_score.to(device=self.accelerator.device, dtype=self.dtype)
+
+        if bool(config.train.use_fsdp):
+            _remove_custom_module_call(self.student, self.logger)
+        if self.mode == "self_forcing":
+            _register_cp_group(self.accelerator, self.cp_size, self.logger)
+
+        self.student.eval()
+        if self.fake_score is not None:
+            self.fake_score.eval()
+            self.real_score.eval()
+
+        self.text_encoder = SanaTextEncoder(
+            self.student_config,
+            device=self.accelerator.device,
+            dtype=self.dtype,
+        )
+        self.text_encoder.eval().requires_grad_(False)
+        self.dataloader = self._build_dataloader()
+        set_random_seed(seed + self.dp_rank)
+        self.global_step = 0
+
+        resume_from = config.get("resume_from", None)
+        if resume_from:
+            state_path = osp.join(str(resume_from), "trainer_state.json")
+            if osp.isfile(state_path):
+                with open(state_path, encoding="utf-8") as f:
+                    self.global_step = int(json.load(f).get("global_step", 0))
+
+        steps_per_epoch = len(self.dataloader)
+        if steps_per_epoch == 0:
+            raise ValueError("The distillation dataloader has no complete batch.")
+        batches_seen = self.global_step
+        if self.mode == "self_forcing":
+            interval = int(self.config.generator_update_interval)
+            batches_seen += (self.global_step + interval - 1) // interval
+        self.data_epoch = batches_seen // steps_per_epoch
+        self.dataloader.sampler.set_epoch(self.data_epoch)
+        self.data_iterator = iter(self.dataloader)
+        for _ in range(batches_seen % steps_per_epoch):
+            next(self.data_iterator)
+
+        if resume_from:
+            if self.accelerator.is_main_process:
+                self.logger.info(f"Resuming from {resume_from} at step {self.global_step}")
+            self._materialize_adam_state()
+            # Load last so checkpointed Python/NumPy/Torch RNG states replace
+            # any randomness consumed while positioning the dataloader.
+            self.accelerator.load_state(str(resume_from))
+            if self.accelerator.is_main_process:
+                self.logger.info(f"Restored model, optimizer, and RNG state at step {self.global_step}")
+
+        if self.accelerator.is_main_process:
+            OmegaConf.save(config, osp.join(self.work_dir, "config.yaml"))
+        if report_to not in {None, "none", "None"}:
+            init_kwargs = {}
+            if report_to == "wandb":
+                init_kwargs["wandb"] = {"dir": tracking_dir}
+                if config.get("wandb_name", None):
+                    init_kwargs["wandb"]["name"] = str(config.wandb_name)
+            self.accelerator.init_trackers(
+                str(config.get("tracker_project_name", "sana-wm-distill")),
+                config=OmegaConf.to_container(config, resolve=True),
+                init_kwargs=init_kwargs,
+            )
+
+    @staticmethod
+    def _load_model_config(path: str) -> DictConfig:
+        config = OmegaConf.load(path)
+        config.model = OmegaConf.merge(OmegaConf.create(asdict(ModelVideoCamCtrlConfig())), config.model)
+        config.vae = OmegaConf.merge(OmegaConf.create(asdict(AEConfig())), config.vae)
+        config.text_encoder = OmegaConf.merge(OmegaConf.create(asdict(TextEncoderConfig())), config.text_encoder)
+        config.scheduler = OmegaConf.merge(OmegaConf.create(asdict(SchedulerConfig())), config.scheduler)
+        return config
+
+    def _build_model(
+        self,
+        model_config: DictConfig,
+        checkpoint: str,
+        trainable: bool,
+        checkpoint_key: str | None = None,
+    ) -> torch.nn.Module:
+        latent_size = int(model_config.model.image_size) // int(model_config.vae.vae_stride[-1])
+        model = build_model(
+            str(model_config.model.model),
+            use_grad_checkpoint=bool(self.config.train.grad_checkpointing and trainable),
+            use_fp32_attention=bool(model_config.model.get("fp32_attention", False)),
+            **model_video_camctrl_init_config(model_config, latent_size=latent_size),
+        )
+
+        state = find_model(checkpoint)
+        if checkpoint_key is not None and checkpoint_key in state:
+            state = state[checkpoint_key]
+        elif "generator" in state:
+            state = state["generator"]
+        elif "model" in state:
+            state = state["model"]
+        if "state_dict" in state:
+            state = state["state_dict"]
+        state = {(key[6:] if key.startswith("model.") else key): value for key, value in state.items()}
+        state.pop("pos_embed", None)
+        missing, unexpected = model.load_state_dict(state, strict=False)
+        if set(missing) != {"pos_embed"} or unexpected:
+            raise RuntimeError(
+                f"Checkpoint {checkpoint} does not match {model_config.model.model}: "
+                f"missing={missing}, unexpected={unexpected}"
+            )
+        if self.accelerator.is_main_process:
+            self.logger.info(
+                f"Loaded {checkpoint}: model={model_config.model.model}, "
+                f"missing={len(missing)}, unexpected={len(unexpected)}"
+            )
+        # Match the internal SANA-WM trainers: parameters and Adam states are
+        # BF16, rather than FP32 parameters with BF16 forward autocasting.
+        model.to(dtype=self.dtype)
+        model.requires_grad_(trainable)
+        return model.eval()
+
+    def _build_dataloader(self) -> DataLoader:
+        if self.mode == "ode":
+            dataset = SanaWMOdeTrajectoryDataset(
+                str(self.config.data_path),
+                num_frames=int(self.config.num_latent_frames),
+                max_samples=self.config.get("max_samples", None),
+            )
+        else:
+            self.student_config.data = self.config.data
+            _prepare_hf_dataset(self.student_config, self.accelerator, self.logger)
+            data_cfg = OmegaConf.to_container(self.student_config.data, resolve=True)
+            dataset = build_dataset(
+                data_cfg,
+                resolution=int(self.student_config.model.image_size),
+                max_length=int(self.student_config.text_encoder.model_max_length),
+                config=self.student_config,
+                caption_proportion=self.student_config.data.caption_proportion,
+                sort_dataset=bool(self.student_config.data.sort_dataset),
+                vae_downsample_rate=int(self.student_config.vae.vae_stride[-1]),
+                num_frames=int(self.student_config.data.num_frames),
+            )
+
+        sampler = DistributedSampler(
+            dataset,
+            num_replicas=self.dp_size,
+            rank=self.dp_rank,
+            shuffle=True,
+            drop_last=True,
+            seed=int(self.config.train.seed),
+        )
+        return DataLoader(
+            dataset,
+            batch_size=int(self.config.train.batch_size),
+            sampler=sampler,
+            num_workers=int(self.config.train.num_workers),
+            pin_memory=True,
+            persistent_workers=int(self.config.train.num_workers) > 0,
+            drop_last=True,
+            generator=torch.Generator().manual_seed(int(self.config.train.seed) + self.dp_rank),
+        )
+
+    def _next_batch(self):
+        try:
+            return next(self.data_iterator)
+        except StopIteration:
+            self.data_epoch += 1
+            self.dataloader.sampler.set_epoch(self.data_epoch)
+            self.data_iterator = iter(self.dataloader)
+            return next(self.data_iterator)
+
+    def _forward_score_cp(
+        self,
+        model: torch.nn.Module,
+        x: torch.Tensor,
+        timestep: torch.Tensor,
+        y: torch.Tensor,
+        y_mask: torch.Tensor,
+        camera_conditions: torch.Tensor,
+        chunk_plucker: torch.Tensor,
+    ):
+        """Run one bidirectional score-model forward on a temporal CP shard."""
+        batch, _, valid_t, _, _ = x.shape
+        pad = (-valid_t) % self.cp_size
+        if pad:
+            x = torch.cat([x, x.new_zeros(batch, x.shape[1], pad, x.shape[3], x.shape[4])], dim=2)
+            timestep = torch.cat([timestep, timestep.new_zeros(batch, pad)], dim=1)
+            camera_conditions = torch.cat(
+                [camera_conditions, camera_conditions[:, -1:].expand(-1, pad, -1)],
+                dim=1,
+            )
+            chunk_plucker = torch.cat(
+                [
+                    chunk_plucker,
+                    chunk_plucker.new_zeros(
+                        batch,
+                        chunk_plucker.shape[1],
+                        pad,
+                        chunk_plucker.shape[3],
+                        chunk_plucker.shape[4],
+                    ),
+                ],
+                dim=2,
+            )
+        padded_t = x.shape[2]
+        frame_valid = torch.ones(batch, padded_t, device=x.device, dtype=x.dtype)
+        if pad:
+            frame_valid[:, valid_t:] = 0
+
+        cp_group = get_cp_group()
+        cp_rank = dist.get_rank(cp_group) if self.cp_size > 1 else 0
+        local_t = padded_t // self.cp_size
+        local_start = cp_rank * local_t
+        local_end = local_start + local_t
+        x_local = x[:, :, local_start:local_end].contiguous()
+        t_local = timestep[:, local_start:local_end].contiguous()
+        camera_local = camera_conditions[:, local_start:local_end].contiguous()
+        plucker_local = chunk_plucker[:, :, local_start:local_end].contiguous()
+        valid_local = frame_valid[:, local_start:local_end].contiguous()
+        kwargs = {
+            "data_info": {},
+            "camera_conditions": camera_local,
+            "chunk_plucker": plucker_local,
+            # This mask also opts the bidirectional scorer into its CP-aware
+            # halo/all-gather path without changing ordinary LongSANA calls.
+            "frame_valid_mask": valid_local,
+        }
+
+        flow = model(x_local, t_local[:, None, :], y, mask=y_mask, **kwargs)
+        if isinstance(flow, tuple):
+            flow = flow[0]
+        if hasattr(flow, "sample"):
+            flow = flow.sample
+
+        return flow, {
+            "x": x_local,
+            "timestep": t_local,
+            "valid": valid_local,
+            "local_start": local_start,
+            "local_end": local_end,
+            "pad": pad,
+        }
+
+    def _init_kv_cache(self, num_chunks: int) -> list:
+        model = self.accelerator.unwrap_model(self.student)
+        return [[[None] * 10 for _ in model.blocks] for _ in range(num_chunks)]
+
+    def _accumulate_kv_cache(self, caches: list, chunk_id: int) -> list:
+        """Build the cached state consumed by one streaming generator chunk."""
+        if chunk_id == 0:
+            return caches[0]
+
+        cached_chunks = int(self.config.num_cached_blocks)
+        start = max(chunk_id - cached_chunks, 0) if cached_chunks > 0 else 0
+        selected = list(range(start, chunk_id))
+        if bool(self.config.sink_token) and cached_chunks > 0:
+            recent_start = max(chunk_id - cached_chunks + 1, 0)
+            if recent_start > 0:
+                selected = [0, *range(recent_start, chunk_id)]
+
+        current = caches[chunk_id]
+        kept = set(selected)
+        for block_id in range(len(current)):
+            previous = caches[chunk_id - 1][block_id]
+            type_flag = previous[6]
+            is_state = (
+                type_flag is not None and float(type_flag.item() if torch.is_tensor(type_flag) else type_flag) > 0.5
+            )
+            if is_state:
+                current[block_id] = [
+                    previous[0],
+                    previous[1],
+                    previous[2],
+                    previous[3],
+                    previous[4],
+                    None,
+                    previous[6],
+                    None,
+                    None,
+                    previous[-1],
+                ]
+            else:
+                accumulated = [None] * 4
+                for cached_id in selected:
+                    cached = caches[cached_id][block_id]
+                    for slot in range(4):
+                        if cached[slot] is None:
+                            continue
+                        accumulated[slot] = (
+                            cached[slot]
+                            if accumulated[slot] is None
+                            else torch.cat([accumulated[slot], cached[slot]], dim=2)
+                        )
+                current[block_id] = [
+                    *accumulated,
+                    previous[4],
+                    None,
+                    previous[6],
+                    None,
+                    None,
+                    previous[-1],
+                ]
+
+            if cached_chunks > 0:
+                for cached_id in range(chunk_id):
+                    if cached_id not in kept:
+                        caches[cached_id][block_id] = [None] * 10
+
+        return current
+
+    def _masked_mse(self, prediction: torch.Tensor, target: torch.Tensor, frame_mask: torch.Tensor):
+        mask = frame_mask[:, None, :, None, None].float()
+        residual = torch.where(mask.bool(), prediction.float() - target.float(), 0.0)
+        error = residual.square()
+        local_count = mask.sum() * prediction.shape[1] * prediction.shape[3] * prediction.shape[4]
+        loss = error.sum() / local_count.clamp_min(1)
+        if self.cp_size > 1:
+            loss = cp_reduce_loss(loss, get_cp_group(), num_valid_tokens=local_count)
+        return loss
+
+    def _encode(self, prompts, use_chi_prompt: bool = True):
+        encoded = self.text_encoder.forward_chi(prompts, use_chi_prompt=use_chi_prompt)
+        return encoded["prompt_embeds"][:, None], encoded["mask"][:, None, None]
+
+    def _rollout(
+        self,
+        first_frame: torch.Tensor,
+        camera_conditions: torch.Tensor,
+        chunk_plucker: torch.Tensor,
+        y: torch.Tensor,
+        y_mask: torch.Tensor,
+        requires_grad: bool,
+    ) -> torch.Tensor:
+        total_t = int(self.config.num_latent_frames)
+        chunk_size = int(self.student_config.model.chunk_size)
+        chunk_split_strategy = str(self.student_config.model.chunk_split_strategy)
+        starts = chunk_index_from_chunk_size(total_t, chunk_size, chunk_split_strategy)
+        ends = [*starts[1:], total_t]
+        schedule = [int(value) for value in self.config.denoising_step_list][:-1]
+
+        exit_step = torch.randint(0, len(schedule), (1,), device=self.accelerator.device)
+        # This value changes the number of model calls, so every FSDP shard
+        # must take the same branch.  Noise remains independent across DP
+        # replicas and is synchronized only within each CP group below.
+        if dist.is_initialized():
+            dist.broadcast(exit_step, src=0)
+        exit_step = int(exit_step.item())
+
+        batch, channels, _, height, width = first_frame.shape
+        initial_noise = torch.randn(
+            batch,
+            channels,
+            total_t,
+            height,
+            width,
+            device=self.accelerator.device,
+            dtype=self.dtype,
+        )
+        if self.cp_size > 1:
+            cp_group = get_cp_group()
+            dist.broadcast(initial_noise, src=dist.get_global_rank(cp_group, 0), group=cp_group)
+        initial_noise[:, :, :1] = first_frame
+        generated_chunks: list[torch.Tensor] = []
+        kv_cache = self._init_kv_cache(len(starts))
+
+        for chunk_id, (start, end) in enumerate(zip(starts, ends)):
+            current = initial_noise[:, :, start:end]
+            chunk_cache = self._accumulate_kv_cache(kv_cache, chunk_id)
+            chunk_camera = camera_conditions[:, start:end]
+            current_plucker = chunk_plucker[:, :, start:end]
+            frame_index = torch.arange(start, end, device=current.device)
+
+            for step_id, current_t in enumerate(schedule[: exit_step + 1]):
+                chunk_timestep = torch.full(
+                    (batch, end - start),
+                    float(current_t),
+                    device=current.device,
+                    dtype=torch.float32,
+                )
+                if chunk_id == 0:
+                    chunk_timestep[:, 0] = 0
+
+                track_grad = requires_grad and step_id == exit_step
+                grad_context = nullcontext() if track_grad else torch.no_grad()
+                # forward_long checkpoints every transformer block. Keep the
+                # read-cache lists stable until backward; the t=0 cache-save
+                # call below updates the original lists in place.
+                read_cache = [list(block_cache) for block_cache in chunk_cache] if track_grad else chunk_cache
+                with grad_context:
+                    result = self.student(
+                        current,
+                        chunk_timestep[:, None, :],
+                        y,
+                        mask=y_mask,
+                        data_info={},
+                        camera_conditions=chunk_camera,
+                        chunk_plucker=current_plucker,
+                        chunk_size=chunk_size,
+                        chunk_split_strategy=chunk_split_strategy,
+                        start_f=start,
+                        end_f=end,
+                        frame_index=frame_index,
+                        kv_cache=read_cache,
+                        save_kv_cache=False,
+                    )
+                    flow = result[0] if isinstance(result, tuple) else result
+                    if hasattr(flow, "sample"):
+                        flow = flow.sample
+                    sigma = chunk_timestep[:, None, :, None, None] / 1000.0
+                    current_x0 = (current - sigma * flow).to(flow.dtype)
+                    if chunk_id == 0:
+                        current_x0 = torch.cat([first_frame, current_x0[:, :, 1:]], dim=2)
+
+                if step_id < exit_step:
+                    next_sigma = float(schedule[step_id + 1]) / 1000.0
+                    step_noise = torch.randn_like(current_x0)
+                    if self.cp_size > 1:
+                        cp_group = get_cp_group()
+                        dist.broadcast(step_noise, src=dist.get_global_rank(cp_group, 0), group=cp_group)
+                    current = (1.0 - next_sigma) * current_x0.detach() + next_sigma * step_noise
+                    if chunk_id == 0:
+                        current[:, :, :1] = first_frame
+
+            with torch.no_grad():
+                cache_result = self.student(
+                    current_x0.detach(),
+                    torch.zeros(batch, 1, end - start, device=current.device),
+                    y,
+                    mask=y_mask,
+                    data_info={},
+                    camera_conditions=chunk_camera,
+                    chunk_plucker=current_plucker,
+                    chunk_size=chunk_size,
+                    chunk_split_strategy=chunk_split_strategy,
+                    start_f=start,
+                    end_f=end,
+                    frame_index=frame_index,
+                    kv_cache=chunk_cache,
+                    save_kv_cache=True,
+                )
+                if not isinstance(cache_result, tuple) or len(cache_result) != 2:
+                    raise RuntimeError("Streaming SANA-WM generator did not return its KV cache.")
+                kv_cache[chunk_id] = cache_result[1]
+
+            generated_chunks.append(current_x0 if requires_grad else current_x0.detach())
+
+        return torch.cat(generated_chunks, dim=2)
+
+    def _materialize_adam_state(self):
+        """Create step-0 Adam slots for parameters that have not received a gradient."""
+        optimizers = [self.student_optimizer]
+        if self.fake_score is not None:
+            optimizers.append(self.fake_optimizer)
+        for optimizer in optimizers:
+            for group in optimizer.param_groups:
+                for parameter in group["params"]:
+                    if parameter in optimizer.state:
+                        continue
+                    state = optimizer.state[parameter]
+                    step_device = parameter.device if group.get("capturable") or group.get("fused") else "cpu"
+                    state["step"] = torch.zeros((), dtype=torch.float32, device=step_device)
+                    state["exp_avg"] = torch.zeros_like(parameter)
+                    state["exp_avg_sq"] = torch.zeros_like(parameter)
+                    if group.get("amsgrad", False):
+                        state["max_exp_avg_sq"] = torch.zeros_like(parameter)
+
+    def _save(self):
+        checkpoint_dir = osp.join(self.work_dir, "checkpoints", f"step_{self.global_step:06d}")
+        self._materialize_adam_state()
+        self.accelerator.wait_for_everyone()
+        self.accelerator.save_state(checkpoint_dir)
+        generator_state = self.accelerator.get_state_dict(self.student)
+        critic_state = self.accelerator.get_state_dict(self.fake_score) if self.fake_score is not None else None
+        if self.accelerator.is_main_process:
+            payload = {
+                "generator": generator_state,
+                "step": self.global_step,
+                "denoising_step_list": [int(value) for value in self.config.denoising_step_list],
+            }
+            if critic_state is not None:
+                payload["critic"] = critic_state
+            torch.save(payload, osp.join(checkpoint_dir, "model.pt"))
+            with open(osp.join(checkpoint_dir, "trainer_state.json"), "w", encoding="utf-8") as f:
+                json.dump({"global_step": self.global_step}, f)
+        self.accelerator.wait_for_everyone()
+
+    def _train_ode_step(self, batch) -> dict[str, float]:
+        self.student_optimizer.zero_grad(set_to_none=True)
+        trajectory = batch["trajectory"].to(self.accelerator.device, dtype=self.dtype)
+        camera = batch["camera_conditions"].to(self.accelerator.device, dtype=self.dtype)
+        plucker = batch["chunk_plucker"].to(self.accelerator.device, dtype=self.dtype)
+        first_frame = batch["first_frame"].to(self.accelerator.device, dtype=self.dtype)
+        y, y_mask = self._encode(batch["prompt"])
+
+        batch_size, snapshots, total_t, channels, height, width = trajectory.shape
+        if snapshots != len(self.config.denoising_step_list):
+            raise ValueError(
+                f"ODE trajectory has {snapshots} snapshots but denoising_step_list has "
+                f"{len(self.config.denoising_step_list)} entries."
+            )
+        starts = chunk_index_from_chunk_size(
+            total_t,
+            int(self.student_config.model.chunk_size),
+            str(self.student_config.model.chunk_split_strategy),
+        )
+        ends = [*starts[1:], total_t]
+        snapshot_index = torch.empty(batch_size, total_t, device=trajectory.device, dtype=torch.long)
+        for start, end in zip(starts, ends):
+            snapshot_index[:, start:end] = torch.randint(
+                0,
+                snapshots,
+                (batch_size, 1),
+                device=trajectory.device,
+            )
+        snapshot_index[:, 0] = snapshots - 1
+        noisy = torch.gather(
+            trajectory,
+            1,
+            snapshot_index[:, None, :, None, None, None].expand(-1, 1, -1, channels, height, width),
+        ).squeeze(1)
+        noisy = noisy.permute(0, 2, 1, 3, 4).contiguous()
+        noisy[:, :, :1] = first_frame
+        target = trajectory[:, -1].permute(0, 2, 1, 3, 4).contiguous()
+        schedule = torch.tensor(self.config.denoising_step_list, device=trajectory.device)
+        timestep = schedule[snapshot_index].float()
+
+        flow = self.student(
+            noisy,
+            timestep[:, None, :],
+            y,
+            mask=y_mask,
+            data_info={},
+            camera_conditions=camera,
+            chunk_plucker=plucker,
+            chunk_size=int(self.student_config.model.chunk_size),
+            chunk_split_strategy=str(self.student_config.model.chunk_split_strategy),
+            chunk_index=starts,
+        )
+        if isinstance(flow, tuple):
+            flow = flow[0]
+        if hasattr(flow, "sample"):
+            flow = flow.sample
+        sigma = timestep[:, None, :, None, None] / 1000.0
+        prediction = (noisy - sigma * flow).to(flow.dtype)
+        loss = self._masked_mse(prediction, target, timestep != 0)
+        if not torch.isfinite(loss):
+            raise FloatingPointError("Non-finite ODE loss")
+
+        self.accelerator.backward(loss)
+        self.accelerator.unscale_gradients(self.student_optimizer)
+        grad_norm = torch.nn.utils.clip_grad_norm_(
+            self.student.parameters(),
+            float(self.config.train.gradient_clip),
+        )
+        if not torch.isfinite(grad_norm):
+            raise FloatingPointError("Non-finite ODE gradient")
+        self.student_optimizer.step()
+        return {"ode_loss": float(loss.detach()), "generator_grad_norm": float(grad_norm)}
+
+    def _self_forcing_batch(self, batch):
+        latent = batch[0].to(self.accelerator.device, dtype=self.dtype)
+        camera = batch[6].to(self.accelerator.device, dtype=self.dtype)
+        plucker = batch[-1].to(self.accelerator.device, dtype=self.dtype)
+        latent = latent[:, :, : int(self.config.num_latent_frames)]
+        camera = camera[:, : int(self.config.num_latent_frames)]
+        plucker = plucker[:, :, : int(self.config.num_latent_frames)]
+        y, y_mask = self._encode(batch[1])
+        negative = [str(self.config.negative_prompt)] * latent.shape[0]
+        y_uncond, y_uncond_mask = self._encode(negative, use_chi_prompt=False)
+        return latent[:, :, :1], camera, plucker, y, y_mask, y_uncond, y_uncond_mask
+
+    def _train_generator_step(self, values) -> dict[str, float]:
+        self.student_optimizer.zero_grad(set_to_none=True)
+        first_frame, camera, plucker, y, y_mask, y_uncond, y_uncond_mask = values
+        generated = self._rollout(first_frame, camera, plucker, y, y_mask, requires_grad=True)
+        batch, _, total_t, _, _ = generated.shape
+
+        timestep = torch.randint(
+            0,
+            1000,
+            (batch, 1),
+            device=generated.device,
+        ).float()
+        shift = float(self.config.timestep_shift)
+        timestep = shift * (timestep / 1000.0) / (1.0 + (shift - 1.0) * (timestep / 1000.0)) * 1000.0
+        timestep = timestep.clamp(
+            min=float(self.config.min_score_timestep),
+            max=float(self.config.max_score_timestep),
+        )
+        timestep = timestep.expand(-1, total_t).clone()
+        timestep[:, 0] = 0
+        noise = torch.randn_like(generated)
+        if self.cp_size > 1:
+            cp_group = get_cp_group()
+            source = dist.get_global_rank(cp_group, 0)
+            dist.broadcast(timestep, src=source, group=cp_group)
+            dist.broadcast(noise, src=source, group=cp_group)
+        sigma = timestep[:, None, :, None, None] / 1000.0
+        noisy = ((1.0 - sigma) * generated + sigma * noise).to(generated.dtype)
+        noisy[:, :, :1] = generated[:, :, :1]
+
+        with torch.no_grad():
+            fake_flow, meta = self._forward_score_cp(
+                self.fake_score,
+                noisy,
+                timestep,
+                y,
+                y_mask,
+                camera,
+                plucker,
+            )
+            real_flow_cond, _ = self._forward_score_cp(
+                self.real_score,
+                noisy,
+                timestep,
+                y,
+                y_mask,
+                camera,
+                plucker,
+            )
+            real_flow_uncond, _ = self._forward_score_cp(
+                self.real_score,
+                noisy,
+                timestep,
+                y_uncond,
+                y_uncond_mask,
+                camera,
+                plucker,
+            )
+            local_sigma = meta["timestep"][:, None, :, None, None] / 1000.0
+            pred_fake = (meta["x"] - local_sigma * fake_flow).to(fake_flow.dtype)
+            pred_real_cond = (meta["x"] - local_sigma * real_flow_cond).to(real_flow_cond.dtype)
+            pred_real_uncond = (meta["x"] - local_sigma * real_flow_uncond).to(real_flow_uncond.dtype)
+            pred_real = pred_real_cond + float(self.config.real_guidance_scale) * (pred_real_cond - pred_real_uncond)
+
+        generated_padded = generated
+        if meta["pad"]:
+            generated_padded = torch.cat(
+                [
+                    generated,
+                    generated.new_zeros(
+                        batch,
+                        generated.shape[1],
+                        meta["pad"],
+                        generated.shape[3],
+                        generated.shape[4],
+                    ),
+                ],
+                dim=2,
+            )
+        generated_local = generated_padded[:, :, meta["local_start"] : meta["local_end"]]
+        with torch.no_grad():
+            valid = meta["valid"][:, None, :, None, None].float()
+            normalizer_error = torch.where(
+                valid.bool(),
+                (generated_local - pred_real).abs(),
+                0.0,
+            )
+            normalizer_sum = normalizer_error.sum(dim=(1, 2, 3, 4))
+            normalizer_count = (
+                meta["valid"].float().sum(dim=1)
+                * generated_local.shape[1]
+                * generated_local.shape[3]
+                * generated_local.shape[4]
+            )
+            if self.cp_size > 1:
+                dist.all_reduce(normalizer_sum, group=get_cp_group())
+                dist.all_reduce(normalizer_count, group=get_cp_group())
+            normalizer = (normalizer_sum / normalizer_count).clamp_min(1e-6)
+            dmd_gradient = (pred_fake - pred_real) / normalizer[:, None, None, None, None]
+            dmd_gradient = torch.nan_to_num(dmd_gradient)
+
+        target = (generated_local - dmd_gradient).detach()
+        frame_mask = meta["valid"].clone()
+        if meta["local_start"] == 0:
+            frame_mask[:, 0] = 0
+        loss = 0.5 * self._masked_mse(generated_local, target, frame_mask)
+        if not torch.isfinite(loss):
+            raise FloatingPointError("Non-finite generator loss")
+
+        self.accelerator.backward(loss)
+        self.accelerator.unscale_gradients(self.student_optimizer)
+        grad_norm = torch.nn.utils.clip_grad_norm_(
+            self.student.parameters(),
+            float(self.config.train.generator_gradient_clip),
+        )
+        if not torch.isfinite(grad_norm):
+            raise FloatingPointError("Non-finite generator gradient")
+        self.student_optimizer.step()
+        return {
+            "generator_loss": float(loss.detach()),
+            "generator_grad_norm": float(grad_norm),
+            "dmd_gradient_norm": float(dmd_gradient.abs().mean()),
+        }
+
+    def _train_critic_step(self, values) -> dict[str, float]:
+        self.fake_optimizer.zero_grad(set_to_none=True)
+        first_frame, camera, plucker, y, y_mask, _, _ = values
+        with torch.no_grad():
+            generated = self._rollout(first_frame, camera, plucker, y, y_mask, requires_grad=False)
+        batch, _, total_t, _, _ = generated.shape
+        timestep = torch.randint(
+            0,
+            1000,
+            (batch, 1),
+            device=generated.device,
+        ).float()
+        shift = float(self.config.timestep_shift)
+        timestep = shift * (timestep / 1000.0) / (1.0 + (shift - 1.0) * (timestep / 1000.0)) * 1000.0
+        timestep = timestep.clamp(
+            min=float(self.config.min_score_timestep),
+            max=float(self.config.max_score_timestep),
+        )
+        timestep = timestep.expand(-1, total_t).clone()
+        timestep[:, 0] = 0
+        noise = torch.randn_like(generated)
+        if self.cp_size > 1:
+            cp_group = get_cp_group()
+            source = dist.get_global_rank(cp_group, 0)
+            dist.broadcast(timestep, src=source, group=cp_group)
+            dist.broadcast(noise, src=source, group=cp_group)
+        sigma = timestep[:, None, :, None, None] / 1000.0
+        noisy = ((1.0 - sigma) * generated + sigma * noise).to(generated.dtype)
+        noisy[:, :, :1] = generated[:, :, :1]
+
+        fake_flow, meta = self._forward_score_cp(
+            self.fake_score,
+            noisy,
+            timestep,
+            y,
+            y_mask,
+            camera,
+            plucker,
+        )
+        generated_padded = generated
+        noise_padded = noise
+        if meta["pad"]:
+            pad_shape = (batch, generated.shape[1], meta["pad"], generated.shape[3], generated.shape[4])
+            generated_padded = torch.cat([generated, generated.new_zeros(pad_shape)], dim=2)
+            noise_padded = torch.cat([noise, noise.new_zeros(pad_shape)], dim=2)
+        local_slice = slice(meta["local_start"], meta["local_end"])
+        generated_local = generated_padded[:, :, local_slice]
+        noise_local = noise_padded[:, :, local_slice]
+        target_flow = noise_local - generated_local
+        frame_mask = meta["valid"].clone()
+        if meta["local_start"] == 0:
+            frame_mask[:, 0] = 0
+        loss = self._masked_mse(fake_flow, target_flow, frame_mask)
+        if not torch.isfinite(loss):
+            raise FloatingPointError("Non-finite critic loss; model_path must be a distilled generator checkpoint.")
+
+        self.accelerator.backward(loss)
+        self.accelerator.unscale_gradients(self.fake_optimizer)
+        grad_norm = torch.nn.utils.clip_grad_norm_(
+            self.fake_score.parameters(),
+            float(self.config.train.critic_gradient_clip),
+        )
+        if not torch.isfinite(grad_norm):
+            raise FloatingPointError("Non-finite critic gradient")
+        self.fake_optimizer.step()
+        return {"critic_loss": float(loss.detach()), "critic_grad_norm": float(grad_norm)}
+
+    def train(self):
+        start_time = time.time()
+        max_steps = min(int(self.config.train.max_steps), int(self.config.get("max_iters", 10**18)))
+        save_steps = int(self.config.train.save_model_steps)
+        save_enabled = not bool(self.config.get("no_save", False))
+        log_interval = int(self.config.train.log_interval)
+        early_stop_hours = float(self.config.train.early_stop_hours)
+        if self.accelerator.is_main_process:
+            self.logger.info(
+                f"mode={self.mode} start_step={self.global_step} max_steps={max_steps} "
+                f"save_enabled={save_enabled} cp_size={self.cp_size} dp_size={self.dp_size}"
+            )
+
+        while self.global_step < max_steps:
+            batch = self._next_batch()
+            if self.mode == "ode":
+                logs = self._train_ode_step(batch)
+            else:
+                values = self._self_forcing_batch(batch)
+                logs = {}
+                if self.global_step % int(self.config.generator_update_interval) == 0:
+                    logs.update(self._train_generator_step(values))
+                    values = self._self_forcing_batch(self._next_batch())
+                logs.update(self._train_critic_step(values))
+
+            self.global_step += 1
+            if self.accelerator.is_main_process and (self.global_step == 1 or self.global_step % log_interval == 0):
+                self.logger.info(
+                    f"mode={self.mode} step={self.global_step} "
+                    + " ".join(f"{key}={value:.6f}" for key, value in logs.items())
+                )
+                if self.accelerator.trackers:
+                    self.accelerator.log(logs, step=self.global_step)
+
+            saved_this_step = save_enabled and save_steps > 0 and self.global_step % save_steps == 0
+            if saved_this_step:
+                self._save()
+            should_stop = early_stop_hours > 0 and time.time() - start_time >= early_stop_hours * 3600
+            if dist.is_initialized():
+                stop_tensor = torch.tensor(int(should_stop), device=self.accelerator.device)
+                dist.all_reduce(stop_tensor, op=dist.ReduceOp.MAX)
+                should_stop = bool(stop_tensor.item())
+            if should_stop:
+                if save_enabled and not saved_this_step:
+                    self._save()
+                break
+
+        if save_enabled and self.global_step >= max_steps and (save_steps <= 0 or self.global_step % save_steps):
+            self._save()
+        self.accelerator.end_training()

--- a/diffusion/model/nets/basic_modules.py
+++ b/diffusion/model/nets/basic_modules.py
@@ -16,9 +16,13 @@
 
 # This file is modified from https://github.com/PixArt-alpha/PixArt-sigma
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 from timm.models.vision_transformer import Mlp
+from torch.distributed.nn import functional as dist_nn
 
+from diffusion.distributed.context_parallel.config import cp_enabled, get_cp_group
+from diffusion.distributed.context_parallel.halo_exchange import cp_halo_exchange
 from diffusion.model.act import build_act, get_act_name
 from diffusion.model.norms import build_norm, get_norm_name
 from diffusion.model.registry import FFN_BLOCKS
@@ -235,7 +239,6 @@ class GLUMBConvTemp(GLUMBConv):
         nn.init.zeros_(self.t_conv.weight)
 
     def forward(self, x: torch.Tensor, HW=None, **kwargs) -> torch.Tensor:
-        del kwargs
         B, N, C = x.shape
 
         assert len(HW) == 3, "HW must be a tuple of (T, H, W)"
@@ -246,13 +249,11 @@ class GLUMBConvTemp(GLUMBConv):
 
         # Temporal aggregation
         x_reshaped = x.view(B, T, C, H * W).permute(0, 2, 1, 3)
-        try:
-            from diffusion.distributed.context_parallel.config import cp_enabled, get_cp_group
-            from diffusion.distributed.context_parallel.halo_exchange import cp_halo_exchange
-        except Exception:
-            cp_active = False
-        else:
-            cp_active = cp_enabled() and get_cp_group() is not None
+        frame_mask = kwargs.get("frame_valid_mask", None)
+        if frame_mask is not None:
+            frame_mask = frame_mask.reshape(B, T).to(x_reshaped)
+            x_reshaped = x_reshaped * frame_mask[:, None, :, None]
+        cp_active = cp_enabled() and get_cp_group() is not None
 
         if cp_active and self.t_conv.padding[0] > 0:
             halo = int(self.t_conv.padding[0])
@@ -261,6 +262,8 @@ class GLUMBConvTemp(GLUMBConv):
         else:
             t_out = self.t_conv(x_reshaped)
         x_out = x_reshaped + t_out
+        if frame_mask is not None:
+            x_out = x_out * frame_mask[:, None, :, None]
 
         x_out = x_out.permute(0, 2, 3, 1).reshape(B, N, C)
 
@@ -269,7 +272,6 @@ class GLUMBConvTemp(GLUMBConv):
 
 class ChunkGLUMBConvTemp(GLUMBConvTemp):
     def forward(self, x: torch.Tensor, HW=None, chunk_index=None, **kwargs) -> torch.Tensor:
-        del kwargs
         if chunk_index is None:
             chunk_index = [0]
         B, N, C = x.shape
@@ -281,8 +283,24 @@ class ChunkGLUMBConvTemp(GLUMBConvTemp):
         x = self._apply_spatial_autochunked(x)
 
         x_reshaped = x.view(B, T, C, H * W).permute(0, 2, 1, 3)  # B, C, T, H*W
+        frame_mask = kwargs.get("frame_valid_mask")
+        if frame_mask is not None:
+            frame_mask = frame_mask.reshape(B, T).to(x_reshaped)
+            x_reshaped = x_reshaped * frame_mask[:, None, :, None]
+
+        x_local = x_reshaped
+        cp_group = get_cp_group() if cp_enabled() else None
+        if cp_group is not None and kwargs.get("chunk_index_global") is not None:
+            cp_rank = dist.get_rank(cp_group)
+            x_reshaped = torch.cat(dist_nn.all_gather(x_reshaped.contiguous(), group=cp_group), dim=2)
+            chunk_index = kwargs["chunk_index_global"]
+            T_work = x_reshaped.shape[2]
+        else:
+            cp_rank = 0
+            T_work = T
+
         padding_size = self.t_conv.kernel_size[0] // 2
-        chunk_boundaries = [int(idx) for idx in chunk_index] + [T]
+        chunk_boundaries = sorted({0, *(int(idx) for idx in chunk_index if 0 < int(idx) < T_work), T_work})
         chunk_sizes = [end - start for start, end in zip(chunk_boundaries, chunk_boundaries[1:])]
         x_reshaped_list = x_reshaped.split(chunk_sizes, dim=-2)
 
@@ -322,9 +340,15 @@ class ChunkGLUMBConvTemp(GLUMBConvTemp):
             unpadded_chunks.append(unpadded_chunk)
 
         t_conv_out_final = torch.cat(unpadded_chunks, dim=-2)
-        assert t_conv_out_final.shape[-2] == T, f"Expected temporal dimension {T}, got {t_conv_out_final.shape[-2]}"
+        assert (
+            t_conv_out_final.shape[-2] == T_work
+        ), f"Expected temporal dimension {T_work}, got {t_conv_out_final.shape[-2]}"
+        if cp_group is not None and kwargs.get("chunk_index_global") is not None:
+            t_conv_out_final = t_conv_out_final[:, :, cp_rank * T : (cp_rank + 1) * T]
 
-        x_out = x_reshaped + t_conv_out_final
+        x_out = x_local + t_conv_out_final
+        if frame_mask is not None:
+            x_out = x_out * frame_mask[:, None, :, None]
 
         x_out = x_out.permute(0, 2, 3, 1).reshape(B, N, C)
 

--- a/diffusion/model/nets/sana_gdn_blocks.py
+++ b/diffusion/model/nets/sana_gdn_blocks.py
@@ -32,7 +32,6 @@ from torch.distributed.nn import functional as dist_nn
 from diffusion.distributed.context_parallel.config import cp_enabled, get_cp_group
 from diffusion.distributed.context_parallel.halo_exchange import cp_halo_exchange
 from diffusion.model.liger_norms import get_rmsnorm_class
-from diffusion.model.registry import ATTENTION_BLOCKS
 from diffusion.model.ops.fused_streaming import (
     _SLOT_FWD_KV,
     _SLOT_FWD_Z,
@@ -41,6 +40,7 @@ from diffusion.model.ops.fused_streaming import (
     _cached_gdn_forward_triton,
     _slice_rope_to_current_chunk,
 )
+from diffusion.model.registry import ATTENTION_BLOCKS
 from diffusion.utils.chunk_utils import normalize_chunk_index
 
 RMSNorm = get_rmsnorm_class()

--- a/diffusion/model/nets/sana_gdn_blocks.py
+++ b/diffusion/model/nets/sana_gdn_blocks.py
@@ -22,30 +22,34 @@ import math
 import os
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
-from einops import rearrange
 from fla.modules import ShortConvolution
 from timm.models.vision_transformer import Attention as Attention_
+from torch.distributed.nn import functional as dist_nn
 
+from diffusion.distributed.context_parallel.config import cp_enabled, get_cp_group
+from diffusion.distributed.context_parallel.halo_exchange import cp_halo_exchange
 from diffusion.model.liger_norms import get_rmsnorm_class
-from diffusion.utils.chunk_utils import (
-    chunk_index_from_chunk_size,
-    is_chunk_causal_request,
-    is_uniform_chunking,
-    normalize_chunk_index,
-    size1_chunk_position_indices,
+from diffusion.model.registry import ATTENTION_BLOCKS
+from diffusion.model.ops.fused_streaming import (
+    _SLOT_FWD_KV,
+    _SLOT_FWD_Z,
+    _SLOT_TYPE_FLAG,
+    _TYPE_CONCAT,
+    _cached_gdn_forward_triton,
+    _slice_rope_to_current_chunk,
 )
+from diffusion.utils.chunk_utils import normalize_chunk_index
 
 RMSNorm = get_rmsnorm_class()
-from diffusion.model.registry import ATTENTION_BLOCKS
 
 # Gate ``@torch.compile`` on all GDN scan / helper functions via
 # ``GDN_DISABLE_COMPILE``.  When set to anything other than ``"0"`` / ``"false"``,
 # compile is disabled (useful for debugging / parity work).
 _COMPILE_DISABLE = os.environ.get("GDN_DISABLE_COMPILE", "0") not in ("0", "false")
 
-_HAS_FLEX_ATTENTION = bool(int(os.environ.get("SANA_USE_FLEX_ATTENTION", "0")))
 _SDPA_D112_DIRECT = os.environ.get("SANA_WM_SDPA_D112_DIRECT", "").strip().lower() in {
     "1",
     "true",
@@ -532,14 +536,18 @@ class BidirectionalGDN(GDN):
             x: Input tensor of shape (B, N, C) where N = T * S.
             conv: FLA ``ShortConvolution`` module.
             HW: Tuple of (T, H, W) describing the token layout.
-            **kwargs: Unused.
+            **kwargs: ``frame_valid_mask`` enables the WM score-model CP path.
 
         Returns:
             Tensor of shape (B, N, C) after bidirectional temporal conv.
         """
-        del kwargs
-
         x, B, S, T = self._reshape_to_temporal(x, HW)
+        if kwargs.get("frame_valid_mask") is not None:
+            if cp_enabled():
+                halo = int(conv.weight.shape[-1]) - 1
+                x = cp_halo_exchange(x, left_size=halo, right_size=halo, dim=1, group=get_cp_group())
+                x = self._bidirectional_causal_conv_1d(x, conv)[:, halo : halo + T]
+                return self._reshape_from_temporal(x, B, S, T)
         x = self._bidirectional_causal_conv_1d(x, conv)
         return self._reshape_from_temporal(x, B, S, T)
 
@@ -659,6 +667,15 @@ class ChunkCausalGDN(GDN):
         parts: list[torch.Tensor] = []
         for start_t, end_t in bounds:
             seg = x[:, start_t:end_t, :]
+            if end_t - start_t == 1:
+                # FLA's ShortConvolution update kernel does not support a
+                # length-1 sequence without a cache.  For one position the
+                # causal convolution is exactly its center tap (plus bias).
+                seg_out = seg * conv.weight[:, 0, -1].view(1, 1, -1)
+                if conv.bias is not None:
+                    seg_out = seg_out + conv.bias.view(1, 1, -1)
+                parts.append(seg_out)
+                continue
             seg_out, _ = conv(seg.flip(1))
             parts.append(seg_out.flip(1))
         return torch.cat(parts, dim=1)
@@ -694,12 +711,36 @@ class ChunkCausalGDN(GDN):
         """
         chunk_size = kwargs.get("chunk_size")
         chunk_index = kwargs.get("chunk_index")
+        chunk_index_global = kwargs.get("chunk_index_global")
         chunk_split_strategy = kwargs.get("chunk_split_strategy", "uniform")
 
         dtype_in = x.dtype
         x, B, S, T = self._reshape_to_temporal(x, HW)
 
-        # NOTE: CP removed — single-GPU path only.
+        if cp_enabled() and get_cp_group() is not None and conv.weight.shape[-1] > 1:
+            cp_group = get_cp_group()
+            halo = int(conv.weight.shape[-1]) - 1
+
+            x_fwd = cp_halo_exchange(x, left_size=halo, right_size=0, dim=1, group=cp_group).contiguous()
+            y_fwd = self._causal_conv_1d(x_fwd, conv)[:, halo:]
+
+            cp_rank = dist.get_rank(cp_group)
+            cp_world = dist.get_world_size(cp_group)
+            global_start = cp_rank * T
+            x_global = torch.cat(dist_nn.all_gather(x.contiguous(), group=cp_group), dim=1)
+            y_bwd_global = self._backward_causal_conv_per_chunk(
+                x_global,
+                conv,
+                T * cp_world,
+                chunk_size,
+                chunk_index_global,
+                chunk_split_strategy,
+            )
+            y_bwd = y_bwd_global[:, global_start : global_start + T]
+            center = x * conv.weight[:, 0, -1].view(1, 1, -1)
+            y = y_fwd + y_bwd - center
+            return self._reshape_from_temporal(y.to(dtype_in), B, S, T)
+
         # 1. Global forward causal conv (cross-chunk context flows forward).
         y_fwd, _ = conv(x)
 
@@ -757,8 +798,6 @@ def _forward_softmax_attn(
     softmax attention instead of the gated-delta recurrence. Reuses the
     parent block's QKV/q_norm/k_norm/proj for parameter compatibility.
     """
-    import torch.nn.functional as F
-
     B, N, C = x.shape
     T, H, W = HW
     S = H * W
@@ -801,12 +840,37 @@ def _forward_softmax_attn(
     v = v.transpose(1, 2)
 
     dtype_orig = x.dtype
+    token_valid_mask_global = token_valid_mask
     if q.dtype == torch.float32:
         q, k, v = q.bfloat16(), k.bfloat16(), v.bfloat16()
 
-    attn_mask = _get_frame_causal_mask(T, S, x.device) if frame_causal else None
+    if token_valid_mask is not None:
+        if cp_enabled():
+            cp_group = get_cp_group()
+            k = torch.cat(dist_nn.all_gather(k.contiguous(), group=cp_group), dim=2)
+            v = torch.cat(dist_nn.all_gather(v.contiguous(), group=cp_group), dim=2)
+            token_valid_mask_global = torch.cat(
+                dist_nn.all_gather(token_valid_mask.contiguous(), group=cp_group), dim=1
+            )
 
-    out = F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask)
+    attn_mask = _get_frame_causal_mask(T, S, x.device) if frame_causal else None
+    if token_valid_mask_global is not None and not bool(token_valid_mask_global.all()):
+        valid_key_mask = token_valid_mask_global.bool().view(B, 1, 1, -1)
+        attn_mask = valid_key_mask if attn_mask is None else attn_mask & valid_key_mask
+
+    head_dim = q.shape[-1]
+    padded_head = token_valid_mask is not None and _sdpa_needs_head_pad(head_dim)
+    if padded_head:
+        pad_to = 128 if head_dim <= 128 else 256
+        q = F.pad(q, (0, pad_to - head_dim))
+        k = F.pad(k, (0, pad_to - head_dim))
+        v = F.pad(v, (0, pad_to - head_dim))
+    if padded_head:
+        out = F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask, scale=head_dim**-0.5)
+    else:
+        out = F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask)
+    if padded_head:
+        out = out[..., :head_dim]
     out = out.transpose(1, 2).reshape(B, N, C).to(dtype_orig)
 
     if apply_output_gate:
@@ -815,122 +879,14 @@ def _forward_softmax_attn(
         if hasattr(self, "proj_gate"):
             out = out * F.silu(self.proj_gate(x))
         out = self.proj(out)
+    if token_valid_mask is not None:
+        out = out * token_valid_mask.view(B, N, 1).to(out.dtype)
     return out
 
 
 # ---------------------------------------------------------------------------
 # Chunk-causal softmax attention for hybrid GDN-Softmax architectures
 # ---------------------------------------------------------------------------
-
-# flex_attention for chunk-causal softmax (single-kernel, no O(N^2) mask).
-try:
-    from torch.nn.attention.flex_attention import BlockMask, create_block_mask
-    from torch.nn.attention.flex_attention import flex_attention as _flex_attention_raw
-
-    _flex_attention = torch.compile(_flex_attention_raw, dynamic=False, mode="max-autotune-no-cudagraphs")
-    _HAS_FLEX_ATTENTION_CHUNK = True
-except ImportError:
-    _HAS_FLEX_ATTENTION_CHUNK = False
-
-_chunk_causal_block_mask_cache: dict[tuple, BlockMask] = {}
-
-
-def _get_chunk_causal_block_mask(
-    chunk_boundaries: list[int],
-    S: int,
-    q_len: int,
-    kv_len: int,
-    q_frame_offset: int,
-    device: torch.device,
-) -> BlockMask:
-    """Build a flex_attention BlockMask for chunk-causal attention.
-
-    Token ``q_idx`` can attend to ``kv_idx`` iff ``chunk(q) >= chunk(kv)``,
-    i.e. ``kv_idx < chunk_end(q)``.  Uses the HiAR pattern: precompute an
-    ``ends`` tensor mapping each token to its chunk's exclusive end token
-    index.  Results are cached by
-    ``(chunk_boundaries, S, q_len, kv_len, q_frame_offset, device)``.
-    """
-    cache_key = (tuple(chunk_boundaries), S, q_len, kv_len, q_frame_offset, device)
-    if cache_key in _chunk_causal_block_mask_cache:
-        return _chunk_causal_block_mask_cache[cache_key]
-
-    # flex_attention requires Q_LEN and KV_LEN to be multiples of 128.
-    q_pad = (128 - q_len % 128) % 128
-    kv_pad = (128 - kv_len % 128) % 128
-    Q_LEN = q_len + q_pad
-    KV_LEN = kv_len + kv_pad
-
-    # Build per-token ``ends`` array: ends[tok] = exclusive end token index
-    # of the chunk that ``tok`` belongs to (in global KV token space).
-    # Padded tokens map to KV_LEN so they attend to everything (masked later).
-    ends_kv = torch.full((KV_LEN,), KV_LEN, device=device, dtype=torch.long)
-    for ci in range(len(chunk_boundaries) - 1):
-        tok_start = chunk_boundaries[ci] * S
-        tok_end = chunk_boundaries[ci + 1] * S
-        if tok_end > KV_LEN:
-            tok_end = KV_LEN
-        if tok_start < KV_LEN:
-            ends_kv[tok_start:tok_end] = tok_end
-
-    # For Q tokens: map local Q index -> global token, then look up chunk end.
-    q_offset_tokens = q_frame_offset * S
-    ends_q = torch.full((Q_LEN,), KV_LEN, device=device, dtype=torch.long)
-    for qi in range(min(q_len, Q_LEN)):
-        global_qi = qi + q_offset_tokens
-        if global_qi < len(ends_kv):
-            ends_q[qi] = ends_kv[global_qi]
-
-    def mask_fn(b, h, q_idx, kv_idx):
-        return kv_idx < ends_q[q_idx]
-
-    block_mask = create_block_mask(
-        mask_fn,
-        B=None,
-        H=None,
-        Q_LEN=Q_LEN,
-        KV_LEN=KV_LEN,
-        _compile=False,
-        device=device,
-    )
-
-    _chunk_causal_block_mask_cache[cache_key] = block_mask
-    return block_mask
-
-
-_chunk_causal_mask_cache: dict[tuple, torch.Tensor] = {}
-
-
-def _get_chunk_causal_mask(
-    T: int,
-    S: int,
-    chunk_boundaries: list[int],
-    device: torch.device,
-) -> torch.Tensor:
-    """Chunk-wise block-causal mask for video generation.
-
-    Full attention within each chunk (all spatial tokens across all frames
-    in the chunk attend to each other), causal across chunks (tokens in
-    chunk C attend to all tokens in chunks 0..C only).
-
-    Args:
-        T: Number of temporal frames.
-        S: Number of spatial tokens per frame (``H * W``).
-        chunk_boundaries: Sorted chunk boundary list ``[0, c1, ..., T]``.
-        device: Target device for the mask tensor.
-
-    Returns:
-        Boolean mask ``(1, 1, T*S, T*S)`` where ``True`` = allowed to attend.
-    """
-    key = (T, S, tuple(chunk_boundaries), device)
-    if key not in _chunk_causal_mask_cache:
-        frame_to_chunk = torch.zeros(T, device=device, dtype=torch.long)
-        for i in range(len(chunk_boundaries) - 1):
-            frame_to_chunk[chunk_boundaries[i] : chunk_boundaries[i + 1]] = i
-        token_to_chunk = frame_to_chunk.repeat_interleave(S)
-        mask = token_to_chunk.unsqueeze(1) >= token_to_chunk.unsqueeze(0)
-        _chunk_causal_mask_cache[key] = mask.unsqueeze(0).unsqueeze(0)
-    return _chunk_causal_mask_cache[key]
 
 
 def _forward_softmax_attn_chunk_causal(
@@ -944,7 +900,7 @@ def _forward_softmax_attn_chunk_causal(
     apply_output_gate: bool = True,
     **kwargs: object,
 ) -> torch.Tensor:
-    """Chunk-causal softmax attention (SDPA / flex_attention) reusing GDN parameters.
+    """Chunk-causal softmax attention using SDPA and GDN parameters.
 
     Used by ``ChunkCausalSoftmaxAttn``.  Reuses ``qkv``, ``q_norm``,
     ``k_norm``, ``proj``, and the output gate from the parent ``GDN``
@@ -993,51 +949,46 @@ def _forward_softmax_attn_chunk_causal(
     v = v.transpose(1, 2)
 
     dtype_orig = x.dtype
+    token_valid_mask_global = token_valid_mask
     if q.dtype == torch.float32:
         q, k, v = q.bfloat16(), k.bfloat16(), v.bfloat16()
 
-    # NOTE: CP removed — single-GPU path only.
+    q_frame_offset = 0
+    chunk_index_for_mask = chunk_index
+    if cp_enabled() and get_cp_group() is not None:
+        cp_group = get_cp_group()
+        cp_rank = dist.get_rank(cp_group)
+        cp_world = dist.get_world_size(cp_group)
+        k = torch.cat(dist_nn.all_gather(k.contiguous(), group=cp_group), dim=2)
+        v = torch.cat(dist_nn.all_gather(v.contiguous(), group=cp_group), dim=2)
+        if token_valid_mask is not None:
+            token_valid_mask_global = torch.cat(
+                dist_nn.all_gather(token_valid_mask.contiguous(), group=cp_group), dim=1
+            )
+        q_frame_offset = cp_rank * T
+        T = T * cp_world
+        chunk_index_for_mask = kwargs.get("chunk_index_global", chunk_index)
+
+    invalid_key_mask = None
+    if token_valid_mask_global is not None and not bool(token_valid_mask_global.all()):
+        invalid_key_mask = token_valid_mask_global.bool().view(B, 1, 1, -1)
+
     _chunk_causal = chunk_size is not None and chunk_size < T
 
     if _chunk_causal:
-        chunk_boundaries, _ = normalize_chunk_index(chunk_index, T, chunk_size, chunk_split_strategy)
-        q_len = T * S
-        kv_len = T * S
-        q_frame_offset = 0
-
-        if _HAS_FLEX_ATTENTION_CHUNK:
-            # flex_attention: single compiled kernel with block-sparse mask.
-            block_mask = _get_chunk_causal_block_mask(chunk_boundaries, S, q_len, kv_len, q_frame_offset, x.device)
-            q_pad = (128 - q_len % 128) % 128
-            kv_pad = (128 - kv_len % 128) % 128
-            if q_pad > 0:
-                q = F.pad(q, (0, 0, 0, q_pad))
-            if kv_pad > 0:
-                k = F.pad(k, (0, 0, 0, kv_pad))
-                v = F.pad(v, (0, 0, 0, kv_pad))
-            out = _flex_attention(q, k, v, block_mask=block_mask)
-            if q_pad > 0:
-                out = out[:, :, :q_len, :]
-        else:
-            # Fallback: per-chunk loop with head_dim padding for FlashAttention.
-            D = q.shape[-1]
-            _need_pad = _sdpa_needs_head_pad(D)
-            if _need_pad:
-                _pad_to = 128 if D <= 128 else 256
-                _pad_size = _pad_to - D
-                q = F.pad(q, (0, _pad_size))
-                k = F.pad(k, (0, _pad_size))
-                v = F.pad(v, (0, _pad_size))
-            out_chunks: list[torch.Tensor] = []
-            for ci in range(len(chunk_boundaries) - 1):
-                c_start = chunk_boundaries[ci]
-                c_end = chunk_boundaries[ci + 1]
-                q_chunk = q[:, :, c_start * S : c_end * S, :]
-                out_chunk = F.scaled_dot_product_attention(q_chunk, k[:, :, : c_end * S, :], v[:, :, : c_end * S, :])
-                out_chunks.append(out_chunk)
-            out = torch.cat(out_chunks, dim=2)
-            if _need_pad:
-                out = out[..., :D]
+        out = _sdpa_maybe_chunk_causal(
+            q,
+            k,
+            v,
+            need_chunk_mask=True,
+            T=T,
+            S=S,
+            chunk_size=chunk_size,
+            chunk_index=chunk_index_for_mask,
+            chunk_split_strategy=chunk_split_strategy,
+            q_frame_offset=q_frame_offset,
+            attn_mask=invalid_key_mask,
+        )
     else:
         # Fully bidirectional softmax (no chunking).
         D = q.shape[-1]
@@ -1048,7 +999,13 @@ def _forward_softmax_attn_chunk_causal(
             q = F.pad(q, (0, _pad_size))
             k = F.pad(k, (0, _pad_size))
             v = F.pad(v, (0, _pad_size))
-        out = F.scaled_dot_product_attention(q, k, v)
+        out = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=invalid_key_mask,
+            scale=D**-0.5 if _need_pad else None,
+        )
         if _need_pad:
             out = out[..., :D]
 
@@ -1077,11 +1034,10 @@ class ChunkCausalSoftmaxAttn(ChunkCausalGDN):
     ``A_log``, ``dt_bias``, ``recall_gate``) are present but unused in
     forward.
 
-    Uses ``F.scaled_dot_product_attention`` (or ``flex_attention`` when
-    available) with a chunk-wise causal mask: full bidirectional attention
-    within each chunk, causal across chunks.  This matches the attention
-    pattern of ``ChunkCausalGDN`` while using exact softmax instead of the
-    linear GDN recurrence.
+    Uses ``F.scaled_dot_product_attention`` per chunk: full bidirectional
+    attention within each chunk and causal attention across chunks.  This
+    matches the attention pattern of ``ChunkCausalGDN`` while using exact
+    softmax instead of the linear GDN recurrence.
     """
 
     def __init__(self, *args: object, conv_kernel_size: int = 0, **kwargs: object) -> None:
@@ -1143,7 +1099,8 @@ def _sdpa_maybe_chunk_causal(
     chunk_size: int | None,
     chunk_index: list[int] | None,
     chunk_split_strategy: str,
-    device: torch.device,
+    q_frame_offset: int = 0,
+    attn_mask: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Run SDPA with chunk-causal masking when needed, or plain SDPA otherwise.
 
@@ -1156,26 +1113,9 @@ def _sdpa_maybe_chunk_causal(
     """
     if need_chunk_mask:
         chunk_boundaries, _ = normalize_chunk_index(chunk_index, T, chunk_size, chunk_split_strategy)
-        q_len = T * S
-        kv_len = T * S
-
-        if _HAS_FLEX_ATTENTION:
-            block_mask = _get_chunk_causal_block_mask(chunk_boundaries, S, q_len, kv_len, 0, device)
-            q_pad = (128 - q_len % 128) % 128
-            kv_pad = (128 - kv_len % 128) % 128
-            if q_pad > 0:
-                q = F.pad(q, (0, 0, 0, q_pad))
-            if kv_pad > 0:
-                k = F.pad(k, (0, 0, 0, kv_pad))
-                v = F.pad(v, (0, 0, 0, kv_pad))
-            out = _flex_attention(q, k, v, block_mask=block_mask)
-            if q_pad > 0:
-                out = out[:, :, :q_len, :]
-            return out
-
-        # Fallback: per-chunk loop with head_dim padding for FlashAttention.
+        q_len = q.shape[2]
         D = q.shape[-1]
-        _need_pad = D not in (32, 64, 128, 256) and D < 256
+        _need_pad = _sdpa_needs_head_pad(D)
         if _need_pad:
             _pad_to = 128 if D <= 128 else 256
             _pad_size = _pad_to - D
@@ -1183,14 +1123,21 @@ def _sdpa_maybe_chunk_causal(
             k = F.pad(k, (0, _pad_size))
             v = F.pad(v, (0, _pad_size))
         out_chunks: list[torch.Tensor] = []
+        q_frame_end = q_frame_offset + q_len // S
         for ci in range(len(chunk_boundaries) - 1):
             c_start = chunk_boundaries[ci]
             c_end = chunk_boundaries[ci + 1]
-            q_chunk = q[:, :, c_start * S : c_end * S, :]
+            if c_end <= q_frame_offset or c_start >= q_frame_end:
+                continue
+            q_start = max(c_start, q_frame_offset) - q_frame_offset
+            q_end = min(c_end, q_frame_end) - q_frame_offset
+            q_chunk = q[:, :, q_start * S : q_end * S, :]
             out_chunk = F.scaled_dot_product_attention(
                 q_chunk,
                 k[:, :, : c_end * S, :],
                 v[:, :, : c_end * S, :],
+                attn_mask=None if attn_mask is None else attn_mask[..., : c_end * S],
+                scale=D**-0.5 if _need_pad else None,
             )
             out_chunks.append(out_chunk)
         out = torch.cat(out_chunks, dim=2)
@@ -1200,14 +1147,20 @@ def _sdpa_maybe_chunk_causal(
 
     # Standard path: full SDPA (all cached tokens are causally prior).
     D = q.shape[-1]
-    _need_pad = D not in (32, 64, 128, 256) and D < 256
+    _need_pad = _sdpa_needs_head_pad(D)
     if _need_pad:
         _pad_to = 128 if D <= 128 else 256
         _pad_size = _pad_to - D
         q = F.pad(q, (0, _pad_size))
         k = F.pad(k, (0, _pad_size))
         v = F.pad(v, (0, _pad_size))
-    out = F.scaled_dot_product_attention(q, k, v)
+    out = F.scaled_dot_product_attention(
+        q,
+        k,
+        v,
+        attn_mask=attn_mask,
+        scale=D**-0.5 if _need_pad else None,
+    )
     if _need_pad:
         out = out[..., :D]
     return out
@@ -1235,8 +1188,6 @@ class CachedChunkCausalGDN(ChunkCausalGDN):
         chunk_index: list[int] | None = None,
         **kwargs: object,
     ) -> tuple[torch.Tensor, list]:
-        from diffusion.model.ops.fused_streaming import _cached_gdn_forward_triton
-
         if kwargs.get("kv_cache", None) is None:
             raise RuntimeError("CachedChunkCausalGDN requires kv_cache to be provided " "(streaming inference only).")
         del mask, block_mask, chunk_split_strategy, chunk_index
@@ -1273,14 +1224,6 @@ class CachedChunkCausalSoftmaxAttn(ChunkCausalSoftmaxAttn):
         chunk_index: list[int] | None = None,
         **kwargs: object,
     ) -> torch.Tensor | tuple[torch.Tensor, list]:
-        from diffusion.model.ops.fused_streaming import (
-            _SLOT_FWD_KV,
-            _SLOT_FWD_Z,
-            _SLOT_TYPE_FLAG,
-            _TYPE_CONCAT,
-            _slice_rope_to_current_chunk,
-        )
-
         kv_cache = kwargs.get("kv_cache", None)
         save_kv_cache = kwargs.get("save_kv_cache", False)
 
@@ -1353,7 +1296,6 @@ class CachedChunkCausalSoftmaxAttn(ChunkCausalSoftmaxAttn):
             chunk_size=chunk_size,
             chunk_index=chunk_index,
             chunk_split_strategy=chunk_split_strategy,
-            device=x.device,
         )
 
         if out.dtype != dtype_orig:

--- a/diffusion/model/nets/sana_gdn_blocks_triton.py
+++ b/diffusion/model/nets/sana_gdn_blocks_triton.py
@@ -9,9 +9,16 @@ scan.
 from __future__ import annotations
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 
-from diffusion.distributed.context_parallel.config import cp_enabled
+from diffusion.distributed.context_parallel.config import (
+    cp_enabled,
+    get_cp_group,
+    get_cp_triton_block_fusion,
+)
+from diffusion.distributed.context_parallel.distributed_scan import cp_frame_gdn_scan
+from diffusion.distributed.context_parallel.halo_exchange import cp_halo_exchange
 from diffusion.model.nets.sana_camctrl_blocks import (
     _maybe_drop_cam_branch,
     _prepare_ray_apply_fns,
@@ -40,6 +47,11 @@ from diffusion.model.ops.fused_gdn import (
     prepare_rope_tables,
 )
 from diffusion.model.ops.fused_gdn_chunkwise import cam_scan_bidi_chunkwise, cam_scan_pair_chunkwise
+from diffusion.model.ops.frame_gdn.api import _build_transition_matrices
+from diffusion.model.ops.fused_gdn_cp import (
+    cp_fused_cam_gdn_num_autograd,
+    cp_fused_gdn_chunkwise_raw_autograd,
+)
 from diffusion.model.registry import ATTENTION_BLOCKS
 from diffusion.utils.chunk_utils import (
     is_chunk_causal_request,
@@ -129,19 +141,8 @@ class ChunkCausalGDNTriton(ChunkCausalGDN):
             ``(B, N_local, C)`` after attention + (optional) output gate
             + projection.
         """
-        import torch.distributed as dist
-
-        from diffusion.distributed.context_parallel.config import get_cp_group
-        from diffusion.distributed.context_parallel.halo_exchange import cp_halo_exchange
-        from diffusion.model.ops.fused_gdn_cp import cp_fused_gdn_chunkwise_raw_autograd
-        from diffusion.utils.chunk_utils import normalize_chunk_index
-
         del mask, block_mask  # unused on this path
 
-        if kwargs.get("frame_valid_mask", None) is not None:
-            raise NotImplementedError(
-                "ChunkCausalGDNTriton CP-Triton path does not support " "frame_valid_mask (training-only feature)."
-            )
         if self.conv_q is not None or self.conv_v is not None:
             raise NotImplementedError(
                 "ChunkCausalGDNTriton CP-Triton path supports k_conv_only="
@@ -158,6 +159,16 @@ class ChunkCausalGDNTriton(ChunkCausalGDN):
         if C != H * D:
             raise ValueError(f"C={C} != heads*dim={H * D}.")
 
+        token_valid_mask, beta_valid_mask, decay_valid_mask = self._prepare_frame_valid_masks(
+            kwargs.get("frame_valid_mask"),
+            B=B,
+            T=T,
+            S=S,
+            device=x.device,
+            dtype=x.dtype,
+        )
+        token_mask = token_valid_mask.view(B, N, 1) if token_valid_mask is not None else None
+
         cp_group = get_cp_group()
         if cp_group is None:
             raise RuntimeError(
@@ -166,6 +177,8 @@ class ChunkCausalGDNTriton(ChunkCausalGDN):
 
         # ---- 1. QKV projection on the CP-local slice. ---------------------
         qkv = self.qkv(x).reshape(B, N, 3, H, D)
+        if token_mask is not None:
+            qkv = qkv * token_mask[:, :, None, None]
 
         # ---- 2. Chunk-causal short conv on K (in-place writeback). --------
         if self.conv_k is not None:
@@ -188,6 +201,9 @@ class ChunkCausalGDNTriton(ChunkCausalGDN):
             beta, decay = precomputed_gates
         else:
             beta, decay = self._compute_frame_gates(x, HW)
+        if beta_valid_mask is not None:
+            beta = torch.where(beta_valid_mask.bool(), beta, 0.0)
+            decay = torch.where(decay_valid_mask.bool(), decay, 1.0)
         beta = beta.contiguous()
         decay = decay.contiguous()
 
@@ -242,7 +258,7 @@ class ChunkCausalGDNTriton(ChunkCausalGDN):
             T_global = T * cp_world
             global_offset = cp_rank_local * T
             valid_chunk_index_global, _ = normalize_chunk_index(
-                chunk_index,
+                kwargs.get("chunk_index_global", chunk_index),
                 T_global,
                 chunk_size,
                 chunk_split_strategy,
@@ -258,6 +274,9 @@ class ChunkCausalGDNTriton(ChunkCausalGDN):
             input_mask = torch.ones(B, 1, T, 1, 1, device=x.device, dtype=qkv.dtype)
             if boundaries:
                 input_mask[:, :, boundaries] = 0.0
+        if token_valid_mask is not None:
+            frame_valid = token_valid_mask.view(B, T, S)[:, :, 0].view(B, 1, T, 1, 1)
+            input_mask = input_mask * frame_valid
 
         def _cp_flip_and_shift(tensors: list[torch.Tensor], shift_vals: list[float]) -> list[torch.Tensor]:
             is_last = cp_rank_local == cp_world - 1
@@ -355,6 +374,8 @@ class ChunkCausalGDNTriton(ChunkCausalGDN):
         if apply_output_gate:
             out = self._apply_output_gate(out, x)
             out = self.proj(out.to(self.proj.weight.dtype))
+        if token_mask is not None:
+            out = out * token_mask.to(out.dtype)
         return out
 
     def forward(
@@ -373,10 +394,6 @@ class ChunkCausalGDNTriton(ChunkCausalGDN):
         if HW is None:
             raise ValueError("ChunkCausalGDNTriton requires HW=(T, H, W).")
         if cp_enabled():
-            from diffusion.distributed.context_parallel.config import (
-                get_cp_triton_block_fusion,
-            )
-
             if not get_cp_triton_block_fusion():
                 raise NotImplementedError(
                     "ChunkCausalGDNTriton context-parallel execution requires "
@@ -696,10 +713,6 @@ class ChunkCausalGDNUCPESinglePathLiteLABothTriton(ChunkCausalGDNUCPESinglePathL
             7. Apply inverse UCPE (``apply_fn_o``) in torch.
         """
         if cp_enabled():
-            from diffusion.distributed.context_parallel.config import (
-                get_cp_triton_block_fusion,
-            )
-
             if not get_cp_triton_block_fusion():
                 raise NotImplementedError(
                     "ChunkCausalGDNUCPESinglePathLiteLABothTriton context-parallel "
@@ -876,14 +889,12 @@ class ChunkCausalGDNUCPESinglePathLiteLABothTriton(ChunkCausalGDNUCPESinglePathL
         """CP-aware Triton-fused chunk-causal camera branch.
 
         The forward branch uses :func:`cam_prep_func_with_grad` followed by
-        :func:`cp_fused_cam_gdn_num_autograd`. The backward branch keeps
-        chunk-local anti-causal semantics by running each rank's local chunks
-        independently, so no cross-rank communication is needed for the
-        reverse scan.
+        :func:`cp_fused_cam_gdn_num_autograd`. The backward branch uses the
+        same distributed scan in reverse rank order, with chunk-boundary
+        resets preserving chunk-local anti-causal semantics.
 
         Limitations / rejections:
 
-        * ``frame_valid_mask`` (training-only feature) -> NotImplementedError.
         * Q/V short conv (``conv_q_cam`` / ``conv_v_cam``) -> NotImplementedError.
         * Multi-chunk schedule required (chunk_size < T_global or
           explicit chunk_index). Single-chunk falls through to eager
@@ -898,20 +909,7 @@ class ChunkCausalGDNUCPESinglePathLiteLABothTriton(ChunkCausalGDNUCPESinglePathL
         Returns:
             ``(B, N_local, cam_dim)`` post-inverse-UCPE camera output.
         """
-        import torch.distributed as dist
-
-        from diffusion.distributed.context_parallel.config import get_cp_group
-        from diffusion.distributed.context_parallel.distributed_scan import get_local_scan_cls
-        from diffusion.model.nets.sana_gdn_blocks import flip_and_shift
-        from diffusion.model.ops.frame_gdn.api import _build_transition_matrices
-        from diffusion.model.ops.fused_gdn_cp import cp_fused_cam_gdn_num_autograd
-
         # ---- Guards. ----
-        if kwargs.get("frame_valid_mask", None) is not None:
-            raise NotImplementedError(
-                "ChunkCausalGDNUCPESinglePathLiteLABothTriton CP-Triton "
-                "cam branch does not support frame_valid_mask (training-only feature)."
-            )
         if self.conv_q_cam is not None or self.conv_v_cam is not None:
             raise NotImplementedError(
                 "ChunkCausalGDNUCPESinglePathLiteLABothTriton CP-Triton "
@@ -925,6 +923,16 @@ class ChunkCausalGDNUCPESinglePathLiteLABothTriton(ChunkCausalGDNUCPESinglePathL
         dtype_orig = x.dtype
         H_heads = self.cam_heads
         D_head = self.cam_head_dim
+
+        token_valid_mask, beta_valid_mask, decay_valid_mask = self._prepare_frame_valid_masks(
+            kwargs.get("frame_valid_mask"),
+            B=B,
+            T=T,
+            S=S,
+            device=x.device,
+            dtype=x.dtype,
+        )
+        token_mask = token_valid_mask.view(B, N, 1) if token_valid_mask is not None else None
 
         cp_group = get_cp_group()
         if cp_group is None:
@@ -950,6 +958,8 @@ class ChunkCausalGDNUCPESinglePathLiteLABothTriton(ChunkCausalGDNUCPESinglePathL
         qkv_w = torch.cat([self.q_proj_cam.weight, self.k_proj_cam.weight, self.v_proj_cam.weight])
         qkv_b = torch.cat([self.q_proj_cam.bias, self.k_proj_cam.bias, self.v_proj_cam.bias])
         qkv_cam = torch.nn.functional.linear(x, qkv_w, qkv_b)
+        if token_mask is not None:
+            qkv_cam = qkv_cam * token_mask
         q_raw, k_raw, v_raw = qkv_cam.chunk(3, dim=-1)
 
         if self.conv_k_cam is not None:
@@ -1040,6 +1050,9 @@ class ChunkCausalGDNUCPESinglePathLiteLABothTriton(ChunkCausalGDNUCPESinglePathL
         else:
             assert beta.shape == (B, H_heads, T, S), f"beta shape {beta.shape}"
             beta_bhfs = beta.contiguous()
+        if beta_valid_mask is not None:
+            beta_bhfs = torch.where(beta_valid_mask.bool(), beta_bhfs, 0.0)
+            decay = torch.where(decay_valid_mask.bool(), decay, 1.0)
         decay = decay.contiguous()
 
         q_cam_trans = q_cam_trans.contiguous()
@@ -1060,13 +1073,10 @@ class ChunkCausalGDNUCPESinglePathLiteLABothTriton(ChunkCausalGDNUCPESinglePathL
             truncate_to_active=None,
         )
 
-        # ---- 8. Backward scan (per-chunk local). ----
-        # Each rank runs the backward independently on its local chunks.
-        # Chunk-isolated backward semantics make this correct without
-        # cross-rank communication.
+        # ---- 8. Backward scan (chunk-causal, distributed across CP). ----
         global_offset = cp_rank_local * T
         valid_chunk_index_global, _ = normalize_chunk_index(
-            chunk_index,
+            kwargs.get("chunk_index_global", chunk_index),
             T_global,
             chunk_size,
             chunk_split_strategy,
@@ -1077,72 +1087,58 @@ class ChunkCausalGDNUCPESinglePathLiteLABothTriton(ChunkCausalGDNUCPESinglePathL
             if global_offset <= idx < global_offset + T and idx != 0
         ]
 
-        local_chunk_ends = [0]
-        for b in boundaries:
-            if 0 < b < T:
-                local_chunk_ends.append(b)
-        local_chunk_ends.append(T)
-        local_chunk_ends = sorted(set(local_chunk_ends))
+        decay_bwd_input = decay.clone()
+        if boundaries:
+            decay_bwd_input[:, :, boundaries] = 0.0
+        input_mask = torch.ones(B, 1, T, 1, 1, device=x.device, dtype=q_cam_trans.dtype)
+        if boundaries:
+            input_mask[:, :, boundaries] = 0.0
+        if token_valid_mask is not None:
+            frame_valid = token_valid_mask.view(B, T, S)[:, :, 0].view(B, 1, T, 1, 1)
+            input_mask = input_mask * frame_valid
 
-        def _to_time_bwd(t: torch.Tensor) -> torch.Tensor:
-            return t.view(B, H_heads, D_head, T, S).permute(0, 1, 3, 2, 4)
+        def _to_frame(t: torch.Tensor) -> torch.Tensor:
+            return t.view(B, H_heads, D_head, T, S).permute(0, 1, 3, 2, 4).contiguous()
 
-        q_rot_T = _to_time_bwd(q_cam_trans)
-        k_rot_T = _to_time_bwd(k_cam_trans)
-        v_T = _to_time_bwd(v_cam_trans)
+        def _from_frame(t: torch.Tensor) -> torch.Tensor:
+            return t.permute(0, 1, 3, 2, 4).reshape(B, H_heads, D_head, T * S).contiguous()
 
-        out_bwd_chunks: list[torch.Tensor] = []
-        for ci in range(len(local_chunk_ends) - 1):
-            cs = local_chunk_ends[ci]
-            ce = local_chunk_ends[ci + 1]
-            chunk_len = ce - cs
+        def _cp_flip_and_shift(tensors: list[torch.Tensor], shift_vals: list[float]) -> list[torch.Tensor]:
+            is_last = cp_rank_local == cp_world - 1
+            results = []
+            for tensor, sv in zip(tensors, shift_vals):
+                first_frame = tensor[:, :, :1, ...].contiguous()
+                haloed = cp_halo_exchange(first_frame, left_size=0, right_size=1, dim=2, group=cp_group)
+                boundary = haloed[:, :, 1:2, ...]
+                if is_last and sv != 0.0:
+                    boundary = boundary.mul(0.0).add(sv)
+                flipped = torch.flip(tensor, dims=[2])
+                results.append(torch.cat([boundary, flipped[:, :, : T - 1, ...]], dim=2))
+            return results
 
-            # Size-1 chunk: anti-causal scan contributes zero (matches
-            # eager frame-causal design).
-            if chunk_len == 1:
-                out_bwd_chunks.append(q_rot_T.new_zeros(B, H_heads, D_head, 1, S))
-                continue
+        q_rot_f = _to_frame(q_cam_trans)
+        k_rot_f = _to_frame(k_cam_trans) * input_mask
+        v_f = _to_frame(v_cam_trans) * input_mask
+        q_rot_bwd_f = torch.flip(q_rot_f, dims=[2])
+        k_rot_bwd_f, v_bwd_f = _cp_flip_and_shift([k_rot_f, v_f], [0.0, 0.0])
 
-            q_chunk = q_rot_T[:, :, cs:ce]
-            k_chunk = k_rot_T[:, :, cs:ce]
-            v_chunk = v_T[:, :, cs:ce]
-            if beta_bhfs.ndim == 4:
-                beta_chunk = beta_bhfs[:, :, cs:ce, :]
-            else:
-                beta_chunk = beta_bhfs[:, :, cs:ce]
-            decay_chunk = decay[:, :, cs:ce]
+        beta_f = beta_bhfs.unsqueeze(3) * input_mask
+        decay_f = decay_bwd_input.view(B, H_heads, T, 1, 1)
+        beta_bwd_f, decay_bwd_f = _cp_flip_and_shift([beta_f, decay_f], [0.0, 1.0])
 
-            q_bwd_c = torch.flip(q_chunk, dims=[2])
-            k_bwd_c = flip_and_shift(k_chunk, dim=2, shift_val=0.0)
-            v_bwd_c = flip_and_shift(v_chunk, dim=2, shift_val=0.0)
-            beta_bwd_c = flip_and_shift(beta_chunk, dim=2, shift_val=0.0)
-            decay_bwd_c = flip_and_shift(decay_chunk, dim=2, shift_val=1.0)
-
-            beta_bwd_c = beta_bwd_c.unsqueeze(3)
-            decay_bwd_c = decay_bwd_c.view(B, H_heads, chunk_len, 1, 1)
-            identity = torch.eye(D_head, device=x.device, dtype=q_bwd_c.dtype).reshape(1, 1, 1, D_head, D_head)
-            W_kv_bwd, U_kv_bwd, W_z_bwd, U_z_bwd = _build_transition_matrices(
-                k_bwd_c,
-                v_bwd_c,
-                k_bwd_c,
-                beta_bwd_c,
-                decay_bwd_c,
-                identity,
-                B * H_heads,
-                chunk_len,
-                D_head,
-            )
-            W_z_bwd = torch.zeros_like(W_z_bwd)
-            U_z_bwd = torch.zeros_like(U_z_bwd)
-            local_scan = get_local_scan_cls(W_kv_bwd.is_cuda)
-            S_kv_bwd, _ = local_scan.apply(W_kv_bwd, U_kv_bwd, W_z_bwd, U_z_bwd)
-            S_kv_bwd = S_kv_bwd.view(B, H_heads, chunk_len, D_head, D_head)
-            out_bwd_c = torch.matmul(S_kv_bwd, q_bwd_c)
-            out_bwd_c = torch.flip(out_bwd_c, dims=[2]).permute(0, 1, 3, 2, 4).contiguous()
-            out_bwd_chunks.append(out_bwd_c)
-
-        out_bwd_cat = torch.cat(out_bwd_chunks, dim=3)
-        out_bwd_flat = out_bwd_cat.reshape(B, H_heads, D_head, T * S)
+        out_bwd_flipped, _ = cp_fused_cam_gdn_num_autograd(
+            _from_frame(q_rot_bwd_f),
+            _from_frame(k_rot_bwd_f),
+            _from_frame(v_bwd_f),
+            beta_bwd_f.squeeze(3).contiguous(),
+            decay_bwd_f.squeeze(-1).squeeze(-1).contiguous(),
+            F=T,
+            S=S,
+            group=cp_group,
+            reverse_rank_order=True,
+            truncate_to_active=None,
+        )
+        out_bwd_flat = _from_frame(torch.flip(_to_frame(out_bwd_flipped), dims=[2]))
 
         # ---- 9. Single-path combine: num_fwd + num_bwd (no divide). ----
         out = out_fwd + out_bwd_flat
@@ -1160,6 +1156,8 @@ class ChunkCausalGDNUCPESinglePathLiteLABothTriton(ChunkCausalGDNUCPESinglePathL
         )
         out = apply_fn_o(out.transpose(-1, -2)).transpose(-1, -2).contiguous()
         out = out.reshape(B, self.cam_dim, -1).permute(0, 2, 1)
+        if token_mask is not None:
+            out = out * token_mask.to(out.dtype)
         return out
 
 
@@ -1231,18 +1229,8 @@ class BidirectionalGDNTriton(BidirectionalGDN):
             ``(B, N_local, C)`` after attention + (optional) output gate
             + projection.
         """
-        import torch.distributed as dist
-
-        from diffusion.distributed.context_parallel.config import get_cp_group
-        from diffusion.distributed.context_parallel.halo_exchange import cp_halo_exchange
-        from diffusion.model.ops.fused_gdn_cp import cp_fused_gdn_chunkwise_raw_autograd
-
         del mask, block_mask  # unused on this path
 
-        if kwargs.get("frame_valid_mask", None) is not None:
-            raise NotImplementedError(
-                "BidirectionalGDNTriton CP-Triton path does not support " "frame_valid_mask (training-only feature)."
-            )
         if self.conv_q is not None or self.conv_v is not None:
             raise NotImplementedError(
                 "BidirectionalGDNTriton CP-Triton path supports k_conv_only="
@@ -1258,6 +1246,16 @@ class BidirectionalGDNTriton(BidirectionalGDN):
         if C != H * D:
             raise ValueError(f"C={C} != heads*dim={H * D}.")
 
+        token_valid_mask, beta_valid_mask, decay_valid_mask = self._prepare_frame_valid_masks(
+            kwargs.get("frame_valid_mask", None),
+            B=B,
+            T=T,
+            S=S,
+            device=x.device,
+            dtype=x.dtype,
+        )
+        token_mask = token_valid_mask.view(B, N, 1) if token_valid_mask is not None else None
+
         cp_group = get_cp_group()
         if cp_group is None:
             raise RuntimeError(
@@ -1266,11 +1264,18 @@ class BidirectionalGDNTriton(BidirectionalGDN):
 
         # ---- 1. QKV projection on the CP-local slice. ---------------------
         qkv = self.qkv(x).reshape(B, N, 3, H, D)
+        if token_mask is not None:
+            qkv = qkv * token_mask[:, :, None, None]
 
         # ---- 2. Bidirectional short conv on K (parent method). ----
         if self.conv_k is not None:
             k_raw = qkv[:, :, 1].contiguous().reshape(B, N, C)
-            k_conv = self._apply_temporal_short_conv(k_raw, self.conv_k, HW)
+            k_conv = self._apply_temporal_short_conv(
+                k_raw,
+                self.conv_k,
+                HW,
+                frame_valid_mask=kwargs.get("frame_valid_mask"),
+            )
             qkv = qkv.clone()
             qkv[:, :, 1] = k_conv.reshape(B, N, H, D)
 
@@ -1280,6 +1285,9 @@ class BidirectionalGDNTriton(BidirectionalGDN):
             beta, decay = precomputed_gates
         else:
             beta, decay = self._compute_frame_gates(x, HW)
+        if beta_valid_mask is not None:
+            beta = torch.where(beta_valid_mask.bool(), beta, 0.0)
+            decay = torch.where(decay_valid_mask.bool(), decay, 1.0)
         beta = beta.contiguous()
         decay = decay.contiguous()
 
@@ -1424,6 +1432,8 @@ class BidirectionalGDNTriton(BidirectionalGDN):
         if apply_output_gate:
             out = self._apply_output_gate(out, x)
             out = self.proj(out.to(self.proj.weight.dtype))
+        if token_mask is not None:
+            out = out * token_mask.to(out.dtype)
         return out
 
     def forward(
@@ -1439,10 +1449,6 @@ class BidirectionalGDNTriton(BidirectionalGDN):
         if HW is None:
             raise ValueError("BidirectionalGDNTriton requires HW=(T, H, W).")
         if cp_enabled():
-            from diffusion.distributed.context_parallel.config import (
-                get_cp_triton_block_fusion,
-            )
-
             if not get_cp_triton_block_fusion():
                 raise NotImplementedError(
                     "BidirectionalGDNTriton context-parallel execution requires "
@@ -1692,10 +1698,6 @@ class BidirectionalGDNUCPESinglePathLiteLABothTriton(BidirectionalGDNUCPESingleP
     ) -> torch.Tensor:
         # ---- Guards: no CP, k_conv_only=True (apply in either mode). ----
         if cp_enabled():
-            from diffusion.distributed.context_parallel.config import (
-                get_cp_triton_block_fusion,
-            )
-
             if not get_cp_triton_block_fusion():
                 raise NotImplementedError(
                     "BidirectionalGDNUCPESinglePathLiteLABothTriton context-parallel "
@@ -1870,20 +1872,7 @@ class BidirectionalGDNUCPESinglePathLiteLABothTriton(BidirectionalGDNUCPESingleP
           reverse scan is used (the eager bidi cam path).
         * Bidirectional camera runs full sequence end-to-end.
         """
-        import torch.distributed as dist
-
-        from diffusion.distributed.context_parallel.config import get_cp_group
-        from diffusion.distributed.context_parallel.distributed_scan import cp_frame_gdn_scan
-        from diffusion.distributed.context_parallel.halo_exchange import cp_halo_exchange
-        from diffusion.model.ops.frame_gdn.api import _build_transition_matrices
-        from diffusion.model.ops.fused_gdn_cp import cp_fused_cam_gdn_num_autograd
-
-        # ---- Guards: training-only / Q-V conv rejections. ----
-        if kwargs.get("frame_valid_mask", None) is not None:
-            raise NotImplementedError(
-                "BidirectionalGDNUCPESinglePathLiteLABothTriton CP-Triton "
-                "cam branch does not support frame_valid_mask (training-only feature)."
-            )
+        # ---- Guards: Q/V conv rejections. ----
         if self.conv_q_cam is not None or self.conv_v_cam is not None:
             raise NotImplementedError(
                 "BidirectionalGDNUCPESinglePathLiteLABothTriton CP-Triton "
@@ -1897,6 +1886,16 @@ class BidirectionalGDNUCPESinglePathLiteLABothTriton(BidirectionalGDNUCPESingleP
         H_heads = self.cam_heads
         D_head = self.cam_head_dim
 
+        token_valid_mask, beta_valid_mask, decay_valid_mask = self._prepare_frame_valid_masks(
+            kwargs.get("frame_valid_mask", None),
+            B=B,
+            T=T,
+            S=S,
+            device=x.device,
+            dtype=x.dtype,
+        )
+        token_mask = token_valid_mask.view(B, N, 1) if token_valid_mask is not None else None
+
         cp_group = get_cp_group()
         if cp_group is None:
             raise RuntimeError("_forward_cam_branch_cp_triton_ag (bidi) called but CP group is not initialized.")
@@ -1905,12 +1904,19 @@ class BidirectionalGDNUCPESinglePathLiteLABothTriton(BidirectionalGDNUCPESingleP
         qkv_w = torch.cat([self.q_proj_cam.weight, self.k_proj_cam.weight, self.v_proj_cam.weight])
         qkv_b = torch.cat([self.q_proj_cam.bias, self.k_proj_cam.bias, self.v_proj_cam.bias])
         qkv_cam = torch.nn.functional.linear(x, qkv_w, qkv_b)
+        if token_mask is not None:
+            qkv_cam = qkv_cam * token_mask
         q_raw, k_raw, v_raw = qkv_cam.chunk(3, dim=-1)
 
         if self.conv_k_cam is not None:
             # Parent (BidirectionalGDN._apply_temporal_short_conv) handles
             # CP halo exchange internally.
-            k_raw = self._apply_temporal_short_conv(k_raw, self.conv_k_cam, HW)
+            k_raw = self._apply_temporal_short_conv(
+                k_raw,
+                self.conv_k_cam,
+                HW,
+                frame_valid_mask=kwargs.get("frame_valid_mask"),
+            )
 
         q_raw = q_raw.contiguous().view(B, N, H_heads, D_head).contiguous()
         k_raw = k_raw.contiguous().view(B, N, H_heads, D_head).contiguous()
@@ -1997,6 +2003,9 @@ class BidirectionalGDNUCPESinglePathLiteLABothTriton(BidirectionalGDNUCPESingleP
         else:
             assert beta.shape == (B, H_heads, T, S), f"beta shape {beta.shape}"
             beta_bhfs = beta.contiguous()
+        if beta_valid_mask is not None:
+            beta_bhfs = torch.where(beta_valid_mask.bool(), beta_bhfs, 0.0)
+            decay = torch.where(decay_valid_mask.bool(), decay, 1.0)
         decay = decay.contiguous()
 
         q_cam_trans = q_cam_trans.contiguous()
@@ -2103,4 +2112,6 @@ class BidirectionalGDNUCPESinglePathLiteLABothTriton(BidirectionalGDNUCPESingleP
         )
         out = apply_fn_o(out.transpose(-1, -2)).transpose(-1, -2).contiguous()
         out = out.reshape(B, self.cam_dim, -1).permute(0, 2, 1)
+        if token_mask is not None:
+            out = out * token_mask.to(out.dtype)
         return out

--- a/diffusion/model/nets/sana_gdn_blocks_triton.py
+++ b/diffusion/model/nets/sana_gdn_blocks_triton.py
@@ -31,6 +31,7 @@ from diffusion.model.nets.sana_gdn_camctrl_blocks import (
     BidirectionalGDNUCPESinglePathLiteLA,
     ChunkCausalGDNUCPESinglePathLiteLA,
 )
+from diffusion.model.ops.frame_gdn.api import _build_transition_matrices
 from diffusion.model.ops.fused_cam_gdn import (
     _invert_SE3,
     _prepare_ucpe_rope_tables,
@@ -47,7 +48,6 @@ from diffusion.model.ops.fused_gdn import (
     prepare_rope_tables,
 )
 from diffusion.model.ops.fused_gdn_chunkwise import cam_scan_bidi_chunkwise, cam_scan_pair_chunkwise
-from diffusion.model.ops.frame_gdn.api import _build_transition_matrices
 from diffusion.model.ops.fused_gdn_cp import (
     cp_fused_cam_gdn_num_autograd,
     cp_fused_gdn_chunkwise_raw_autograd,

--- a/diffusion/model/nets/sana_gdn_camctrl_blocks.py
+++ b/diffusion/model/nets/sana_gdn_camctrl_blocks.py
@@ -39,20 +39,32 @@ from __future__ import annotations
 from copy import deepcopy
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 from fla.modules import ShortConvolution
+from torch.distributed.nn import functional as dist_nn
 
+from diffusion.distributed.context_parallel.config import cp_enabled, get_cp_group
+from diffusion.model.ops.fused_streaming import (
+    _SLOT_CAM,
+    _SLOT_CAM_AUX,
+    _cam_main_triton,
+    _cam_prep_triton,
+)
 from diffusion.model.registry import ATTENTION_BLOCKS
 
 from .sana_camctrl_blocks import _maybe_drop_cam_branch, prepare_prope_fns
 from .sana_gdn_blocks import (
     GDN,
     BidirectionalGDN,
+    CachedChunkCausalGDN,
+    CachedChunkCausalSoftmaxAttn,
     ChunkCausalGDN,
     _forward_softmax_attn,
+    _forward_softmax_attn_chunk_causal,
+    _sdpa_maybe_chunk_causal,
     _sdpa_needs_head_pad,
-    flip_and_shift,
 )
 
 # ---------------------------------------------------------------------------
@@ -492,26 +504,65 @@ def _forward_cam_branch_softmax(
     if q_sdpa.dtype == torch.float32:
         q_sdpa, k_sdpa, v_sdpa = q_sdpa.bfloat16(), k_sdpa.bfloat16(), v_sdpa.bfloat16()
 
+    key_valid_mask = token_valid_mask
+    attention_t = T
+    q_frame_offset = 0
+    chunk_index = kwargs.get("chunk_index")
+    if cp_enabled() and get_cp_group() is not None:
+        cp_group = get_cp_group()
+        cp_rank = dist.get_rank(cp_group)
+        cp_world = dist.get_world_size(cp_group)
+        k_sdpa = torch.cat(dist_nn.all_gather(k_sdpa.contiguous(), group=cp_group), dim=2)
+        v_sdpa = torch.cat(dist_nn.all_gather(v_sdpa.contiguous(), group=cp_group), dim=2)
+        if token_valid_mask is not None:
+            key_valid_mask = torch.cat(dist_nn.all_gather(token_valid_mask.contiguous(), group=cp_group), dim=1)
+        q_frame_offset = cp_rank * T
+        attention_t = T * cp_world
+        chunk_index = kwargs.get("chunk_index_global", chunk_index)
+
     invalid_kv_logit_bias = None
-    if token_valid_mask is not None and not bool(token_valid_mask.all()):
+    if key_valid_mask is not None and not bool(key_valid_mask.all()):
         invalid_kv_logit_bias = torch.where(
-            token_valid_mask.bool().view(B, 1, 1, -1),
+            key_valid_mask.bool().view(B, 1, 1, -1),
             torch.zeros((), dtype=q_sdpa.dtype, device=q_sdpa.device),
             torch.full((), -1e9, dtype=q_sdpa.dtype, device=q_sdpa.device),
         )
 
-    # FlashAttention-2 only supports head_dim in {32, 64, 128, 256}.
-    D = q_sdpa.shape[-1]
-    _need_pad = D not in (32, 64, 128, 256) and D < 256
-    if _need_pad:
-        _pad_to = 128 if D <= 128 else 256
-        _pad_size = _pad_to - D
-        q_sdpa = F.pad(q_sdpa, (0, _pad_size))
-        k_sdpa = F.pad(k_sdpa, (0, _pad_size))
-        v_sdpa = F.pad(v_sdpa, (0, _pad_size))
-    out = F.scaled_dot_product_attention(q_sdpa, k_sdpa, v_sdpa, attn_mask=invalid_kv_logit_bias)
-    if _need_pad:
-        out = out[..., :D]
+    chunk_size = kwargs.get("chunk_size")
+    need_chunk_mask = chunk_size is not None and chunk_size < attention_t
+    if need_chunk_mask:
+        out = _sdpa_maybe_chunk_causal(
+            q_sdpa,
+            k_sdpa,
+            v_sdpa,
+            need_chunk_mask=True,
+            T=attention_t,
+            S=S,
+            chunk_size=chunk_size,
+            chunk_index=chunk_index,
+            chunk_split_strategy=str(kwargs.get("chunk_split_strategy", "uniform")),
+            q_frame_offset=q_frame_offset,
+            attn_mask=invalid_kv_logit_bias,
+        )
+    else:
+        # FlashAttention-2 only supports head_dim in {32, 64, 128, 256}.
+        D = q_sdpa.shape[-1]
+        _need_pad = _sdpa_needs_head_pad(D)
+        if _need_pad:
+            _pad_to = 128 if D <= 128 else 256
+            _pad_size = _pad_to - D
+            q_sdpa = F.pad(q_sdpa, (0, _pad_size))
+            k_sdpa = F.pad(k_sdpa, (0, _pad_size))
+            v_sdpa = F.pad(v_sdpa, (0, _pad_size))
+        out = F.scaled_dot_product_attention(
+            q_sdpa,
+            k_sdpa,
+            v_sdpa,
+            attn_mask=invalid_kv_logit_bias,
+            scale=D**-0.5 if _need_pad else None,
+        )
+        if _need_pad:
+            out = out[..., :D]
 
     out = out.transpose(-1, -2)
     if out.dtype != dtype_orig:
@@ -554,16 +605,33 @@ class _SoftmaxUCPESinglePathLiteLA(
         chunk_size: int | None = None,
         **kwargs: object,
     ) -> torch.Tensor:
-        main_raw = _forward_softmax_attn(
-            self,
-            x,
-            HW,
-            rotary_emb,
-            frame_causal=False,
-            apply_output_gate=False,
-            chunk_size=chunk_size,
-            **kwargs,
-        )
+        if HW is None:
+            raise ValueError("HW must be provided for softmax attention.")
+        if chunk_size is not None:
+            softmax_kwargs = dict(kwargs)
+            chunk_split_strategy = str(softmax_kwargs.pop("chunk_split_strategy", "uniform"))
+            chunk_index = softmax_kwargs.pop("chunk_index", None)
+            main_raw = _forward_softmax_attn_chunk_causal(
+                self,
+                x,
+                HW,
+                rotary_emb,
+                chunk_size=chunk_size,
+                chunk_split_strategy=chunk_split_strategy,
+                chunk_index=chunk_index,
+                apply_output_gate=False,
+                **softmax_kwargs,
+            )
+        else:
+            main_raw = _forward_softmax_attn(
+                self,
+                x,
+                HW,
+                rotary_emb,
+                frame_causal=False,
+                apply_output_gate=False,
+                **kwargs,
+            )
 
         cam_contrib: torch.Tensor | int = 0
         camera_conditions = _maybe_drop_cam_branch(
@@ -630,8 +698,6 @@ class CachedChunkCausalGDNUCPESinglePathLiteLA(ChunkCausalGDNUCPESinglePathLiteL
         chunk_size: int | None = None,
         **kwargs: object,
     ) -> tuple[torch.Tensor, list]:
-        from .sana_gdn_blocks import CachedChunkCausalGDN
-
         kv_cache = kwargs.pop("kv_cache", None)
         save_kv_cache = kwargs.pop("save_kv_cache", False)
         if kv_cache is None:
@@ -670,8 +736,6 @@ class CachedChunkCausalGDNUCPESinglePathLiteLA(ChunkCausalGDNUCPESinglePathLiteL
                 kv_cache,
                 save_kv_cache,
                 precomputed_gates,
-                chunk_size=chunk_size,
-                **kwargs,
             )
             cam_contrib = self.out_proj_cam(cam_raw)
 
@@ -689,24 +753,25 @@ class CachedChunkCausalGDNUCPESinglePathLiteLA(ChunkCausalGDNUCPESinglePathLiteL
         kv_cache: list,
         save_kv_cache: bool,
         precomputed_gates: tuple | None,
-        **kwargs: object,
     ) -> torch.Tensor:
         """Camera branch with cached delta-rule state."""
-        from diffusion.model.ops.fused_streaming import (
-            _SLOT_CAM,
-            _cam_main_triton,
-            _cam_prep_triton,
-        )
-
         B, N, _ = x.shape
         T, H_sp, W_sp = HW
         S = H_sp * W_sp
         dtype_orig = x.dtype
 
         # Fused Triton cam prep: RMSNorm + ReLU + K-scale + UCPE 4x4 + RoPE.
-        q_cam_trans, k_cam_trans, v_cam_trans, inflation_sq, apply_fn_o = _cam_prep_triton(
-            self, x, HW, camera_conditions, rotary_emb, **kwargs
+        q_cam_trans, k_cam_trans, v_cam_trans, inflation_sq, apply_fn_o, cam_conv_cache = _cam_prep_triton(
+            self,
+            x,
+            HW,
+            camera_conditions,
+            rotary_emb,
+            kv_cache[_SLOT_CAM_AUX],
+            save_kv_cache,
         )
+        if save_kv_cache:
+            kv_cache[_SLOT_CAM_AUX] = cam_conv_cache
 
         if precomputed_gates is not None:
             beta, decay = precomputed_gates
@@ -766,8 +831,6 @@ class CachedSoftmaxUCPESinglePathLiteLA(_SoftmaxUCPESinglePathLiteLA):
         chunk_size: int | None = None,
         **kwargs: object,
     ) -> torch.Tensor | tuple[torch.Tensor, list]:
-        from .sana_gdn_blocks import CachedChunkCausalSoftmaxAttn
-
         kv_cache = kwargs.pop("kv_cache", None)
         save_kv_cache = kwargs.pop("save_kv_cache", False)
         if kv_cache is None:
@@ -827,10 +890,6 @@ class CachedSoftmaxUCPESinglePathLiteLA(_SoftmaxUCPESinglePathLiteLA):
         **kwargs: object,
     ) -> torch.Tensor:
         """Camera branch: SDPA with cached UCPE-transformed K, V."""
-        from diffusion.model.ops.fused_streaming import _SLOT_CAM, _SLOT_CAM_AUX
-
-        from .sana_gdn_blocks import _sdpa_maybe_chunk_causal
-
         B, N, _ = x.shape
         T, H_sp, W_sp = HW
         S = H_sp * W_sp
@@ -867,7 +926,6 @@ class CachedSoftmaxUCPESinglePathLiteLA(_SoftmaxUCPESinglePathLiteLA):
             chunk_size=kwargs.get("chunk_size", None),
             chunk_index=kwargs.get("chunk_index", None),
             chunk_split_strategy=kwargs.get("chunk_split_strategy", "uniform"),
-            device=x.device,
         )
 
         out = out.transpose(-1, -2)

--- a/diffusion/model/nets/sana_multi_scale_video_camctrl.py
+++ b/diffusion/model/nets/sana_multi_scale_video_camctrl.py
@@ -27,8 +27,8 @@ import torch.nn.functional as F
 from timm.models.layers import DropPath
 from torch.nn.attention.flex_attention import flex_attention
 
-from diffusion.model.builder import MODELS
 from diffusion.distributed.context_parallel.config import cp_enabled, get_cp_group
+from diffusion.model.builder import MODELS
 from diffusion.model.nets.basic_modules import ChunkGLUMBConvTemp, GLUMBConv, GLUMBConvTemp, Mlp
 from diffusion.model.nets.sana_blocks import (
     CaptionEmbedder,

--- a/diffusion/model/nets/sana_multi_scale_video_camctrl.py
+++ b/diffusion/model/nets/sana_multi_scale_video_camctrl.py
@@ -21,11 +21,14 @@ import warnings
 from typing import Optional
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 from timm.models.layers import DropPath
+from torch.nn.attention.flex_attention import flex_attention
 
 from diffusion.model.builder import MODELS
+from diffusion.distributed.context_parallel.config import cp_enabled, get_cp_group
 from diffusion.model.nets.basic_modules import ChunkGLUMBConvTemp, GLUMBConv, GLUMBConvTemp, Mlp
 from diffusion.model.nets.sana_blocks import (
     CaptionEmbedder,
@@ -71,8 +74,6 @@ _xformers_available = (
     and os.environ.get("DISABLE_XFORMERS", "0") != "1"
     and is_xformers_available()
 )
-if _xformers_available:
-    import xformers.ops
 
 
 class DeltaActionEmbedder(nn.Module):
@@ -929,12 +930,8 @@ class SanaMSVideoCamCtrl(Sana):
 
     def _compute_rope_with_cp(self, device: torch.device, h: int, w: int) -> torch.Tensor:
         """Compute RoPE frequencies with correct global positions under CP."""
-        from diffusion.distributed.context_parallel.config import cp_enabled, get_cp_group
-
         if not cp_enabled():
             return self.rope((self.f, h, w), device)
-
-        import torch.distributed as dist
 
         cp_group = get_cp_group()
         if cp_group is None:
@@ -1265,8 +1262,6 @@ class SanaMSVideoCamCtrl(Sana):
         diag_width=1,
         multiplier=2,
     ):
-        from torch.nn.attention.flex_attention import flex_attention
-
         assert diag_width == multiplier, f"{diag_width} is not equivalent to {multiplier}"
 
         seq_len = context_length + num_frame * frame_size
@@ -1571,14 +1566,18 @@ class SanaMSVideoCamCtrlStreaming(SanaMSVideoCamCtrl):
     :class:`CachedSoftmaxUCPESinglePathLiteLA`) so each block accepts a
     per-block ``kv_cache`` slot and updates it in place.
 
-    The streaming entry point is :meth:`forward_long`, which the
-    self-forcing scheduler invokes directly. Plain :meth:`forward` is
-    inherited but will raise inside the cached attention because
-    ``kv_cache`` is mandatory — use the streaming sampler instead.
+    :meth:`forward` dispatches calls with ``start_f`` to :meth:`forward_long`;
+    calls without it follow the inherited behavior.
     """
 
     _camctrl_cls_gdn: type = CachedChunkCausalGDNUCPESinglePathLiteLA
     _camctrl_cls_softmax: type = CachedSoftmaxUCPESinglePathLiteLA
+    __call__ = nn.Module.__call__
+
+    def forward(self, x, timestep, y, mask=None, **kwargs):
+        if kwargs.get("start_f") is not None:
+            return self.forward_long(x, timestep, y, mask=mask, **kwargs)
+        return super().forward(x, timestep, y, mask=mask, **kwargs)
 
     # ------------------------------------------------------------------ #
     # AR KV-cache streaming forward
@@ -1944,17 +1943,6 @@ class SanaMSVideoCamCtrlStreaming(SanaMSVideoCamCtrl):
             block_output = self.get_block_output()
             self.block_output_buffer[self.inference_timestep] = block_output
         return x, kv_cache
-
-    def __call__(self, *args, **kwargs):
-        """Dispatch to :meth:`forward_long` when ``start_f`` is provided.
-
-        The self-forcing scheduler calls :meth:`forward_long` directly, but
-        the training-time longsana pipeline goes through ``__call__`` with
-        ``start_f`` set, so we keep this dispatch for backwards compat.
-        """
-        if kwargs.get("start_f") is not None:
-            return self.forward_long(*args, **kwargs)
-        return self.forward(*args, **kwargs)
 
 
 @MODELS.register_module()

--- a/diffusion/model/ops/fused_cam_gdn.py
+++ b/diffusion/model/ops/fused_cam_gdn.py
@@ -43,6 +43,7 @@ from diffusion.model.nets.sana_camctrl_blocks import (
     ucm_unproject_grid_fov,
     world_to_ray_mats,
 )
+from diffusion.model.ops.fused_gdn_chunkwise import cam_scan_chunkwise
 
 # =============================================================================
 # Scalar helpers
@@ -1427,8 +1428,6 @@ def cam_scan_func(
     # mode in phase_b_triton, which has the same flip-and-shift semantics as
     # cam's REVERSE=1 path. Bypass via FUSED_GDN_FORCE_LEGACY=1.
     if os.environ.get("FUSED_GDN_FORCE_LEGACY", "0") != "1":
-        from diffusion.model.ops.fused_gdn_chunkwise import cam_scan_chunkwise
-
         return cam_scan_chunkwise(
             q,
             k,
@@ -1699,7 +1698,9 @@ def _torch_cam_scan_single_chunk(
     v: torch.Tensor,
     beta: torch.Tensor,
     decay: torch.Tensor,
-) -> torch.Tensor:
+    init_state: torch.Tensor | None = None,
+    return_final_state: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """Pure-torch single-chunk delta-rule scan (numerator-only).
 
     Algebraically equivalent to ``torch_chunk_cam_single_path_delta_rule`` with
@@ -1744,7 +1745,11 @@ def _torch_cam_scan_single_chunk(
     W = decay_view * (eye - torch.matmul(k_beta, k_t.transpose(-1, -2)))
     U = torch.matmul(v_t * beta_view, k_t.transpose(-1, -2))
 
-    state = torch.zeros(B, H, D, D, device=q.device, dtype=q.dtype)
+    state = (
+        torch.zeros(B, H, D, D, device=q.device, dtype=q.dtype)
+        if init_state is None
+        else init_state.to(device=q.device, dtype=q.dtype)
+    )
     s_kv_list: list[torch.Tensor] = []
     for t in range(T):
         state = torch.matmul(state, W[:, :, t]) + U[:, :, t]
@@ -1752,7 +1757,8 @@ def _torch_cam_scan_single_chunk(
     s_all = torch.stack(s_kv_list, dim=2)  # (B, H, T, D, D)
 
     out_t = torch.matmul(s_all, q_t)  # (B, H, T, D, S)
-    return out_t.permute(0, 1, 3, 2, 4).reshape(B, H, D, N)
+    out = out_t.permute(0, 1, 3, 2, 4).reshape(B, H, D, N)
+    return (out, state) if return_final_state else out
 
 
 def _torch_cam_scan_reference(

--- a/diffusion/model/ops/fused_streaming.py
+++ b/diffusion/model/ops/fused_streaming.py
@@ -47,28 +47,55 @@ scheduler).  Slot 6 distinguishes GDN (state-based) from softmax
      - cam_S_kv state (B, H_c, D_c, D_c)
      - cam_k post-UCPE (B, H_c, N, D_c)
    * - 3
-     - None
+     - camera K ShortConv state (B*S, K-1, C)
      - cam_v post-UCPE (B, H_c, N, D_c)
    * - 4
      - ShortConv K state (B*S, K-1, C)
      - None (no conv for softmax)
    * - 5
-     - tconv state (handled by CachedGLUMBConvTemp)
-     - tconv state
+     - reserved
+     - reserved
    * - 6
      - type flag: 1.0
      - type flag: 0.0
-   * - 7-9
+   * - 7-8
      - reserved
      - reserved
+   * - 9
+     - tconv state (handled by CachedGLUMBConvTemp)
+     - tconv state
 """
 
 from __future__ import annotations
 
+import os
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import triton
 from fla.modules import ShortConvolution
+
+from diffusion.model.nets.sana_camctrl_blocks import _prepare_ray_apply_fns
+from diffusion.model.ops.fused_cam_gdn import (
+    _invert_SE3,
+    _prepare_ucpe_rope_tables,
+    _process_camera_conditions_raymats_only,
+    _torch_cam_scan_reference,
+    _torch_cam_scan_single_chunk,
+    cam_prep_func,
+    cam_prep_func_with_grad,
+)
+from diffusion.model.ops.fused_gdn import fused_qk_inv_rms, prepare_rope_tables
+from diffusion.model.ops.fused_gdn_chunkwise import (
+    _default_dot_prec,
+    cam_scan_chunkwise,
+    phase_a,
+    phase_b_triton,
+    phase_c,
+)
+from diffusion.model.ops.fused_gdn_chunkwise_cuda import cam_scan_chunkwise_cuda
+from diffusion.model.ops.fused_gdn_chunkwise_stateful_raw import fused_gdn_chunkwise_stateful_raw_autograd
 
 # ---------------------------------------------------------------------------
 # Cache slot indices (must match scheduler constants)
@@ -232,10 +259,6 @@ def _gdn_main_triton(
         ``(out, S_kv_new, S_z_new)`` where ``out`` is ``(B, N, H, D)``
         post-divide in the kernel's dot_precision dtype (fp32 or bf16).
     """
-    # Imports are local so the module loads on CPU-only environments.
-    from diffusion.model.ops.fused_gdn import fused_qk_inv_rms, prepare_rope_tables
-    from diffusion.model.ops.fused_gdn_chunkwise import _default_dot_prec, phase_a, phase_b_triton, phase_c
-
     B, N, three, H, D = qkv.shape
     assert three == 3, f"qkv last-3 dim must be 3 (q,k,v); got shape {qkv.shape}"
     T, H_sp, W_sp = HW
@@ -253,9 +276,6 @@ def _gdn_main_triton(
         k_nw = layer.k_norm.weight.float().contiguous()
         norm_eps = float(getattr(layer.q_norm, "eps", 1e-5))
 
-    # ---- inv RMS (single fused launch over Q and K halves of qkv) ----
-    q_inv_rms, k_inv_rms = fused_qk_inv_rms(qkv, eps=norm_eps)
-
     # ---- RoPE tables for the current chunk ----
     if rotary_emb is None:
         rope_cos = torch.ones(N, D, device=qkv.device, dtype=torch.float32)
@@ -272,6 +292,51 @@ def _gdn_main_triton(
     decay_c = decay.contiguous()
 
     dot_prec = _default_dot_prec()
+
+    if torch.is_grad_enabled() and qkv.requires_grad:
+        forward = fused_gdn_chunkwise_stateful_raw_autograd(
+            qkv,
+            beta_c,
+            decay_c,
+            q_nw,
+            k_nw,
+            rope_cos,
+            rope_sin,
+            T,
+            S,
+            init_state_kv=S_kv_prev,
+            init_state_z=S_z_prev,
+            k_scale=k_scale,
+            norm_eps=norm_eps,
+            dot_precision=dot_prec,
+            save_final_state=save_kv_cache,
+            direction=1,
+        )
+        reverse = fused_gdn_chunkwise_stateful_raw_autograd(
+            qkv,
+            beta_c,
+            decay_c,
+            q_nw,
+            k_nw,
+            rope_cos,
+            rope_sin,
+            T,
+            S,
+            k_scale=k_scale,
+            norm_eps=norm_eps,
+            dot_precision=dot_prec,
+            direction=2,
+        )
+        num_fwd, den_fwd = forward[:2]
+        num_rev, den_rev = reverse
+        denominator = (den_fwd.float() + den_rev.float()).permute(0, 2, 1).unsqueeze(-1)
+        out = ((num_fwd.float() + num_rev.float()) / (denominator + float(layer.eps))).to(qkv.dtype)
+        if save_kv_cache:
+            return out, forward[2], forward[3]
+        return out, None, None
+
+    # ---- inv RMS (single fused launch over Q and K halves of qkv) ----
+    q_inv_rms, k_inv_rms = fused_qk_inv_rms(qkv, eps=norm_eps)
 
     # ---- Phase A: shared prep for both directions ----
     I_P_kv, A_buf, I_P_z, B_z = phase_a(
@@ -433,18 +498,37 @@ def _cam_main_triton(
         (fwd + per-chunk bwd combined) and ``cam_S_kv_new`` shaped
         ``(B, H, D, D)`` fp32 (or ``None`` when not saving).
     """
-    import os as _os
-
-    import triton
+    if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in (q_cam_trans, k_cam_trans, v_cam_trans)):
+        beta_f = beta.float().contiguous()
+        if beta_f.ndim == 3:
+            beta_f = beta_f.unsqueeze(-1).expand(-1, -1, -1, S).contiguous()
+        decay_f = decay.float().contiguous()
+        # The fused cache stores M as (K feature, V feature), while the
+        # torch recurrence uses state @ k and therefore keeps (V, K).
+        init_state = cam_S_kv_prev.transpose(-1, -2) if cam_S_kv_prev is not None else None
+        forward, final_state = _torch_cam_scan_single_chunk(
+            q_cam_trans.float().contiguous(),
+            k_cam_trans.float().contiguous(),
+            v_cam_trans.float().contiguous(),
+            beta_f,
+            decay_f,
+            init_state=init_state,
+            return_final_state=True,
+        )
+        reverse = _torch_cam_scan_reference(
+            q_cam_trans.float().contiguous(),
+            k_cam_trans.float().contiguous(),
+            v_cam_trans.float().contiguous(),
+            beta_f,
+            decay_f,
+            reverse=True,
+        )
+        final_state = final_state.transpose(-1, -2).contiguous() if save_kv_cache else None
+        return forward + reverse, final_state
 
     # CUDA cam scan on by default; set SANA_GDN_CUDA=0 to force Triton.
-    if _os.environ.get("SANA_GDN_CUDA", "1") != "0":
-        try:
-            from diffusion.model.ops.fused_gdn_chunkwise_cuda import cam_scan_chunkwise_cuda as cam_scan_chunkwise
-        except Exception:
-            from diffusion.model.ops.fused_gdn_chunkwise import cam_scan_chunkwise
-    else:
-        from diffusion.model.ops.fused_gdn_chunkwise import cam_scan_chunkwise
+    scan = cam_scan_chunkwise_cuda if os.environ.get("SANA_GDN_CUDA", "1") != "0" else None
+    scan = scan or cam_scan_chunkwise
 
     B, H, D, N = q_cam_trans.shape
     assert N == T * S, f"N={N} != T*S={T * S}"
@@ -476,7 +560,7 @@ def _cam_main_triton(
 
     # ---- Forward scan with state ----
     if save_kv_cache:
-        out_fwd, final_state = cam_scan_chunkwise(
+        out_fwd, final_state = scan(
             q32,
             k32,
             v32,
@@ -487,7 +571,7 @@ def _cam_main_triton(
             save_final_state=True,
         )
     else:
-        out_fwd = cam_scan_chunkwise(
+        out_fwd = scan(
             q32,
             k32,
             v32,
@@ -500,7 +584,7 @@ def _cam_main_triton(
         final_state = None
 
     # ---- Backward scan (per-chunk isolated; no state) ----
-    out_bwd = cam_scan_chunkwise(
+    out_bwd = scan(
         q32,
         k32,
         v32,
@@ -533,16 +617,17 @@ def _cam_prep_triton(
     HW: tuple[int, int, int],
     camera_conditions: torch.Tensor,
     rotary_emb: torch.Tensor | None,
-    **kwargs: object,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, callable]:
+    conv_cache: torch.Tensor | None,
+    save_cache: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, callable, torch.Tensor | None]:
     """Streaming cam-branch QKV prep through the bidir's fused Triton kernel.
 
     Mirrors the prep section of
     :meth:`BidirectionalGDNUCPESinglePathLiteLABothTriton._forward_cam_branch`
     (QKV linear + cam-K short conv + ``cam_prep_func`` Triton kernel +
     ``inflation_sq`` reshape) but applies the K conv with a per-chunk
-    isolated bidirectional pattern matching the torch streaming path
-    (``BidirectionalGDN._apply_temporal_short_conv``).
+    cached left context on the forward half and chunk-local context on the
+    backward half.
 
     Args:
         layer: A :class:`CachedChunkCausalGDNUCPESinglePathLiteLA` instance.
@@ -550,22 +635,16 @@ def _cam_prep_triton(
         HW: ``(T, H, W)`` token layout.
         camera_conditions: ``(B, T, ...)`` camera-pose tensor.
         rotary_emb: complex RoPE frequencies for the current chunk.
+        conv_cache: Previous camera-K short-convolution context.
+        save_cache: Whether to return context for the next chunk.
 
     Returns:
-        ``(q_cam_trans, k_cam_trans, v_cam_trans, inflation_sq, apply_fn_o)``
+        ``(q_cam_trans, k_cam_trans, v_cam_trans, inflation_sq, apply_fn_o, new_conv_cache)``
         with ``q/k/v_cam_trans`` shaped ``(B, H_cam, D_cam, N)`` in the input
         dtype, ``inflation_sq`` shaped ``(B, H_cam, 1, N)`` fp32, and
         ``apply_fn_o`` a torch closure that applies the inverse UCPE+RoPE to
-        the scan output.
+        the scan output, and the new short-convolution cache (or ``None``).
     """
-    from diffusion.model.nets.sana_camctrl_blocks import _prepare_ray_apply_fns
-    from diffusion.model.ops.fused_cam_gdn import (
-        _invert_SE3,
-        _prepare_ucpe_rope_tables,
-        _process_camera_conditions_raymats_only,
-        cam_prep_func,
-    )
-
     if layer.conv_q_cam is not None or layer.conv_v_cam is not None:
         raise NotImplementedError(
             "Triton cam-prep requires k_conv_only=True on the camera branch " "(conv_q_cam / conv_v_cam must be None)."
@@ -583,12 +662,15 @@ def _cam_prep_triton(
     qkv_cam = F.linear(x, qkv_w, qkv_b)
     q_raw, k_raw, v_raw = qkv_cam.chunk(3, dim=-1)
 
+    new_conv_cache = None
     if layer.conv_k_cam is not None:
-        # Match the streaming torch path's K-conv routing:
-        # ``_GDNUCPEBase._apply_temporal_short_conv`` dispatches to the
-        # bidirectional in-chunk conv when ``chunk_size >= T`` (the streaming
-        # cam K conv has no cross-chunk state).
-        k_raw = layer._apply_temporal_short_conv(k_raw, layer.conv_k_cam, HW, **kwargs)
+        k_raw, new_conv_cache = _cached_temporal_short_conv(
+            k_raw,
+            layer.conv_k_cam,
+            HW,
+            conv_cache,
+            save_cache,
+        )
 
     q_raw = q_raw.contiguous().view(B, N, H_heads, D_head).contiguous()
     k_raw = k_raw.contiguous().view(B, N, H_heads, D_head).contiguous()
@@ -628,7 +710,8 @@ def _cam_prep_triton(
     k_norm_w = layer.k_norm_cam.weight.float().contiguous()
     k_scale = (D_head**-0.5) * (S**-0.5)
     norm_eps_val = float(getattr(layer.q_norm_cam, "eps", getattr(layer.q_norm_cam, "variance_epsilon", 1e-6)))
-    q_cam_trans, k_cam_trans, v_cam_trans, inflation_sq = cam_prep_func(
+    prep = cam_prep_func_with_grad if torch.is_grad_enabled() and q_raw.requires_grad else cam_prep_func
+    q_cam_trans, k_cam_trans, v_cam_trans, inflation_sq = prep(
         q_raw,
         k_raw,
         v_raw,
@@ -646,7 +729,7 @@ def _cam_prep_triton(
     # ---- 5. Inverse-UCPE closure for the scan output ----
     _, _, apply_fn_o = _prepare_ray_apply_fns(head_dim=D_head, P=P, P_T=P_T, P_inv=P_inv, rotary_emb=rotary_emb_cam)
 
-    return q_cam_trans, k_cam_trans, v_cam_trans, inflation_sq, apply_fn_o
+    return q_cam_trans, k_cam_trans, v_cam_trans, inflation_sq, apply_fn_o, new_conv_cache
 
 
 def _cached_gdn_forward_triton(
@@ -705,7 +788,7 @@ def _cached_gdn_forward_triton(
         k_flat, new_conv_cache = _cached_temporal_short_conv(
             k_flat, layer.conv_k, HW, kv_cache[_SLOT_SHORTCONV], save_kv_cache
         )
-        qkv = qkv.contiguous()
+        qkv = qkv.clone() if torch.is_grad_enabled() and qkv.requires_grad else qkv.contiguous()
         qkv[:, :, 1].copy_(k_flat.reshape(B, N, H, D))
         if save_kv_cache:
             kv_cache[_SLOT_SHORTCONV] = new_conv_cache

--- a/diffusion/scheduler/self_forcing_flow_euler_sampler.py
+++ b/diffusion/scheduler/self_forcing_flow_euler_sampler.py
@@ -126,7 +126,7 @@ def _pop_extra_model_kwargs(model_kwargs: dict) -> dict:
 #   0: k, 1: v, 2: beta, 3: decay, 4: shortconv, 5: tconv, 6-9: None
 #
 # New layout (CachedChunkCausalGDN / CachedChunkCausalSoftmaxAttn):
-#   GDN:     0: S_kv state, 1: S_z state, 2: cam_S_kv state, 3: None
+#   GDN:     0: S_kv state, 1: S_z state, 2: cam_S_kv state, 3: cam K-conv state
 #   Softmax: 0: k post-RoPE, 1: v, 2: cam_k post-UCPE, 3: cam_v post-UCPE
 #   Both:    4: shortconv, 5: tconv, 6: type flag (1.0=state, 0.0=concat),
 #            9: FFN tconv state written by ``CachedGLUMBConvTemp``.
@@ -748,7 +748,7 @@ class SelfForcingFlowEulerCamCtrl(SelfForcingFlowEuler):
                     prev_last[0],  # S_kv state (or accumulated softmax k)
                     prev_last[1],  # S_z state (or accumulated softmax v)
                     prev_last[2],  # cam_S_kv state
-                    prev_last[3],  # None (GDN cam_aux unused)
+                    prev_last[3],  # camera K ShortConv state
                     prev_last[_SLOT_SHORTCONV],  # ShortConv state
                     None,  # (slot 5 unused)
                     prev_last[_SLOT_TYPE_FLAG],  # type flag

--- a/docs/sana_wm.md
+++ b/docs/sana_wm.md
@@ -341,6 +341,12 @@ The implementation lives in
 self-forcing warmup, and T121 self-forcing/DMD stages with the released data
 and checkpoints:
 
+The CI smoke test at
+`tests/bash/training/test_training_sana_wm_distill.sh` follows the same three
+stages with deterministic synthetic trajectory/latent fixtures. It runs one
+optimizer step per stage and passes the saved ODE checkpoint into T43, then the
+saved generator/critic checkpoint into the T121 sink + sliding-cache stage.
+
 ```bash
 # T43 ODE regression (FSDP2, no CP). Set data_path first.
 torchrun --nproc_per_node=8 \

--- a/docs/sana_wm.md
+++ b/docs/sana_wm.md
@@ -285,7 +285,7 @@ This repo includes the minimal chunk-causal Stage-1 training path:
 - training script: `train_video_scripts/train_sana_wm_stage1.py`
 - training config: `configs/sana_wm/stage1/sana_wm_stage1_sekai_chunk_causal_cp2_fsdp2.yaml`
 - latent dataset loader: `diffusion/data/datasets/video/sana_wm_zip_latent_data.py`
-- CP/FSDP2 tests: `tests/test_context_parallel*.py`
+- CP2/FSDP2 smoke test: `tests/bash/training/test_training_sana_wm_stage1.sh`
 
 The example can run directly from the public HF dataset
 [`Efficient-Large-Model/SANA-WM-example-training-dataset`](https://huggingface.co/datasets/Efficient-Large-Model/SANA-WM-example-training-dataset).
@@ -325,6 +325,42 @@ entries are resolved under that directory after download.
 The Sekai-derived dataset is redistributed for non-commercial research use
 only. See the dataset card, `LICENSE`, and `NOTICE.md` in the HF dataset repo
 before training or redistributing derivatives.
+
+This public Stage-1 recipe matches the released model, 121-frame latent shape,
+CP2, three-frame chunking, and hybrid GDN/softmax settings. It intentionally
+uses only the redistributable Sekai camera-control data; the internal training
+curriculum also mixed separate video-only and no-camera data sources. Exact
+weight reproduction therefore requires the original data mixture.
+
+## ODE and Self-Forcing Distillation
+
+The implementation lives in
+`diffusion/longsana/trainer/sana_wm_distill.py` and is selected by
+`train_video_scripts/train_longsana.py` through `trainer: wm_ode` or
+`trainer: wm_self_forcing`. The three public configs provide the T43 ODE, T43
+self-forcing warmup, and T121 self-forcing/DMD stages with the released data
+and checkpoints:
+
+```bash
+# T43 ODE regression (FSDP2, no CP). Set data_path first.
+torchrun --nproc_per_node=8 \
+  train_video_scripts/train_longsana.py \
+  --config_path configs/sana_wm/distill/ode_t43.yaml \
+  --disable-wandb
+
+# T43 self-forcing warmup (8 GPUs, CP4 / DP2).
+torchrun --nproc_per_node=8 \
+  train_video_scripts/train_longsana.py \
+  --config_path configs/sana_wm/distill/self_forcing_t43.yaml \
+  --disable-wandb
+
+# T121 self-forcing + DMD (8 GPUs, CP4 / DP2).
+torchrun --nproc_per_node=8 \
+  train_video_scripts/train_longsana.py \
+  --config_path configs/sana_wm/distill/self_forcing_t121.yaml \
+  --disable-wandb
+```
+
 
 ## 🎛️ Argument Reference
 

--- a/docs/sana_wm.md
+++ b/docs/sana_wm.md
@@ -361,7 +361,6 @@ torchrun --nproc_per_node=8 \
   --disable-wandb
 ```
 
-
 ## 🎛️ Argument Reference
 
 | Argument | Format / Default |

--- a/tests/bash/training/test_training_sana_wm_distill.sh
+++ b/tests/bash/training/test_training_sana_wm_distill.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+set -e
+
+echo "Testing the SANA-WM ODE and self-forcing distillation chain"
+
+cleanup() {
+    rm -rf data/sana_wm_distill_ci output/test_sana_wm_distill_ci
+}
+trap cleanup EXIT
+
+python - <<'PY'
+import io
+import json
+import shutil
+import zipfile
+from pathlib import Path
+
+import lmdb
+import numpy as np
+import yaml
+
+from diffusion.longsana.utils.lmdb import store_arrays_to_lmdb
+
+
+data_root = Path("data/sana_wm_distill_ci")
+ode_data_root = data_root / "ode_trajectories"
+raw_root = data_root / "sekai_game"
+cache_root = data_root / "vae_cache"
+out_root = Path("output/test_sana_wm_distill_ci")
+
+for path in (data_root, out_root):
+    shutil.rmtree(path, ignore_errors=True)
+ode_data_root.mkdir(parents=True)
+raw_root.mkdir(parents=True)
+cache_root.mkdir(parents=True)
+out_root.mkdir(parents=True)
+
+# ODE uses DP8 in CI, so provide one deterministic trajectory per rank. Seven
+# latent frames keep this smoke test short while still crossing chunk boundaries.
+rng = np.random.default_rng(3407)
+num_samples = 8
+num_snapshots = 5
+num_latent_frames = 7
+latent_shape = (num_samples, num_latent_frames, 128, 22, 40)
+clean = rng.standard_normal(latent_shape, dtype=np.float32)
+noise = rng.standard_normal(latent_shape, dtype=np.float32)
+sigmas = np.array([1.0, 0.967, 0.908, 0.764, 0.0], dtype=np.float32)
+assert len(sigmas) == num_snapshots
+latents = np.stack([(1.0 - sigma) * clean + sigma * noise for sigma in sigmas], axis=1).astype(np.float16)
+
+camera_conditions = np.zeros((num_samples, num_latent_frames, 20), dtype=np.float16)
+camera_conditions[..., :16] = np.eye(4, dtype=np.float16).reshape(1, 1, 16)
+camera_conditions[..., 16:] = np.array([40.0, 22.0, 20.0, 11.0], dtype=np.float16)
+chunk_plucker = np.zeros((num_samples, 48, num_latent_frames, 22, 40), dtype=np.float16)
+prompts = np.array(["A car drives forward across a dry lake bed under a blue sky."] * num_samples)
+
+ode_arrays = {
+    "latents": latents,
+    "prompts": prompts,
+    "camera_conditions": camera_conditions,
+    "chunk_plucker": chunk_plucker,
+}
+env = lmdb.open(str(ode_data_root), map_size=1 << 30)
+with env.begin(write=True) as txn:
+    for name, array in ode_arrays.items():
+        txn.put(f"{name}_shape".encode(), " ".join(map(str, array.shape)).encode())
+store_arrays_to_lmdb(env, ode_arrays)
+env.sync()
+env.close()
+
+# Reuse the same zip-latent fixture layout as the existing Stage-1 CI test.
+# The two self-forcing configs slice this 25-frame latent to 10 and 13 frames.
+key = "sample_000000"
+raw_zip = raw_root / "sekai_game_train_00000000.zip"
+cache_zip = cache_root / raw_zip.name
+prompt = "A car drives forward across a dry lake bed under a blue sky."
+
+with zipfile.ZipFile(raw_zip, "w", compression=zipfile.ZIP_STORED) as zf:
+    zf.writestr(f"{key}.json", json.dumps({"prompt": prompt, "width": 1280, "height": 704}))
+
+latent = rng.standard_normal((128, 25, 22, 40), dtype=np.float32)
+buf = io.BytesIO()
+np.savez(buf, z=latent)
+with zipfile.ZipFile(cache_zip, "w", compression=zipfile.ZIP_STORED) as zf:
+    zf.writestr(f"{key}.npz", buf.getvalue())
+
+num_pixel_frames = 193
+poses = np.repeat(np.eye(4, dtype=np.float32)[None], num_pixel_frames, axis=0)
+poses[:, 2, 3] = np.linspace(0.0, 1.0, num_pixel_frames, dtype=np.float32)
+intrinsics = np.tile(np.array([760.0, 760.0, 640.0, 352.0], dtype=np.float32), (num_pixel_frames, 1))
+np.savez(
+    raw_zip.with_name(raw_zip.stem + "_camera.npz"),
+    ids=np.array([key]),
+    ranges=np.array([[0, num_pixel_frames]], dtype=np.int64),
+    pose=poses,
+    intrinsics=intrinsics,
+)
+
+caption_suffix = "_LongSceneStaticCaption-Qwen3-VL-30B-A3B-Instruct"
+raw_zip.with_name(raw_zip.stem + f"{caption_suffix}.json").write_text(
+    json.dumps({key: {"prompt": prompt}}), encoding="utf-8"
+)
+filter_scores = {
+    "_vmafmotion": 1.0,
+    "_unimatch": 10.0,
+    "_dover": 0.5,
+    "_vlm_entity_filter": 5.0,
+    "_vlm_quality_filter": 1.0,
+}
+for suffix, score in filter_scores.items():
+    raw_zip.with_name(raw_zip.stem + f"{suffix}.json").write_text(
+        json.dumps({key: {"score": score}}), encoding="utf-8"
+    )
+
+
+def configure_train(cfg, work_dir, save_model_steps):
+    cfg["work_dir"] = str(work_dir)
+    cfg["train"]["batch_size"] = 1
+    cfg["train"]["num_workers"] = 0
+    cfg["train"]["max_steps"] = 1
+    cfg["train"]["log_interval"] = 1
+    cfg["train"]["save_model_steps"] = save_model_steps
+    cfg["train"]["early_stop_hours"] = 0
+    cfg["report_to"] = "none"
+    cfg["resume_from"] = None
+
+
+def configure_self_forcing_data(cfg):
+    cfg["data"]["hf_dataset_repo"] = None
+    cfg["data"]["hf_dataset_revision"] = None
+    cfg["data"]["hf_dataset_local_dir"] = "."
+    cfg["data"]["hf_dataset_allow_patterns"] = None
+    cfg["data"]["data_dir"] = {"sekai_game": str(raw_root)}
+    cfg["data"]["vae_cache_dir"] = str(cache_root)
+    # CP4 on eight GPUs leaves DP2, so repeat the fixture once per DP rank.
+    cfg["data"]["data_repeat"] = {"sekai_game": 2}
+    cfg["data"]["num_frames"] = num_pixel_frames
+    cfg["data"]["sort_dataset"] = True
+    cfg["data"]["shuffle_dataset"] = False
+
+
+ode_work_dir = out_root / "ode_t7"
+ode_cfg = yaml.safe_load(Path("configs/sana_wm/distill/ode_t43.yaml").read_text(encoding="utf-8"))
+ode_cfg["data_path"] = str(ode_data_root)
+ode_cfg["max_samples"] = num_samples
+ode_cfg["num_latent_frames"] = num_latent_frames
+configure_train(ode_cfg, ode_work_dir, save_model_steps=1)
+ode_ci_cfg = out_root / "ode_t7_ci.yaml"
+ode_ci_cfg.write_text(yaml.safe_dump(ode_cfg, sort_keys=False), encoding="utf-8")
+
+t43_work_dir = out_root / "self_forcing_t10"
+t43_cfg = yaml.safe_load(Path("configs/sana_wm/distill/self_forcing_t43.yaml").read_text(encoding="utf-8"))
+t43_cfg["model_path"] = str(ode_work_dir / "checkpoints/step_000001/model.pt")
+# CP4 pads this to 12 frames, leaving three frames per rank. That is the
+# minimum local length required by the temporal-convolution halo exchange.
+t43_cfg["num_latent_frames"] = 10
+configure_self_forcing_data(t43_cfg)
+configure_train(t43_cfg, t43_work_dir, save_model_steps=1)
+t43_ci_cfg = out_root / "self_forcing_t10_ci.yaml"
+t43_ci_cfg.write_text(yaml.safe_dump(t43_cfg, sort_keys=False), encoding="utf-8")
+
+t121_work_dir = out_root / "self_forcing_t13"
+t121_cfg = yaml.safe_load(Path("configs/sana_wm/distill/self_forcing_t121.yaml").read_text(encoding="utf-8"))
+t43_checkpoint = t43_work_dir / "checkpoints/step_000001/model.pt"
+t121_cfg["model_path"] = str(t43_checkpoint)
+t121_cfg["fake_model_path"] = str(t43_checkpoint)
+# Four streaming chunks are enough to exercise the T121 sink + sliding-window
+# cache policy without making CI roll out all 121 production frames.
+t121_cfg["num_latent_frames"] = 13
+configure_self_forcing_data(t121_cfg)
+configure_train(t121_cfg, t121_work_dir, save_model_steps=0)
+t121_ci_cfg = out_root / "self_forcing_t13_ci.yaml"
+t121_ci_cfg.write_text(yaml.safe_dump(t121_cfg, sort_keys=False), encoding="utf-8")
+
+print(f"Wrote {ode_ci_cfg}, {t43_ci_cfg}, and {t121_ci_cfg}")
+PY
+
+torchrun --nproc_per_node=8 --master_port=$((RANDOM % 10000 + 20000)) \
+    train_video_scripts/train_longsana.py \
+    --config_path output/test_sana_wm_distill_ci/ode_t7_ci.yaml \
+    --disable-wandb --no-auto-resume --max_iters=1
+
+ODE_CHECKPOINT=output/test_sana_wm_distill_ci/ode_t7/checkpoints/step_000001/model.pt
+test -s "$ODE_CHECKPOINT"
+
+torchrun --nproc_per_node=8 --master_port=$((RANDOM % 10000 + 20000)) \
+    train_video_scripts/train_longsana.py \
+    --config_path output/test_sana_wm_distill_ci/self_forcing_t10_ci.yaml \
+    --disable-wandb --no-auto-resume --max_iters=1
+
+T43_CHECKPOINT=output/test_sana_wm_distill_ci/self_forcing_t10/checkpoints/step_000001/model.pt
+test -s "$T43_CHECKPOINT"
+
+torchrun --nproc_per_node=8 --master_port=$((RANDOM % 10000 + 20000)) \
+    train_video_scripts/train_longsana.py \
+    --config_path output/test_sana_wm_distill_ci/self_forcing_t13_ci.yaml \
+    --disable-wandb --no-auto-resume --no_save --max_iters=1
+
+grep -q "mode=self_forcing step=1" output/test_sana_wm_distill_ci/self_forcing_t13/train_log.log

--- a/tests/bash/training/test_training_sana_wm_stage1.sh
+++ b/tests/bash/training/test_training_sana_wm_stage1.sh
@@ -36,13 +36,13 @@ with zipfile.ZipFile(raw_zip, "w", compression=zipfile.ZIP_STORED) as zf:
     )
 
 rng = np.random.default_rng(3407)
-latent = rng.standard_normal((128, 24, 22, 40), dtype=np.float32)
+latent = rng.standard_normal((128, 25, 22, 40), dtype=np.float32)
 buf = io.BytesIO()
 np.savez(buf, z=latent)
 with zipfile.ZipFile(cache_zip, "w", compression=zipfile.ZIP_STORED) as zf:
     zf.writestr(f"{key}.npz", buf.getvalue())
 
-num_pixel_frames = 192
+num_pixel_frames = 193
 poses = np.repeat(np.eye(4, dtype=np.float32)[None], num_pixel_frames, axis=0)
 poses[:, 2, 3] = np.linspace(0.0, 1.0, num_pixel_frames, dtype=np.float32)
 intrinsics = np.tile(np.array([760.0, 760.0, 640.0, 352.0], dtype=np.float32), (num_pixel_frames, 1))

--- a/train_video_scripts/train_longsana.py
+++ b/train_video_scripts/train_longsana.py
@@ -1,12 +1,30 @@
+# ruff: noqa: E402
+
 import argparse
 import os
+
+# Importing the shared Stage-1 helpers must not disable xFormers for legacy
+# LongSANA trainers. The WM branch opts out explicitly after config dispatch.
+_disable_xformers_before_wm_import = os.environ.get("DISABLE_XFORMERS")
+_tokenizers_parallelism_before_wm_import = os.environ.get("TOKENIZERS_PARALLELISM")
+os.environ.setdefault("DISABLE_XFORMERS", "0")
 
 import wandb
 from omegaconf import OmegaConf
 
+import diffusion.model.nets.sana_blocks as sana_blocks
+import diffusion.model.nets.sana_multi_scale_video_camctrl as sana_video_camctrl
 from diffusion.longsana.trainer.longsana_trainer import LongSANATrainer
 from diffusion.longsana.trainer.ode import ODESANATrainer
+from diffusion.longsana.trainer.sana_wm_distill import SanaWMDistillTrainer
 from diffusion.longsana.trainer.self_forcing_trainer import Trainer as SelfForcingScoreDistillationTrainer
+
+if _disable_xformers_before_wm_import is None:
+    os.environ.pop("DISABLE_XFORMERS", None)
+if _tokenizers_parallelism_before_wm_import is None:
+    os.environ.pop("TOKENIZERS_PARALLELISM", None)
+del _disable_xformers_before_wm_import
+del _tokenizers_parallelism_before_wm_import
 
 
 def main():
@@ -48,6 +66,15 @@ def main():
         trainer = LongSANATrainer(config)
     elif config.trainer == "ode":
         trainer = ODESANATrainer(config)
+    elif config.trainer in {"wm_ode", "wm_self_forcing"}:
+        os.environ["DISABLE_XFORMERS"] = "1"
+        sana_blocks._xformers_available = False
+        sana_video_camctrl._xformers_available = False
+        config.mode = config.trainer.removeprefix("wm_")
+        config.wandb_name = args.wandb_name
+        trainer = SanaWMDistillTrainer(config)
+    else:
+        raise ValueError(f"Unknown trainer: {config.trainer}")
     trainer.train()
 
     wandb.finish()

--- a/train_video_scripts/train_sana_wm_stage1.py
+++ b/train_video_scripts/train_sana_wm_stage1.py
@@ -319,7 +319,7 @@ def _chunk_index_from_config(config: SanaVideoCamCtrlConfig, num_frames: int) ->
 
 def _pad_and_split_cp(clean_images, noise, timesteps, camera_conditions, chunk_plucker, loss_mask, cp_size: int):
     if cp_size <= 1:
-        return clean_images, noise, timesteps, camera_conditions, chunk_plucker, loss_mask
+        return clean_images, noise, timesteps, camera_conditions, chunk_plucker, loss_mask, None
 
     from diffusion.distributed.context_parallel import (
         cp_broadcast_tensor,
@@ -336,6 +336,7 @@ def _pad_and_split_cp(clean_images, noise, timesteps, camera_conditions, chunk_p
 
     local_world = dist.get_world_size(cp_group)
     pad_frames = cp_right_pad_size(clean_images.shape[2], local_world)
+    frame_valid_mask = None
     if pad_frames > 0:
         clean_images = cp_right_pad_temporal(clean_images, dim=2, pad_size=pad_frames, value=0.0)
         noise = cp_right_pad_temporal(noise, dim=2, pad_size=pad_frames, value=0.0)
@@ -362,7 +363,6 @@ def _pad_and_split_cp(clean_images, noise, timesteps, camera_conditions, chunk_p
         cp_broadcast_tensor(chunk_plucker, cp_group)
     if loss_mask is not None:
         cp_broadcast_tensor(loss_mask, cp_group)
-
     clean_images = cp_split_temporal(clean_images, dim=2, group=cp_group).contiguous()
     noise = cp_split_temporal(noise, dim=2, group=cp_group).contiguous()
     if isinstance(timesteps, torch.Tensor) and timesteps.ndim >= 3:
@@ -373,7 +373,9 @@ def _pad_and_split_cp(clean_images, noise, timesteps, camera_conditions, chunk_p
         chunk_plucker = cp_split_temporal(chunk_plucker, dim=2, group=cp_group).contiguous()
     if loss_mask is not None:
         loss_mask = cp_split_temporal(loss_mask, dim=2, group=cp_group).contiguous()
-    return clean_images, noise, timesteps, camera_conditions, chunk_plucker, loss_mask
+    if frame_valid_mask is not None:
+        frame_valid_mask = cp_split_temporal(frame_valid_mask, dim=2, group=cp_group).contiguous()
+    return clean_images, noise, timesteps, camera_conditions, chunk_plucker, loss_mask, frame_valid_mask
 
 
 def _build_timesteps(
@@ -669,14 +671,16 @@ def main(cfg: SanaVideoCamCtrlConfig) -> None:
             loss_mask = _build_i2v_loss_mask(clean_images, do_i2v)
             timesteps, _ = _build_timesteps(config, clean_images, global_t, do_i2v, time_sampler=time_sampler)
             noise = torch.randn_like(clean_images)
-            clean_images, noise, timesteps, camera_conditions, chunk_plucker, loss_mask = _pad_and_split_cp(
-                clean_images,
-                noise,
-                timesteps,
-                camera_conditions,
-                chunk_plucker,
-                loss_mask,
-                cp_size,
+            clean_images, noise, timesteps, camera_conditions, chunk_plucker, loss_mask, frame_valid_mask = (
+                _pad_and_split_cp(
+                    clean_images,
+                    noise,
+                    timesteps,
+                    camera_conditions,
+                    chunk_plucker,
+                    loss_mask,
+                    cp_size,
+                )
             )
             full_t = clean_images.shape[2] * cp_size if cp_size > 1 else clean_images.shape[2]
             chunk_index_global = _chunk_index_from_config(config, full_t)
@@ -707,6 +711,8 @@ def main(cfg: SanaVideoCamCtrlConfig) -> None:
                 model_kwargs["camera_conditions"] = camera_conditions
             if chunk_plucker is not None:
                 model_kwargs["chunk_plucker"] = chunk_plucker
+            if frame_valid_mask is not None:
+                model_kwargs["frame_valid_mask"] = frame_valid_mask
 
             with accelerator.accumulate(model):
                 optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
## Summary

This PR releases the SANA-WM distillation training path used after Stage 1:

- T43 ODE regression
- T43 self-forcing warm-up
- T121 self-forcing / DMD training

The implementation lives in a dedicated `SanaWMDistillTrainer` and is selected from the existing LongSANA entry point with `trainer: wm_ode` or `trainer: wm_self_forcing`. This keeps the legacy LongSANA trainers and their xFormers behavior isolated from the WM-specific path.

The PR also adds the differentiable cached-streaming and context-parallel correctness support required to train the released SANA-WM architecture, together with public configs, documentation, and an updated Stage-1 CP/FSDP2 smoke test.

## What changed

### Distillation training

- Added `diffusion/longsana/trainer/sana_wm_distill.py` with:
  - ODE regression against five-step LMDB trajectories using exact `sigma = timestep / 1000`, clean first-frame conditioning, and masked x0 loss.
  - Autoregressive self-forcing rollout with the streaming student's recurrent cache.
  - DMD generator updates using a learned fake scorer and a frozen CFG real scorer.
  - Flow-matching critic updates.
  - FSDP2/BF16 support, gradient clipping, finite-value checks, checkpointing, and resume support.
- Added `SanaWMOdeTrajectoryDataset` for sharded trajectories containing latents, prompts, camera conditions, Plücker features, and an optional first frame.
- Added public configs:
  - `configs/sana_wm/distill/ode_t43.yaml`
  - `configs/sana_wm/distill/self_forcing_t43.yaml`
  - `configs/sana_wm/distill/self_forcing_t121.yaml`
- Documented the three-stage workflow and public-data constraints in `docs/sana_wm.md`.

### Streaming and distributed training support

- Added differentiable cached GDN and camera execution for the trainable streaming student while retaining fused inference paths.
- Added CP-aware temporal convolution, hybrid-softmax attention, padding masks, and global chunk-boundary handling.
- Preserved camera short-convolution state across streaming chunks.
- Restored standard `nn.Module.__call__` behavior for the streaming model so hooks and FSDP/wrapper machinery remain active.
- Added an exact center-tap fallback for explicit one-frame ShortConvolution segments.
- Kept WM-specific xFormers settings from changing legacy LongSANA imports or runtime behavior.

## Bugs fixed in the original release paths

1. **Hybrid softmax leaked future chunks.** The main and camera softmax branches ignored `chunk_size` and always executed bidirectional SDPA. They now use the same chunk-causal boundaries as the GDN blocks.
2. **D=112 attention used the wrong scale after padding.** Padding the head dimension to 128 let SDPA default to `1/sqrt(128)`. The code now explicitly preserves the intended `1/sqrt(112)` scale.
3. **Temporal K short convolution reset at CP shard boundaries.** The forward path now exchanges its left halo, while the backward chunk path uses global chunk boundaries instead of treating each rank as an independent sequence.
4. **Chunked temporal FFN convolution was shard-local.** It now gathers the temporal activations differentiably, evaluates global chunk boundaries, and slices the local result back to each CP rank.
5. **Hybrid-softmax K/V context was CP-local.** Main and camera branches now gather K/V and validity masks and account for each query shard's global frame offset.
6. **CP padding could contaminate valid states.** The Stage-1 path computed a validity mask only for the loss and discarded it before model forward. The mask is now propagated through QKV, gates, recurrent scans, temporal convolutions, attention keys, and outputs.
7. **Chunk boundaries used inconsistent local/global coordinates under CP.** Rank-local `chunk_index` values were normalized against the global sequence length, which could remove true recurrence resets. The GDN and camera paths now consume `chunk_index_global` where global coordinates are required.
8. **The chunk-causal camera reverse scan was rank-local.** It now scans in reverse CP-rank order and resets only at true global chunk boundaries, including chunks that cross a shard boundary.
9. **Streaming camera K-convolution lost cross-chunk context.** Its short-convolution state is now read from and written to cache slot 3, matching the main cached branch.
10. **The streaming model overrode `nn.Module.__call__`.** Dispatch now happens in `forward`, avoiding bypassed hooks and wrapper/FSDP machinery.

## Validation

Validated in the `sana-nvlabs` environment on 8 H100 GPUs:

- Python compilation, YAML resolution, trainer/entry-point import, shell syntax, and diff whitespace checks pass.
- Stage-1 CP2/FSDP2 completed a real one-step update using a non-divisible 25-latent-frame fixture, exercising temporal padding.
- T43 ODE training completed a full FSDP2/BF16 update with finite loss and gradient norm.
- T43 and T121 self-forcing runs completed CP4/DP2 generator and critic updates with finite losses and gradients.
- Checkpoint and resume tests restored generator, critic, optimizer state, step, dataloader position, and RNG state.
- Focused numerical tests covered CP padding/halos, global chunked softmax, temporal FFN boundaries, main/camera alignment, and cached-streaming forward/backward behavior.
- Legacy LongSANA no-mask behavior remained unchanged in isolation checks.

## Reproducibility notes

- The public Stage-1 and self-forcing data use only the redistributable Sekai camera-control subset. The original internal curriculum also mixed private video-only and no-camera sources, so this PR does not claim exact reproduction of the private final weights or loss curve.
- ODE trajectories are not redistributed. `ode_t43.yaml` documents the expected LMDB layout and requires a local `data_path`.

## Known limitations

- The released self-forcing configs are validated with CP4. The current CP1 score-training path still rejects the frame-valid mask and is not supported by this PR.
- Non-default `FUSED_GDN_PRECISION` overrides do not currently propagate through the frozen real-score fast path; default precision behavior is unchanged.
