### PR TITLE
Fix LTXFlowEuler BF16 denoising mask

### DIFF
--- a/diffusion/scheduler/flow_euler_sampler.py
+++ b/diffusion/scheduler/flow_euler_sampler.py
@@ -128,7 +128,7 @@ class LTXFlowEuler(FlowEuler):
         condition_frame_info = self.model_kwargs["data_info"].pop(
             "condition_frame_info", {}
         )  # {frame_idx: frame_weight}
-        condition_mask = torch.zeros_like(latents)  # 1,C,F,H,W
+        condition_mask = torch.zeros_like(latents, dtype=torch.float32)  # 1,C,F,H,W
         image_cond_noise_scale = 0.0
         for frame_idx, frame_weight in condition_frame_info.items():
             condition_mask[:, :, frame_idx] = 1


### PR DESCRIPTION
## Summary

- create the LTX conditioning mask in float32 so high timesteps do not round to 1 during BF16 comparisons
- preserve hard-conditioned tokens while restoring the first generated-token updates

Fixes #423

## Testing

- pre-commit run --files diffusion/scheduler/flow_euler_sampler.py
- CW H100 CUDA regression check: old generated-token masks were [false, false, true], fixed masks were [true, true, true], and the conditioned frame remained unchanged