### PR TITLE
Refine Sol-Attn documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ support a wider range of models.
 
 ## 📰 News
 
-- **[2026/07/28]** 🔥 **Sol-Attn integrated** — [**Sol-Attn**](techniques/sparse_backends/) sparse video attention lands as an acceleration technique for [**HunyuanVideo-13B**](models/hunyuan_video/) and [**Wan2.1-T2V-14B**](models/wan21_t2v_14b/). The released SM90/SM100 kernel is integrated; refreshed end-to-end speed measurements are pending.
+- **[2026/07/28]** 🔥 **Sol-Attn** [[Paper](https://arxiv.org/abs/2607.24027) | [Code](techniques/sparse_backends/sol_attn/)] — sparse video attention lands as an acceleration technique for [**HunyuanVideo-13B**](models/hunyuan_video/) and [**Wan2.1-T2V-14B**](models/wan21_t2v_14b/). The released SM90/SM100 kernel is integrated; refreshed end-to-end speed measurements are pending.
 - **[2026/07/15]** 🔥 **Three new models** — [Wan2.2 TI2V-5B](scripts/wan5b/run_optimized.sh) **~2.89×**, [Wan2.2-A14B](scripts/wan14b/run_optimized.sh) **~2.17×**, and [LingBot-Video](scripts/lingbot/run_optimized.sh) **~2.60×** end-to-end.
 - **[2026/07/13]** ⚙️ **Agent workflow update** — refreshed the agent-native optimization workflow (a master orchestrator driving per-technique executor sub-agents with automatic quality gates). See the [agent-workflow](site_docs/agent-workflow.md) page.
 - **[2026/06]** 📖 **Docs release** — full documentation site live: [3 pipeline designs + 5 acceleration techniques](https://nvlabs.github.io/Sana/Sol-Engine/docs/).
@@ -91,7 +91,7 @@ methods across these levels.
 
 </div>
 
-## 🌀 SOL Attention
+## 🌀 Sol-Attention
 
 [**Sol-Attn**](techniques/sparse_backends/) is our sparse attention
 technique for video DiTs: video-token self-attention runs through a sparse

--- a/techniques/sparse_backends/README.md
+++ b/techniques/sparse_backends/README.md
@@ -1,32 +1,66 @@
-# Sol-Attn backend
+<h1 align="center">Sol-Attn</h1>
 
-`techniques/sparse_backends/sol_attn/` is a clean vendor of
-[`hp-l33/Sol-Attn`](https://github.com/hp-l33/Sol-Attn) at source commit
-`d7ffb1e25999a8a753b679ee7923d7c3f861da6b`. It contains the public SM90 and
-SM100 CuTe DSL kernels. Sana keeps one adapter and one public kernel API for
-both architectures.
+<h4 align="center">
+  Efficient sparse attention kernels for video diffusion transformers
+</h4>
 
-## Public kernel API
+<p align="center">
+  <a href="https://arxiv.org/abs/2607.24027">Paper</a> |
+  <a href="./sol_attn/">Code</a>
+</p>
 
-Add the vendor root to `PYTHONPATH`, then use the upstream API unchanged:
+---
+
+## Introduction
+
+Sol-Attn is a training-free sparse attention method for accelerating image
+and video generation. It performs dynamic block routing during online softmax
+and reuses proxy scores to approximate unselected blocks, avoiding a
+materialized routing map while preserving visual quality. This release
+includes CuTe DSL implementations for NVIDIA Hopper and Blackwell GPUs.
+
+## Requirements
+
+- Python ≥ 3.10
+- PyTorch ≥ 2.10
+- CUDA ≥ 12.8
+- Triton ≥ 3.6
+- NVIDIA CuTe DSL / CUTLASS Python ≥ 4.5
+- `cuda-python`
+
+The released kernels are forward-only and require contiguous BF16 Q/K/V
+tensors in BTHD layout with head dimension 128.
+
+## Installation
+
+From the repository root:
+
+```bash
+python -m pip install -e techniques/sparse_backends/sol_attn
+```
+
+CuTe DSL is imported lazily, so kernel compilation happens on the first
+eligible call for a given configuration.
+
+## Usage
+
+### Core kernel API
 
 ```python
 from sol_attn import sol_attn
 
-# q, k, v: contiguous BF16 [batch, tokens, heads, 128]
 out = sol_attn(
-    q,
-    k,
-    v,
+    q,  # BTHD
+    k,  # BTHD
+    v,  # BTHD
     tau=1.0,
-    thresh_type="diag",
-    kv_splits=1,
+    thresh_type="exact",
 )
 ```
 
-H100 supports `kv_splits=1`, `2`, or `4`; B200 uses `kv_splits=1`.
+### Exact KV sink
 
-For a text prefix:
+Any contiguous valid KV range can be kept exact. For a text prefix:
 
 ```python
 out = sol_attn(
@@ -39,7 +73,7 @@ out = sol_attn(
 )
 ```
 
-For a text suffix:
+For a text suffix, omit `sink_start`:
 
 ```python
 out = sol_attn(
@@ -51,12 +85,29 @@ out = sol_attn(
 )
 ```
 
-The sink is exact at 64-token KV-block granularity. It does not make text
-query rows dense by itself.
+Every query attends all KV blocks overlapping the sink range exactly.
+Exactness is applied at 64-token KV-block granularity. The sink does not
+change query routing: an MMDiT integration should still compute valid text
+query rows with dense attention and use Sol-Attn for image/video query rows.
 
-## Sana model adapters
+### Split KV on H100
 
-Use `techniques.sparse_backends.sol_attn_backend` when integrating a model:
+H100 supports `kv_splits=1`, `2`, and `4`; B200 currently uses
+`kv_splits=1`.
+
+```python
+out = sol_attn(q, k, v, tau=1.0, kv_splits=4)
+```
+
+Split 4 is a useful starting point for very long H100 sequences, while the
+best setting depends on sequence length, batch size, head count, and realized
+sparsity.
+
+## Model integration helpers
+
+The integration module provides dense fallback, architecture-aware split
+selection, Diffusers dispatch hooks, MMDiT padding handling, and lightweight
+runtime counters:
 
 ```python
 from techniques.sparse_backends.sol_attn_backend import (
@@ -70,11 +121,11 @@ out = sol_attn_attention(
     k,
     v,
     tau=1.0,
-    thresh_type="diag",
+    thresh_type="exact",
     kv_splits="auto",
 )
 
-# HunyuanVideo, BHSD with native [video, padded-text] order.
+# MMDiT joint attention, BHSD with [video, padded-text] order.
 out = sol_attn_hunyuan(
     q,
     k,
@@ -82,34 +133,37 @@ out = sol_attn_hunyuan(
     video_len=video_tokens,
     key_valid=key_padding_mask,
     tau=1.0,
-    thresh_type="diag",
+    thresh_type="exact",
     kv_splits="auto",
 )
 ```
 
-The Hunyuan adapter crops padding, passes every valid text KV block as an exact
+The MMDiT helper crops right padding, passes valid text KV blocks as an exact
 sink, replaces valid text-query rows with dense SDPA, and leaves padded query
-rows zero. This is the required MMDiT contract: text K/V is exact and text Q is
-dense; only image/video query rows use Sol-Attn approximation.
+rows zero.
 
 Diffusers integrations can use:
 
 - `make_sol_attn_dispatch(...)` for ordinary self-attention.
-- `make_hunyuan_sol_attn_dispatch(...)` for Hunyuan joint attention.
+- `make_hunyuan_sol_attn_dispatch(...)` for joint MMDiT attention.
 - `sol_attn_begin_forward()` as a transformer pre-hook.
-- `reset_sol_attn_state()` after an untimed warmup generation.
-- `get_sol_attn_stats()` to verify dispatch/kernel calls in an E2E run.
+- `reset_sol_attn_state()` after an untimed warmup.
+- `get_sol_attn_stats()` to verify dispatch and kernel calls.
 
-The shipped candidates use these settings:
+`kv_splits="auto"` is provided by the integration layer. It selects split 4
+for SM90 sequences of at least 65,536 tokens and split 1 otherwise. The core
+kernel API accepts integer `kv_splits` values only.
 
-```text
-*_SOL_ATTN=1
-*_SOL_TAU=1.0
-*_SOL_THRESH_TYPE=diag
-*_SOL_KV_SPLITS=auto
-SOL_ATTN_STRICT=1  # recommended for validation; disables silent fallback
+Set `SOL_ATTN_STRICT=1` during validation to raise kernel or integration
+errors instead of silently falling back to dense attention.
+
+## Citation
+
+```bibtex
+@article{li2026solattn,
+  title={Sol-Attn: Accelerating Video Generation Inference via On-the-Fly Attention Sparsification},
+  author={Li, Haopeng and Li, Yitong and Chen, Junsong and Ye, Tian and Liu, Haozhe and Yu, Jincheng and Wang, Duomin and Zhang, Ruihua and Xie, Zeke and Xie, Enze and Han, Song},
+  journal={arXiv preprint arXiv:2607.24027},
+  year={2026}
+}
 ```
-
-`auto` is an integration convenience: it selects split 4 for SM90 sequences
-of at least 65,536 tokens and split 1 otherwise. The upstream kernel API still
-accepts only integer `kv_splits`.


### PR DESCRIPTION
## Summary

- refresh the Sol-Attn news entry with Paper and Code links and standardize the Sol-Attention section title
- replace the backend README's provenance-oriented opening with a public project-style introduction
- document the supported software requirements, including PyTorch ≥ 2.10
- simplify the core API example, retain sink and model-integration guidance, and add the Sol-Attn paper citation

## Motivation

This presents the integrated Sol-Attn backend as a normal public-facing project, removes internal vendor/source wording, and makes the API documentation and paper attribution easier to follow.

## Impact

Documentation only. Kernel and model runtime behavior are unchanged.

## Validation

- `git diff --check`
- manually reviewed README links, examples, requirements, and citation metadata
