### PR TITLE
fix(sana-wm): enable ti2v bidirectional training

### DIFF
--- a/configs/sana_wm/stage1/sana_wm_stage1_sekai_bidirectional_cp2_fsdp2.yaml
+++ b/configs/sana_wm/stage1/sana_wm_stage1_sekai_bidirectional_cp2_fsdp2.yaml
@@ -1,4 +1,4 @@
-task: df
+task: ti2v
 data:
   hf_dataset_repo: Efficient-Large-Model/SANA-WM-example-training-dataset
   hf_dataset_revision: 4d965e94b9ea11b9c5ba085251ffa7a0345e006f
@@ -144,12 +144,6 @@ train:
   timestep_weight: false
   noise_multiplier: 0.0
   ltx_image_condition_prob: 0.9
-  chunk_sampling_strategy: incremental
-  chunk_mixture_probs:
-    same_t: 0.1
-    incremental: 0.4
-    last_chunk_anchor: 0.4
-    teacher_forcing_clean: 0.1
   extra:
     cp:
       scan_backend: triton

--- a/docs/sana_wm.md
+++ b/docs/sana_wm.md
@@ -282,7 +282,10 @@ with `--chunk_interval_k` only for ablations.
 
 This repo includes matching bidirectional and chunk-causal Stage-1 teacher
 training recipes. They share the same Sekai-Game data, optimizer, and CP2/FSDP2
-settings; only the Stage-1 model and checkpoint differ:
+settings. The bidirectional recipe uses the video-level `ti2v` objective with
+probabilistic clean first-frame conditioning, while the
+chunk-causal recipe uses frame-wise `df` training with chunk-wise timestep
+sampling:
 
 - training script: `train_video_scripts/train_sana_wm_stage1.py`
 - bidirectional config: `configs/sana_wm/stage1/sana_wm_stage1_sekai_bidirectional_cp2_fsdp2.yaml`
@@ -317,6 +320,7 @@ data:
   data_dir:
     sekai_game: data/sekai_game_train_961frames_16fps_ovl640
   vae_cache_dir: data/vae_cache/LTX2VAE_diffusers_704x1280/sekai_game_train_961frames_16fps_ovl640
+task: ti2v
 model:  # Bidirectional
   load_from: hf://Efficient-Large-Model/SANA-WM_bidirectional/dit/sana_wm_1600m_720p.safetensors
   attn_type: BidirectionalGDNTriton
@@ -326,17 +330,27 @@ train:
   use_fsdp: true
   fsdp_version: 2
   cp_size: 2
+  ltx_image_condition_prob: 0.9
 ```
 
-The chunk-causal recipe changes only the model-specific fields:
+The chunk-causal recipe additionally enables frame-wise diffusion and its
+chunk-wise timestep mixture:
 
 ```yaml
+task: df
 model:
   load_from: hf://Efficient-Large-Model/SANA-WM_chunk_causal/dit/sana_wm_chunk_causal_1600m_720p.safetensors
   attn_type: ChunkCausalGDNTriton
   camctrl_type: ChunkCausalGDNUCPESinglePathLiteLABothTriton
   ffn_type: ChunkGLUMBConvTemp
   chunk_size: 3
+train:
+  chunk_sampling_strategy: incremental
+  chunk_mixture_probs:
+    same_t: 0.1
+    incremental: 0.4
+    last_chunk_anchor: 0.4
+    teacher_forcing_clean: 0.1
 ```
 
 Set `data.hf_dataset_local_dir` to a shared filesystem path if you do not want

--- a/train_video_scripts/train_sana_wm_stage1.py
+++ b/train_video_scripts/train_sana_wm_stage1.py
@@ -667,7 +667,7 @@ def main(cfg: SanaVideoCamCtrlConfig) -> None:
             if num_sampler_chunks > time_sampler_chunks:
                 time_sampler = _build_time_sampler(config, global_t, accelerator.device)
                 time_sampler_chunks = num_sampler_chunks
-            do_i2v = config.task == "df" and random.random() < float(config.train.ltx_image_condition_prob)
+            do_i2v = config.task in {"df", "ti2v"} and random.random() < float(config.train.ltx_image_condition_prob)
             loss_mask = _build_i2v_loss_mask(clean_images, do_i2v)
             timesteps, _ = _build_timesteps(config, clean_images, global_t, do_i2v, time_sampler=time_sampler)
             noise = torch.randn_like(clean_images)


### PR DESCRIPTION
## Summary
- enable the existing clean-first-frame conditioning path for explicit `task: ti2v`, while preserving chunk-causal `df` behavior
- configure the bidirectional Stage-1 teacher as `ti2v` and keep `ltx_image_condition_prob: 0.9`
- remove chunk-only timestep controls from the bidirectional recipe and clarify the training documentation

## Validation
- `pre-commit run --files train_video_scripts/train_sana_wm_stage1.py configs/sana_wm/stage1/sana_wm_stage1_sekai_bidirectional_cp2_fsdp2.yaml docs/sana_wm.md`
- `python -m py_compile train_video_scripts/train_sana_wm_stage1.py`
- CW Slurm job `13489390`: 4×H100, CP2/FSDP2, 3 optimizer steps, exit `0`
  - losses: `0.2715`, `0.2812`, `0.3672`
  - pre-clip grad norms: `0.089287`, `0.056410`, `0.028183`
- fresh read-only Claude review: `APPROVE`, no blockers

No validation or instrumentation code is included in the commit.