### PR TITLE
Add Triton fallback dispatch for Sol-Attn

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ support a wider range of models.
 ## 📰 News
 
 - **[2026/08/03]** 🔥 **MiniMax-H3** [[Model](https://huggingface.co/MiniMaxAI/MiniMax-H3)] — 33B audio-video Omni-DiT joins the line at **~3.97×** end-to-end on 8×GB200, composing context parallelism, a lossless kernel line, [**Sol-Attn**](techniques/sparse_backends/) and FirstBlockCache. See [models/minimax_h3](models/minimax_h3/).
-- **[2026/07/28]** 🔥 **Sol-Attn** [[Paper](https://arxiv.org/abs/2607.24027) | [Code](techniques/sparse_backends/sol_attn/)] — sparse video attention lands as an acceleration technique for [**HunyuanVideo-13B**](models/hunyuan_video/) and [**Wan2.1-T2V-14B**](models/wan21_t2v_14b/). The released SM90/SM100/SM120 kernels are integrated; refreshed end-to-end speed measurements are pending.
+- **[2026/07/28]** 🔥 **Sol-Attn** [[Paper](https://arxiv.org/abs/2607.24027) | [Code](techniques/sparse_backends/sol_attn/)] — sparse video attention lands with released SM90/SM100/SM120 kernels for [**HunyuanVideo-13B**](models/hunyuan_video/) (**~5.03×**) and [**Wan2.1-T2V-14B**](models/wan21_t2v_14b/) (**~3.48×**) end-to-end.
 - **[2026/07/15]** 🔥 **Three new models** — [Wan2.2 TI2V-5B](scripts/wan5b/run_optimized.sh) **~2.89×**, [Wan2.2-A14B](scripts/wan14b/run_optimized.sh) **~2.17×**, and [LingBot-Video](scripts/lingbot/run_optimized.sh) **~2.60×** end-to-end.
 - **[2026/07/13]** ⚙️ **Agent workflow update** — refreshed the agent-native optimization workflow (a master orchestrator driving per-technique executor sub-agents with automatic quality gates). See the [agent-workflow](site_docs/agent-workflow.md) page.
 - **[2026/06]** 📖 **Docs release** — full documentation site live: [3 pipeline designs + 5 acceleration techniques](https://nvlabs.github.io/Sana/Sol-Engine/docs/).
@@ -61,8 +61,8 @@ support a wider range of models.
 | **[Wan2.2 TI2V-5B](https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B)** | 5B | EasyCache + kernel fusion + compile | **~2.89×** |
 | **[Wan2.2-A14B](https://huggingface.co/Wan-AI/Wan2.2-T2V-A14B-Diffusers)** | 14B (MoE) | kernel fusion + EasyCache + PISA | **~2.17×** |
 | **[LingBot-Video](https://huggingface.co/robbyant/lingbot-video-moe-30b-a3b)** | 30B-A3B (MoE) | kernel fusion + refiner PISA + EasyCache | **~2.60×** |
-| **[HunyuanVideo-13B](https://huggingface.co/hunyuanvideo-community/HunyuanVideo)** | 13B | kernel fusion + TeaCache + [**Sol-Attn**](techniques/sparse_backends/) | re-benchmark pending |
-| **[Wan2.1-T2V-14B](https://huggingface.co/Wan-AI/Wan2.1-T2V-14B-Diffusers)** | 14B | kernel fusion + EasyCache + [**Sol-Attn**](techniques/sparse_backends/) | re-benchmark pending |
+| **[HunyuanVideo-13B](https://huggingface.co/hunyuanvideo-community/HunyuanVideo)** | 13B | kernel fusion + TeaCache + [**Sol-Attn**](techniques/sparse_backends/) | **~5.03×** |
+| **[Wan2.1-T2V-14B](https://huggingface.co/Wan-AI/Wan2.1-T2V-14B-Diffusers)** | 14B | kernel fusion + EasyCache + [**Sol-Attn**](techniques/sparse_backends/) | **~3.48×** |
 | **[MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3)** | 33B (audio+video) | context parallel + kernel fusion + [**Sol-Attn**](techniques/sparse_backends/) + FirstBlockCache | **~3.97×** |
 
 </div>
@@ -101,8 +101,16 @@ kernel that computes only the most relevant key blocks, while using light weight
 into a model runtime through env-gated hooks and powers the optimization stacks of
 [**HunyuanVideo-13B**](models/hunyuan_video/),
 [**Wan2.1-T2V-14B**](models/wan21_t2v_14b/) and
-[**MiniMax-H3**](models/minimax_h3/). The released-kernel stacks require
-fresh end-to-end performance measurements.
+[**MiniMax-H3**](models/minimax_h3/). The HunyuanVideo and Wan2.1 stacks reach
+**~5.03×** and **~3.48×** end-to-end speedup, respectively.
+
+Backend selection is automatic: H100 (SM90), B200 (SM100), and RTX 5090
+(SM120) use their optimized CuTe DSL kernels when CuTe is installed. Older
+supported GPUs such as A100 (SM80) and RTX 4090 (SM89), or installations
+without CuTe DSL, use the portable Triton implementation. Model call sites do
+not need architecture-specific changes. See the
+[Sol-Attn usage guide](techniques/sparse_backends/) for requirements and API
+details.
 
 ## 🚀 Quick start (agent-native)
 

--- a/models/hunyuan_video/optimized/gpu_infer.py
+++ b/models/hunyuan_video/optimized/gpu_infer.py
@@ -140,7 +140,7 @@ def main() -> int:
         if _repo_sol not in _sys_sol.path:
             _sys_sol.path.insert(0, _repo_sol)
         from techniques.sparse_backends.sol_attn_backend import (
-            make_hunyuan_sol_attn_dispatch,
+            make_mmdit_sol_attn_dispatch,
             sol_attn_begin_forward,
         )
         from diffusers.models.transformers import transformer_hunyuan_video as _thv
@@ -167,7 +167,7 @@ def main() -> int:
             video_len=_video_len,
             morton=os.environ.get("HUNYUAN_SOL_MORTON", "0") == "1",
         )
-        _thv.dispatch_attention_fn = make_hunyuan_sol_attn_dispatch(
+        _thv.dispatch_attention_fn = make_mmdit_sol_attn_dispatch(
             _thv.dispatch_attention_fn, **_sol_kw
         )
         pipe.transformer.register_forward_pre_hook(

--- a/scripts/_hunyuan_sol_correctness.py
+++ b/scripts/_hunyuan_sol_correctness.py
@@ -64,7 +64,7 @@ def main() -> int:
         k[:, :, :effective_tokens],
         v[:, :, :effective_tokens],
     ).transpose(1, 2)
-    all_exact = backend.sol_attn_attention(
+    all_exact = backend._run_sol_attn_bthd(
         q_joint,
         k_joint,
         v_joint,
@@ -80,7 +80,7 @@ def main() -> int:
         k[:, :, :effective_tokens],
         v[:, :, :effective_tokens],
     )
-    actual = backend.sol_attn_hunyuan(
+    actual = backend._run_mmdit_sol_attn_bthd(
         q,
         k,
         v,
@@ -94,7 +94,7 @@ def main() -> int:
     def unexpected_dense_dispatch(*_args, **_kwargs):
         raise AssertionError("eligible Hunyuan dispatch unexpectedly fell back")
 
-    dispatch = backend.make_hunyuan_sol_attn_dispatch(
+    dispatch = backend.make_mmdit_sol_attn_dispatch(
         unexpected_dense_dispatch,
         video_len=video_tokens,
         tau=1.0,

--- a/techniques/sparse_backends/README.md
+++ b/techniques/sparse_backends/README.md
@@ -1,12 +1,14 @@
 <h1 align="center">Sol-Attn</h1>
 
 <h4 align="center">
-  Efficient sparse attention kernels for video diffusion transformers
+  Accelerating Video Generation Inference via On-the-Fly Attention Sparsification
 </h4>
 
 <p align="center">
-  <a href="https://arxiv.org/abs/2607.24027">Paper</a> |
-  <a href="./sol_attn/">Code</a>
+  <a href="./sol_attn/"><img src="https://img.shields.io/badge/💻_Code-Sol--Attn-76b900?style=flat-square" alt="Code"/></a>
+  <a href="https://arxiv.org/abs/2607.24027"><img src="https://img.shields.io/badge/📄_arXiv-2607.24027-b31b1b?style=flat-square" alt="Paper"/></a>
+  <a href="https://nvlabs.github.io/Sana/Sol-Engine/docs/techniques/sparse/"><img src="https://img.shields.io/badge/📖_Docs-Sol--Engine-blue?style=flat-square" alt="Docs"/></a>
+  <a href="../../README.md#-license"><img src="https://img.shields.io/badge/License-Apache_2.0-green?style=flat-square" alt="License"/></a>
 </p>
 
 ---
@@ -16,9 +18,8 @@
 Sol-Attn is a training-free sparse attention method for accelerating image
 and video generation. It performs dynamic block routing during online softmax
 and reuses proxy scores to approximate unselected blocks, avoiding a
-materialized routing map while preserving visual quality. This release
-includes CuTe DSL implementations for NVIDIA Hopper, datacenter Blackwell,
-and GeForce Blackwell GPUs.
+materialized routing map while preserving visual quality. CuTe DSL kernels
+support SM90, SM100, and SM120; SM80 and SM89 use Triton kernels.
 
 ## Requirements
 
@@ -26,6 +27,9 @@ and GeForce Blackwell GPUs.
 - PyTorch ≥ 2.10
 - CUDA ≥ 12.8
 - Triton ≥ 3.6
+
+The optimized CuTe paths additionally require:
+
 - NVIDIA CuTe DSL / CUTLASS Python ≥ 4.5
 - `cuda-python`
 
@@ -46,28 +50,58 @@ From the repository root:
 python -m pip install -e techniques/sparse_backends
 ```
 
-CuTe DSL is imported lazily, so kernel compilation happens on the first
-eligible call for a given configuration.
+Backend dependencies are imported lazily, and kernel compilation happens on
+the first eligible call for a given configuration.
+
+## Backend dispatch
+
+The public `sol_attn(...)` API selects the implementation from `q.device`:
+
+| GPU architecture | Example GPU | Preferred backend | Fallback |
+|---|---|---|---|
+| SM90 | NVIDIA H100 | CuTe DSL SM90 kernel | Triton |
+| SM100 | NVIDIA B200 | CuTe DSL SM100 kernel | Triton |
+| SM120 | RTX 5090 | CuTe DSL SM120 kernel | Triton |
+| SM80 / SM89 | A100 / RTX 4090 | Triton | — |
+| Other NVIDIA CC ≥ 8.0 | Architecture dependent | Triton | — |
+
+CuTe DSL and `cuda-python` are optional at runtime. When either cannot be
+imported, the same public API falls back to Triton.
 
 ## Usage
 
-### Core kernel API
+For kernel and library integrations, `sol_attn(...)` is the public API. It
+validates the tensor contract and automatically selects the CuTe or Triton
+backend for the input device.
+
+### Core API
 
 ```python
 from sol_attn import sol_attn
 
 out = sol_attn(
-    q,  # BTHD
-    k,  # BTHD
-    v,  # BTHD
-    tau=1.0,
-    thresh_type="exact",
+    q,  # Query: contiguous BF16 CUDA tensor in [batch, tokens, heads, 128].
+    k,  # Key: same shape, dtype, layout, and device as q.
+    v,  # Value: same shape, dtype, layout, and device as q.
+    tau=1.0,  # Higher values select fewer KV blocks for exact attention.
+    thresh_type="exact",  # Use the full-covariance routing threshold.
 )
+# out is contiguous [batch, tokens, heads, 128] BF16 on q.device.
 ```
 
 ### Exact KV sink
 
-Any contiguous valid KV range can be kept exact. For a text prefix:
+An exact sink keeps every KV block overlapping a contiguous token range exact
+for all queries. This is useful for text tokens in joint image/video-text
+attention.
+
+| Text placement | `sink_start` | `sink_tokens` |
+|---|---:|---:|
+| Prefix | `0` | Number of valid text tokens |
+| Suffix | Omit | Number of valid text tokens |
+| Interior range | First text-token index | Number of valid text tokens |
+
+For example, keep a text prefix exact:
 
 ```python
 out = sol_attn(
@@ -75,8 +109,8 @@ out = sol_attn(
     k,
     v,
     tau=1.0,
-    sink_start=0,
-    sink_tokens=valid_text_tokens,
+    sink_start=0,                  # Text begins before the image/video tokens.
+    sink_tokens=valid_text_tokens, # All overlapping 64-token KV blocks are exact.
 )
 ```
 
@@ -94,75 +128,61 @@ out = sol_attn(
 
 Every query attends all KV blocks overlapping the sink range exactly.
 Exactness is applied at 64-token KV-block granularity. The sink does not
-change query routing: an MMDiT integration should still compute valid text
-query rows with dense attention and use Sol-Attn for image/video query rows.
+make text query rows dense: an MMDiT integration should still use dense
+attention for valid text queries and Sol-Attn for image/video queries.
 
-### Split KV by architecture
+### Long-sequence tuning on H100
 
-H100 supports `kv_splits=1`, `2`, and `4`; B200 and RTX 5090 currently use
-`kv_splits=1`.
+The SM90 CuTe kernel supports `kv_splits=1`, `2`, and `4`. Splitting KV can
+improve utilization for very long sequences; the best value depends on shape
+and realized sparsity.
 
 ```python
 out = sol_attn(q, k, v, tau=1.0, kv_splits=4)
 ```
 
-Split 4 is a useful starting point for very long H100 sequences, while the
-best setting depends on sequence length, batch size, head count, and realized
-sparsity.
+B200, RTX 5090, and Triton currently use `kv_splits=1`.
 
-## Model integration helpers
+## Sol-Engine integration
 
-The integration module provides dense fallback, architecture-aware split
-selection, Diffusers dispatch hooks, MMDiT padding handling, and lightweight
-runtime counters:
+Sol-Engine exposes two integration factories. They preserve the model's
+original attention function as a dense fallback and route eligible calls to
+the public `sol_attn(...)` kernel API.
+
+| Entry point | Integration |
+|---|---|
+| `make_sol_attn_dispatch(...)` | Ordinary self-attention |
+| `make_mmdit_sol_attn_dispatch(...)` | Joint MMDiT attention with exact text K/V and dense text-query rows |
+
+`kv_splits="auto"` is provided by the integration layer. It selects split 4
+for SM90 CuTe sequences of at least 65,536 tokens and split 1 otherwise. The
+core kernel API accepts integer `kv_splits` values only.
+
+Sol-Engine adapters fall back to dense attention when a call is ineligible or
+a backend fails. Set `SOL_ATTN_STRICT=1` during validation to raise the original
+error instead.
+
+## Triton research implementation
+
+The Triton implementation can also be selected explicitly for portability,
+kernel studies, and comparisons against the architecture-specialized CuTe
+implementations:
 
 ```python
-from techniques.sparse_backends.sol_attn_backend import (
-    sol_attn_attention,
-    sol_attn_hunyuan,
-)
+from sol_attn.triton_ref import sol_attn as triton_sol_attn
 
-# Ordinary self-attention, BTHD.
-out = sol_attn_attention(
+out = triton_sol_attn(
     q,
     k,
     v,
     tau=1.0,
     thresh_type="exact",
-    kv_splits="auto",
-)
-
-# MMDiT joint attention, BHSD with [video, padded-text] order.
-out = sol_attn_hunyuan(
-    q,
-    k,
-    v,
-    video_len=video_tokens,
-    key_valid=key_padding_mask,
-    tau=1.0,
-    thresh_type="exact",
-    kv_splits="auto",
 )
 ```
 
-The MMDiT helper crops right padding, passes valid text KV blocks as an exact
-sink, replaces valid text-query rows with dense SDPA, and leaves padded query
-rows zero.
-
-Diffusers integrations can use:
-
-- `make_sol_attn_dispatch(...)` for ordinary self-attention.
-- `make_hunyuan_sol_attn_dispatch(...)` for joint MMDiT attention.
-- `sol_attn_begin_forward()` as a transformer pre-hook.
-- `reset_sol_attn_state()` after an untimed warmup.
-- `get_sol_attn_stats()` to verify dispatch and kernel calls.
-
-`kv_splits="auto"` is provided by the integration layer. It selects split 4
-for SM90 sequences of at least 65,536 tokens and split 1 otherwise. The core
-kernel API accepts integer `kv_splits` values only.
-
-Set `SOL_ATTN_STRICT=1` during validation to raise kernel or integration
-errors instead of silently falling back to dense attention.
+This explicit entry point bypasses automatic backend selection. It keeps the
+same tensor, threshold, and sink semantics as the public `sol_attn(...)` API,
+but currently uses a single KV split.
 
 ## Citation
 

--- a/techniques/sparse_backends/pyproject.toml
+++ b/techniques/sparse_backends/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "sol-attn"
 version = "0.5.0"
-description = "Sol-Attn forward kernels for NVIDIA Hopper and Blackwell"
+description = "Sol-Attn forward kernels for NVIDIA GPUs"
 requires-python = ">=3.10"
 
 [tool.setuptools.packages.find]

--- a/techniques/sparse_backends/sol_attn/interface.py
+++ b/techniques/sparse_backends/sol_attn/interface.py
@@ -2,22 +2,23 @@
 
 from __future__ import annotations
 
-import cuda.bindings.driver as cuda
-import cutlass.cute as cute
+import functools
+
 import torch
 
-from .common import to_cute_tensor
-from .preprocess import BLOCK_SIZE, prepare
-
-
+BLOCK_SIZE = 64
+_CUTE_BACKENDS = {
+    (9, 0): "cute_sm90",
+    (10, 0): "cute_sm100",
+    (12, 0): "cute_sm120",
+}
 _compiled = {}
 
 
-def _validate(
+def _validate_inputs(
     q,
     k,
     v,
-    kv_splits,
     thresh_type,
     sink_tokens=0,
     sink_start=None,
@@ -32,8 +33,6 @@ def _validate(
         raise ValueError("q, k, and v must be on the same CUDA device")
     if not (q.is_contiguous() and k.is_contiguous() and v.is_contiguous()):
         raise ValueError("q, k, and v must be contiguous BTHD tensors")
-    if kv_splits not in (1, 2, 4):
-        raise ValueError("kv_splits must be 1, 2, or 4")
     if thresh_type not in ("diag", "exact"):
         raise ValueError("thresh_type must be 'diag' or 'exact'")
     if not isinstance(sink_tokens, int):
@@ -48,21 +47,63 @@ def _validate(
         if sink_start + sink_tokens > q.shape[1]:
             raise ValueError("sink_start + sink_tokens must be <= T")
 
-    arch = torch.cuda.get_device_capability(q.device)
-    if arch not in ((9, 0), (10, 0), (12, 0)):
+    return tuple(torch.cuda.get_device_capability(q.device))
+
+
+@functools.lru_cache(maxsize=1)
+def _cute_runtime_available() -> bool:
+    """Whether the optional CuTe DSL runtime can be imported."""
+
+    try:
+        import cuda.bindings.driver  # noqa: F401
+        import cutlass.cute  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _backend_for_arch(
+    arch: tuple[int, int],
+    *,
+    cute_available: bool | None = None,
+) -> str:
+    """Select CuTe when specialized and available, otherwise Triton."""
+
+    if arch[0] < 8:
         raise RuntimeError(
-            "Sol-Attn supports H100 (SM90), B200 (SM100), and RTX 5090 (SM120)"
+            "Sol-Attn requires an NVIDIA GPU with compute capability >= 8.0; "
+            f"got SM{arch[0]}{arch[1]}"
         )
+    cute_backend = _CUTE_BACKENDS.get(arch)
+    if cute_backend is not None:
+        available = (
+            _cute_runtime_available()
+            if cute_available is None
+            else cute_available
+        )
+        if available:
+            return cute_backend
+    return "triton"
+
+
+def _validate_cute(arch, tokens, kv_splits):
     if arch != (9, 0) and kv_splits != 1:
         raise ValueError("kv_splits=2/4 is currently available on SM90 only")
-    route_groups = ((q.shape[1] + 63) // 64 + 63) // 64
+    route_groups = ((tokens + 63) // 64 + 63) // 64
     if kv_splits > route_groups:
         raise ValueError("each KV split must contain at least one N64 route group")
-    return arch
 
 
 def _stream(device):
+    import cuda.bindings.driver as cuda
+
     return cuda.CUstream(torch.cuda.current_stream(device).cuda_stream)
+
+
+def _to_cute_tensors(tensors):
+    from .common import to_cute_tensor
+
+    return [to_cute_tensor(x) for x in tensors]
 
 
 def _sink_block_range(tokens, sink_start, sink_tokens):
@@ -85,10 +126,12 @@ def _compile_sm90(
     sink_range,
     stream,
 ):
+    import cutlass.cute as cute
+
     from .sm90 import make_kernel
 
     operator = make_kernel(tokens, kv_splits)
-    args = [to_cute_tensor(x) for x in tensors]
+    args = _to_cute_tensors(tensors)
     compiled = cute.compile(
         operator,
         *args,
@@ -109,9 +152,11 @@ def _compile_sm100(
     sink_end_block,
     stream,
 ):
+    import cutlass.cute as cute
+
     from .sm100 import forward
 
-    args = [to_cute_tensor(x) for x in tensors]
+    args = _to_cute_tensors(tensors)
     compiled = cute.compile(
         forward,
         *args,
@@ -133,10 +178,12 @@ def _compile_sm120(
     sink_end_block,
     stream,
 ):
+    import cutlass.cute as cute
+
     from .sm120 import make_kernel
 
     operator = make_kernel()
-    args = [to_cute_tensor(x) for x in tensors]
+    args = _to_cute_tensors(tensors)
     compiled = cute.compile(
         operator,
         *args,
@@ -150,36 +197,21 @@ def _compile_sm120(
     return compiled, args
 
 
-def sol_attn(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
+def _sol_attn_cute(
+    q,
+    k,
+    v,
     *,
-    scale: float | None = None,
-    tau: float = 1.0,
-    thresh_type: str = "diag",
-    kv_splits: int = 1,
-    sink_tokens: int = 0,
-    sink_start: int | None = None,
-) -> torch.Tensor:
-    """Compute noncausal Sol-Attn for contiguous BF16 BTHD tensors.
+    arch,
+    scale,
+    tau,
+    thresh_type,
+    kv_splits,
+    sink_tokens,
+    sink_start,
+):
+    from .preprocess import prepare
 
-    ``sink_start`` and ``sink_tokens`` keep every KV block overlapping the
-    corresponding contiguous token range exact for all queries. Omitting
-    ``sink_start`` places the range at the token suffix.
-    """
-
-    arch = _validate(
-        q,
-        k,
-        v,
-        kv_splits,
-        thresh_type,
-        sink_tokens,
-        sink_start,
-    )
-    scale = q.shape[-1] ** -0.5 if scale is None else float(scale)
-    tau = float(tau)
     batch, tokens, heads, _ = q.shape
 
     with torch.cuda.device(q.device):
@@ -238,7 +270,7 @@ def sol_attn(
                     stream,
                 )
             else:
-                args = [to_cute_tensor(x) for x in tensors]
+                args = _to_cute_tensors(tensors)
             compiled(
                 *args,
                 scale,
@@ -263,7 +295,7 @@ def sol_attn(
                     stream,
                 )
             else:
-                args = [to_cute_tensor(x) for x in tensors]
+                args = _to_cute_tensors(tensors)
             compiled(
                 *args,
                 scale,
@@ -289,7 +321,7 @@ def sol_attn(
                     stream,
                 )
             else:
-                args = [to_cute_tensor(x) for x in tensors]
+                args = _to_cute_tensors(tensors)
             compiled(
                 *args,
                 scale,
@@ -298,6 +330,70 @@ def sol_attn(
                 stream=stream,
             )
     return output
+
+
+def sol_attn(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    scale: float | None = None,
+    tau: float = 1.0,
+    thresh_type: str = "diag",
+    kv_splits: int = 1,
+    sink_tokens: int = 0,
+    sink_start: int | None = None,
+) -> torch.Tensor:
+    """Compute noncausal Sol-Attn for contiguous BF16 BTHD tensors.
+
+    ``sink_start`` and ``sink_tokens`` keep every KV block overlapping the
+    corresponding contiguous token range exact for all queries. Omitting
+    ``sink_start`` places the range at the token suffix.
+    """
+
+    arch = _validate_inputs(
+        q,
+        k,
+        v,
+        thresh_type,
+        sink_tokens,
+        sink_start,
+    )
+    if kv_splits not in (1, 2, 4):
+        raise ValueError("kv_splits must be 1, 2, or 4")
+    backend = _backend_for_arch(arch)
+    scale = q.shape[-1] ** -0.5 if scale is None else float(scale)
+    tau = float(tau)
+
+    if backend == "triton":
+        if kv_splits != 1:
+            raise ValueError("kv_splits=2/4 is currently available on SM90 only")
+        from .triton_ref import sol_attn as triton_sol_attn
+
+        return triton_sol_attn(
+            q,
+            k,
+            v,
+            scale=scale,
+            tau=tau,
+            thresh_type=thresh_type,
+            sink_tokens=sink_tokens,
+            sink_start=sink_start,
+        )
+
+    _validate_cute(arch, q.shape[1], kv_splits)
+    return _sol_attn_cute(
+        q,
+        k,
+        v,
+        arch=arch,
+        scale=scale,
+        tau=tau,
+        thresh_type=thresh_type,
+        kv_splits=kv_splits,
+        sink_tokens=sink_tokens,
+        sink_start=sink_start,
+    )
 
 
 __all__ = ["sol_attn"]

--- a/techniques/sparse_backends/sol_attn/triton_ref/fwd.py
+++ b/techniques/sparse_backends/sol_attn/triton_ref/fwd.py
@@ -1,16 +1,31 @@
-"""Triton Sol-Attn reference."""
+"""Architecture-aware Triton Sol-Attn forward implementation."""
 
 import torch
 import triton
 import triton.language as tl
-from triton.tools.tensor_descriptor import TensorDescriptor
 
-from sol_attn.interface import _validate
-from sol_attn.preprocess import prepare
+try:
+    from triton.tools.tensor_descriptor import TensorDescriptor
+except ImportError:  # Pointer path remains usable without descriptors.
+    TensorDescriptor = None
+
+from sol_attn.interface import (
+    _sink_block_range,
+    _validate_inputs,
+)
+
+from .preprocess import prepare as prepare_ptr
 
 
 BLOCK = 64
 GROUP = 32
+
+
+def _use_tma(device) -> bool:
+    """Use descriptor-backed Triton I/O when the GPU supports TMA."""
+
+    capability = torch.cuda.get_device_capability(device)
+    return capability[0] >= 9 and TensorDescriptor is not None
 
 
 @triton.autotune(
@@ -22,7 +37,7 @@ GROUP = 32
     key=["T"],
 )
 @triton.jit
-def _forward(
+def _forward_tma(
     q_desc,
     k_desc,
     v_desc,
@@ -32,6 +47,9 @@ def _forward(
     o_desc,
     scale,
     T,
+    sink_start_block,
+    sink_end_block,
+    HAS_SINK: tl.constexpr,
     H: tl.constexpr,
     D: tl.constexpr,
     NT: tl.constexpr,
@@ -45,8 +63,14 @@ def _forward(
         tl.program_id(2),
     )
     batch, head = batch_head // H, batch_head % H
-    group_offsets = tl.max_contiguous(tl.arange(0, GROUP_SIZE), GROUP_SIZE)
-    token_offsets = tl.max_contiguous(tl.arange(0, BLOCK_SIZE), BLOCK_SIZE)
+    group_offsets = tl.max_contiguous(
+        tl.arange(0, GROUP_SIZE),
+        GROUP_SIZE,
+    )
+    token_offsets = tl.max_contiguous(
+        tl.arange(0, BLOCK_SIZE),
+        BLOCK_SIZE,
+    )
     q_start = q_block * BLOCK_SIZE
     q = q_desc.load([batch, q_start, head, 0]).reshape([BLOCK_SIZE, D])
     q_len = tl.minimum(BLOCK_SIZE, T - q_start).to(tl.float32)
@@ -73,27 +97,37 @@ def _forward(
         exact = (
             (tl.sum(scores, axis=0) / q_len > route_threshold)
             | (tl.abs(q_block - block_indices) <= 1)
-        ) & valid
+        )
+        if HAS_SINK:
+            exact = exact | (
+                (block_indices >= sink_start_block)
+                & (block_indices < sink_end_block)
+            )
+        exact = exact & valid
 
         approximate = valid & ~exact
         approximate_scores = tl.where(
             approximate[None, :], scores, -float("inf")
         )
         new_max = tl.maximum(row_max, tl.max(approximate_scores, axis=1))
-        alpha = tl.math.exp2(tl.where(row_max == new_max, 0.0, row_max - new_max))
+        alpha = tl.math.exp2(
+            tl.where(row_max == new_max, 0.0, row_max - new_max)
+        )
         approximate_probability = tl.where(
             approximate[None, :],
             tl.math.exp2(approximate_scores - new_max[:, None]),
             0.0,
         )
         output = output * alpha[:, None] + tl.dot(
-            approximate_probability.to(vc.dtype), vc
+            approximate_probability.to(vc.dtype),
+            vc,
         )
         lengths = tl.where(
             block_indices == NT - 1, tail_length, BLOCK_SIZE
         ).to(tl.float32)
         row_sum = row_sum * alpha + tl.sum(
-            approximate_probability * lengths[None, :], axis=1
+            approximate_probability * lengths[None, :],
+            axis=1,
         )
         row_max = new_max
 
@@ -102,7 +136,9 @@ def _forward(
             offset = tl.min(exact_offsets)
             block = group_start + offset
             exact_offsets = tl.where(
-                group_offsets == offset, GROUP_SIZE, exact_offsets
+                group_offsets == offset,
+                GROUP_SIZE,
+                exact_offsets,
             )
             kv_start = block * BLOCK_SIZE
             k = k_desc.load(
@@ -116,19 +152,214 @@ def _forward(
             )
             new_max = tl.maximum(row_max, tl.max(exact_scores, axis=1))
             alpha = tl.math.exp2(row_max - new_max)
-            exact_probability = tl.math.exp2(exact_scores - new_max[:, None])
-            row_sum = row_sum * alpha + tl.sum(exact_probability, axis=1)
+            exact_probability = tl.math.exp2(
+                exact_scores - new_max[:, None]
+            )
+            row_sum = row_sum * alpha + tl.sum(
+                exact_probability,
+                axis=1,
+            )
             v = v_desc.load(
                 [batch, kv_start, head, v_tile * BV]
             ).reshape([BLOCK_SIZE, BV])
             output = output * alpha[:, None] + tl.dot(
-                exact_probability.to(v.dtype), v
+                exact_probability.to(v.dtype),
+                v,
             )
             row_max = new_max
 
     o_desc.store(
         [batch, q_start, head, v_tile * BV],
         (output / row_sum[:, None]).to(tl.bfloat16)[None, :, None, :],
+    )
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BV": 128}, num_warps=4, num_stages=1),
+        triton.Config({"BV": 128}, num_warps=8, num_stages=1),
+        triton.Config({"BV": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BV": 64}, num_warps=4, num_stages=1),
+    ],
+    key=["T"],
+)
+@triton.jit
+def _forward_ptr(
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    kc_ptr,
+    vc_ptr,
+    threshold_ptr,
+    o_ptr,
+    scale,
+    T,
+    NPAD,
+    sink_start_block,
+    sink_end_block,
+    HAS_SINK: tl.constexpr,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    NT: tl.constexpr,
+    BV: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+):
+    v_tile, q_block, batch_head = (
+        tl.program_id(0),
+        tl.program_id(1),
+        tl.program_id(2),
+    )
+    batch, head = batch_head // H, batch_head % H
+    group_offsets = tl.max_contiguous(
+        tl.arange(0, GROUP_SIZE),
+        GROUP_SIZE,
+    )
+    token_offsets = tl.max_contiguous(
+        tl.arange(0, BLOCK_SIZE),
+        BLOCK_SIZE,
+    )
+    dims = tl.arange(0, D)
+    value_dims = v_tile * BV + tl.arange(0, BV)
+    q_tokens = q_block * BLOCK_SIZE + token_offsets
+    q_valid = q_tokens < T
+    q_offsets = (
+        ((batch * T + q_tokens[:, None]).to(tl.int64) * H + head) * D
+        + dims[None, :]
+    )
+    q = tl.load(q_ptr + q_offsets, mask=q_valid[:, None], other=0.0)
+    q_len = tl.minimum(BLOCK_SIZE, T - q_block * BLOCK_SIZE).to(tl.float32)
+
+    output = tl.zeros([BLOCK_SIZE, BV], dtype=tl.float32)
+    row_sum = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+    row_max = tl.full((BLOCK_SIZE,), -float("inf"), tl.float32)
+    scale_log2 = scale * 1.4426950408889634
+    route_threshold = tl.load(
+        threshold_ptr + (batch * NT + q_block) * H + head
+    )
+
+    for group_start in range(0, NT, GROUP_SIZE):
+        block_indices = group_start + group_offsets
+        valid = block_indices < NT
+        kc_offsets = (
+            ((batch * NPAD + block_indices[:, None]) * H + head) * D
+            + dims[None, :]
+        )
+        vc_offsets = (
+            ((batch * NPAD + block_indices[:, None]) * H + head) * D
+            + value_dims[None, :]
+        )
+        kc = tl.load(kc_ptr + kc_offsets)
+        vc = tl.load(vc_ptr + vc_offsets)
+        scores = tl.dot(q, kc.T).to(tl.float32) * scale_log2
+        exact = (
+            (tl.sum(scores, axis=0) / q_len > route_threshold)
+            | (tl.abs(q_block - block_indices) <= 1)
+        )
+        if HAS_SINK:
+            exact = exact | (
+                (block_indices >= sink_start_block)
+                & (block_indices < sink_end_block)
+            )
+        exact = exact & valid
+
+        approximate = valid & ~exact
+        has_approximate = tl.sum(approximate.to(tl.int32), axis=0) > 0
+        approximate_scores = tl.where(
+            approximate[None, :],
+            scores,
+            -float("inf"),
+        )
+        safe_scores = tl.where(has_approximate, approximate_scores, 0.0)
+        candidate_max = tl.maximum(row_max, tl.max(safe_scores, axis=1))
+        new_max = tl.where(has_approximate, candidate_max, row_max)
+        alpha = tl.math.exp2(
+            tl.where(has_approximate, row_max - new_max, 0.0)
+        )
+        probability = tl.math.exp2(
+            safe_scores
+            - tl.where(has_approximate, new_max, 0.0)[:, None]
+        )
+        probability = tl.where(
+            has_approximate & approximate[None, :],
+            probability,
+            0.0,
+        )
+        output = output * alpha[:, None] + tl.dot(
+            probability.to(vc.dtype),
+            vc,
+        )
+        lengths = tl.minimum(
+            BLOCK_SIZE,
+            tl.maximum(0, T - block_indices * BLOCK_SIZE),
+        ).to(tl.float32)
+        row_sum = row_sum * alpha + tl.sum(
+            probability * lengths[None, :],
+            axis=1,
+        )
+        row_max = new_max
+
+        exact_offsets = tl.where(exact, group_offsets, GROUP_SIZE)
+        num_exact = tl.sum(exact.to(tl.int32), axis=0)
+        for _ in range(num_exact):
+            offset = tl.min(exact_offsets)
+            block = group_start + offset
+            exact_offsets = tl.where(
+                group_offsets == offset,
+                GROUP_SIZE,
+                exact_offsets,
+            )
+            kv_tokens = block * BLOCK_SIZE + token_offsets
+            kv_valid = kv_tokens < T
+            k_offsets = (
+                ((batch * T + kv_tokens[:, None]).to(tl.int64) * H + head)
+                * D
+                + dims[None, :]
+            )
+            k = tl.load(
+                k_ptr + k_offsets,
+                mask=kv_valid[:, None],
+                other=0.0,
+            )
+            exact_scores = tl.dot(q, k.T).to(tl.float32) * scale_log2
+            exact_scores += tl.where(
+                kv_valid[None, :],
+                0.0,
+                -float("inf"),
+            )
+            new_max = tl.maximum(row_max, tl.max(exact_scores, axis=1))
+            alpha = tl.math.exp2(row_max - new_max)
+            exact_probability = tl.math.exp2(
+                exact_scores - new_max[:, None]
+            )
+            row_sum = row_sum * alpha + tl.sum(
+                exact_probability,
+                axis=1,
+            )
+            v_offsets = (
+                ((batch * T + kv_tokens[:, None]).to(tl.int64) * H + head)
+                * D
+                + value_dims[None, :]
+            )
+            v = tl.load(
+                v_ptr + v_offsets,
+                mask=kv_valid[:, None],
+                other=0.0,
+            )
+            output = output * alpha[:, None] + tl.dot(
+                exact_probability.to(v.dtype),
+                v,
+            )
+            row_max = new_max
+
+    output_offsets = (
+        ((batch * T + q_tokens[:, None]).to(tl.int64) * H + head) * D
+        + value_dims[None, :]
+    )
+    tl.store(
+        o_ptr + output_offsets,
+        (output / row_sum[:, None]).to(tl.bfloat16),
+        mask=q_valid[:, None],
     )
 
 
@@ -139,34 +370,104 @@ def sol_attn(
     *,
     scale: float | None = None,
     tau: float = 1.0,
+    thresh_type: str = "diag",
+    sink_tokens: int = 0,
+    sink_start: int | None = None,
 ) -> torch.Tensor:
-    """Run the readable Triton reference on BTHD inputs."""
+    """Run Triton Sol-Attn on contiguous BF16 BTHD inputs."""
 
-    _validate(q, k, v, 1, "diag")
+    arch = _validate_inputs(
+        q,
+        k,
+        v,
+        thresh_type,
+        sink_tokens,
+        sink_start,
+    )
+    if arch[0] < 8:
+        raise RuntimeError(
+            "Triton Sol-Attn requires an NVIDIA GPU with compute "
+            f"capability >= 8.0; got SM{arch[0]}{arch[1]}"
+        )
     scale = q.shape[-1] ** -0.5 if scale is None else float(scale)
     tau = float(tau)
     batch, tokens, heads, head_dim = q.shape
     blocks = triton.cdiv(tokens, BLOCK)
-    kc, vc, threshold = prepare(q, k, v, scale=scale, tau=tau)
+    sink_start_block, sink_end_block = _sink_block_range(
+        tokens,
+        sink_start,
+        sink_tokens,
+    )
+    use_tma = _use_tma(q.device)
+
+    if use_tma:
+        # Keep the original descriptor-backed preprocessing on TMA devices.
+        # The pointer preprocessing below exists only for older architectures.
+        from ..preprocess import prepare as prepare_tma
+
+        kc, vc, threshold = prepare_tma(
+            q,
+            k,
+            v,
+            scale=scale,
+            tau=tau,
+            thresh_type=thresh_type,
+        )
+        output = torch.empty_like(v)
+        block_shape = [1, BLOCK, 1, head_dim]
+        summary_shape = [1, GROUP, 1, head_dim]
+        _forward_tma[(1, blocks, batch * heads)](
+            TensorDescriptor.from_tensor(q, block_shape),
+            TensorDescriptor.from_tensor(k, block_shape),
+            TensorDescriptor.from_tensor(v, block_shape),
+            TensorDescriptor.from_tensor(kc, summary_shape),
+            TensorDescriptor.from_tensor(vc, summary_shape),
+            threshold,
+            TensorDescriptor.from_tensor(output, block_shape),
+            scale,
+            tokens,
+            sink_start_block,
+            sink_end_block,
+            sink_tokens > 0,
+            heads,
+            head_dim,
+            blocks,
+            head_dim,
+            BLOCK,
+            GROUP,
+        )
+        return output
+
+    kc, vc, threshold = prepare_ptr(
+        q,
+        k,
+        v,
+        scale=scale,
+        tau=tau,
+        thresh_type=thresh_type,
+        tokens=tokens,
+    )
     output = torch.empty_like(v)
-    block_shape = [1, BLOCK, 1, head_dim]
-    summary_shape = [1, GROUP, 1, head_dim]
-    _forward[(1, blocks, batch * heads)](
-        TensorDescriptor.from_tensor(q, block_shape),
-        TensorDescriptor.from_tensor(k, block_shape),
-        TensorDescriptor.from_tensor(v, block_shape),
-        TensorDescriptor.from_tensor(kc, summary_shape),
-        TensorDescriptor.from_tensor(vc, summary_shape),
+    grid = lambda meta: (head_dim // meta["BV"], blocks, batch * heads)
+    _forward_ptr[grid](
+        q,
+        k,
+        v,
+        kc,
+        vc,
         threshold,
-        TensorDescriptor.from_tensor(output, block_shape),
+        output,
         scale,
         tokens,
-        heads,
-        head_dim,
-        blocks,
-        head_dim,
-        BLOCK,
-        GROUP,
+        kc.shape[1],
+        sink_start_block,
+        sink_end_block,
+        HAS_SINK=sink_tokens > 0,
+        H=heads,
+        D=head_dim,
+        NT=blocks,
+        BLOCK_SIZE=BLOCK,
+        GROUP_SIZE=GROUP,
     )
     return output
 

--- a/techniques/sparse_backends/sol_attn/triton_ref/preprocess.py
+++ b/techniques/sparse_backends/sol_attn/triton_ref/preprocess.py
@@ -1,0 +1,389 @@
+"""Pointer preprocessing for Triton Sol-Attn when TMA is unavailable."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+BLOCK_SIZE = 64
+HEAD_DIM = 128
+THRESHOLD_GROUP_SIZE = 64
+SUMMARY_PAD = 64
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=warps, num_stages=stages)
+        for warps in (4, 8)
+        for stages in (1, 2)
+    ],
+    key=["T"],
+)
+@triton.jit
+def _reduce_kv_kernel(
+    k,
+    v,
+    kc,
+    vc,
+    T,
+    TP,
+    NPAD,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    block, batch_head = tl.program_id(0), tl.program_id(1)
+    batch, head = batch_head // H, batch_head % H
+    tokens = block * BLOCK + tl.arange(0, BLOCK)
+    dims = tl.arange(0, D)
+    valid = tokens < T
+    offsets = (
+        ((batch * TP + tokens[:, None]).to(tl.int64) * H + head) * D
+        + dims[None, :]
+    )
+    k_values = tl.load(k + offsets, mask=valid[:, None], other=0.0)
+    v_values = tl.load(v + offsets, mask=valid[:, None], other=0.0)
+    block_len = tl.minimum(BLOCK, T - block * BLOCK).to(tl.float32)
+    summary_offsets = (
+        ((batch * NPAD + block) * H + head) * D + dims
+    )
+    tl.store(kc + summary_offsets, tl.sum(k_values, axis=0) / block_len)
+    tl.store(vc + summary_offsets, tl.sum(v_values, axis=0))
+
+
+@triton.jit
+def _reduce_kc_stats_kernel(
+    kc,
+    kc_mean,
+    kc_var_diag,
+    NPAD,
+    H: tl.constexpr,
+    N: tl.constexpr,
+    D: tl.constexpr,
+    GROUP: tl.constexpr,
+):
+    batch_head = tl.program_id(0)
+    batch, head = batch_head // H, batch_head % H
+    blocks = tl.max_contiguous(tl.arange(0, GROUP), GROUP)
+    dims = tl.arange(0, D)
+    total = tl.zeros((D,), dtype=tl.float32)
+    total_sq = tl.zeros((D,), dtype=tl.float32)
+    count = tl.full((), 0.0, dtype=tl.float32)
+    for start in range(0, N, GROUP):
+        block_indices = start + blocks
+        valid = block_indices < N
+        offsets = (
+            ((batch * NPAD + block_indices[:, None]) * H + head) * D
+            + dims[None, :]
+        )
+        values = tl.load(
+            kc + offsets,
+            mask=valid[:, None],
+            other=0.0,
+        ).to(tl.float32)
+        total += tl.sum(values, axis=0)
+        total_sq += tl.sum(values * values, axis=0)
+        count += tl.sum(valid.to(tl.float32), axis=0)
+    mean = total / count
+    variance = tl.maximum(total_sq / count - mean * mean, 0.0)
+    tl.store(kc_mean + batch_head * D + dims, mean)
+    tl.store(kc_var_diag + batch_head * D + dims, variance)
+
+
+@triton.jit
+def _diag_threshold_kernel(
+    q,
+    kc_mean,
+    kc_var_diag,
+    threshold,
+    scale,
+    T,
+    TP,
+    H: tl.constexpr,
+    N: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK: tl.constexpr,
+    TAU: tl.constexpr,
+):
+    q_block, batch_head = tl.program_id(0), tl.program_id(1)
+    batch, head = batch_head // H, batch_head % H
+    tokens = q_block * BLOCK + tl.arange(0, BLOCK)
+    dims = tl.arange(0, D)
+    valid = tokens < T
+    offsets = (
+        ((batch * TP + tokens[:, None]).to(tl.int64) * H + head) * D
+        + dims[None, :]
+    )
+    q_values = tl.load(q + offsets, mask=valid[:, None], other=0.0)
+    q_len = tl.minimum(BLOCK, T - q_block * BLOCK).to(tl.float32)
+    q_centroid = tl.sum(q_values.to(tl.float32), axis=0) / q_len
+    mean_kc = tl.load(kc_mean + batch_head * D + dims)
+    var_kc = tl.load(kc_var_diag + batch_head * D + dims)
+    log2_scale = scale * 1.4426950408889634
+    mean = tl.sum(q_centroid * mean_kc, axis=0) * log2_scale
+    variance = tl.sum(
+        q_centroid * q_centroid * var_kc,
+        axis=0,
+    ) * (log2_scale * log2_scale)
+    std = tl.sqrt(tl.maximum(variance, 0.0) + 1.0e-6)
+    tl.store(
+        threshold + (batch * N + q_block) * H + head,
+        mean + TAU * std,
+    )
+
+
+@triton.jit
+def _pool_query_kernel(
+    q,
+    q_bar,
+    T,
+    TP,
+    H: tl.constexpr,
+    N: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    q_block, batch_head = tl.program_id(0), tl.program_id(1)
+    batch, head = batch_head // H, batch_head % H
+    tokens = q_block * BLOCK + tl.arange(0, BLOCK)
+    dims = tl.arange(0, D)
+    valid = tokens < T
+    offsets = (
+        ((batch * TP + tokens[:, None]).to(tl.int64) * H + head) * D
+        + dims[None, :]
+    )
+    values = tl.load(q + offsets, mask=valid[:, None], other=0.0)
+    q_len = tl.minimum(BLOCK, T - q_block * BLOCK).to(tl.float32)
+    centroid = tl.sum(values.to(tl.float32), axis=0) / q_len
+    tl.store(q_bar + (batch_head * N + q_block) * D + dims, centroid)
+
+
+@triton.jit
+def _exact_fused_threshold_kernel(
+    q_bar,
+    kc_mean,
+    kc_second_moment,
+    threshold,
+    scale,
+    H: tl.constexpr,
+    N: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    TAU: tl.constexpr,
+):
+    row_tile, batch_head = tl.program_id(0), tl.program_id(1)
+    rows = row_tile * BLOCK_M + tl.arange(0, BLOCK_M)
+    dims = tl.arange(0, D)
+    valid_rows = rows < N
+    q_centroid = tl.load(
+        q_bar + (batch_head * N + rows[:, None]) * D + dims[None, :],
+        mask=valid_rows[:, None],
+        other=0.0,
+    )
+    mean_kc = tl.load(kc_mean + batch_head * D + dims)
+    second_moment = tl.load(
+        kc_second_moment
+        + batch_head * D * D
+        + dims[:, None] * D
+        + dims[None, :]
+    )
+    raw_mean = tl.sum(q_centroid.to(tl.float32) * mean_kc[None, :], axis=1)
+    projected = tl.dot(q_centroid, second_moment, out_dtype=tl.float32)
+    raw_second_moment = tl.sum(
+        projected * q_centroid.to(tl.float32),
+        axis=1,
+    )
+    log2_scale = scale * 1.4426950408889634
+    mean = raw_mean * log2_scale
+    variance = tl.maximum(
+        raw_second_moment - raw_mean * raw_mean,
+        0.0,
+    ) * (log2_scale * log2_scale)
+    result = mean + TAU * tl.sqrt(variance + 1.0e-6)
+    batch, head = batch_head // H, batch_head % H
+    tl.store(
+        threshold + (batch * N + rows) * H + head,
+        result,
+        mask=valid_rows,
+    )
+
+
+def _reduce_kv(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    tokens: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    batch, padded_tokens, heads, head_dim = k.shape
+    tokens = padded_tokens if tokens is None else int(tokens)
+    blocks = triton.cdiv(tokens, BLOCK_SIZE)
+    padded_blocks = triton.cdiv(blocks, SUMMARY_PAD) * SUMMARY_PAD
+    kc = torch.zeros(
+        (batch, padded_blocks, heads, head_dim),
+        device=k.device,
+        dtype=torch.bfloat16,
+    )
+    vc = torch.zeros_like(kc)
+    _reduce_kv_kernel[(blocks, batch * heads)](
+        k,
+        v,
+        kc,
+        vc,
+        tokens,
+        padded_tokens,
+        padded_blocks,
+        heads,
+        head_dim,
+        BLOCK_SIZE,
+    )
+    return kc, vc
+
+
+def _compute_diag_threshold(
+    q: torch.Tensor,
+    kc: torch.Tensor,
+    *,
+    tau: float,
+    scale: float,
+    tokens: int | None = None,
+) -> torch.Tensor:
+    batch, padded_tokens, heads, head_dim = q.shape
+    tokens = padded_tokens if tokens is None else int(tokens)
+    blocks = triton.cdiv(tokens, BLOCK_SIZE)
+    batch_heads = batch * heads
+    kc_mean = torch.empty(
+        (batch_heads, head_dim),
+        device=q.device,
+        dtype=torch.float32,
+    )
+    kc_var_diag = torch.empty_like(kc_mean)
+    threshold = torch.empty(
+        (batch, blocks, heads),
+        device=q.device,
+        dtype=torch.float32,
+    )
+    _reduce_kc_stats_kernel[(batch_heads,)](
+        kc,
+        kc_mean,
+        kc_var_diag,
+        kc.shape[1],
+        heads,
+        blocks,
+        head_dim,
+        THRESHOLD_GROUP_SIZE,
+        num_warps=4,
+        num_stages=2,
+    )
+    _diag_threshold_kernel[(blocks, batch_heads)](
+        q,
+        kc_mean,
+        kc_var_diag,
+        threshold,
+        scale,
+        tokens,
+        padded_tokens,
+        heads,
+        blocks,
+        head_dim,
+        BLOCK_SIZE,
+        tau,
+        num_warps=4,
+        num_stages=2,
+    )
+    return threshold
+
+
+def _compute_exact_threshold(
+    q: torch.Tensor,
+    kc: torch.Tensor,
+    *,
+    tau: float,
+    scale: float,
+    tokens: int | None = None,
+) -> torch.Tensor:
+    batch, padded_tokens, heads, head_dim = q.shape
+    tokens = padded_tokens if tokens is None else int(tokens)
+    blocks = triton.cdiv(tokens, BLOCK_SIZE)
+    batch_heads = batch * heads
+    kc_bh = kc[:, :blocks].permute(0, 2, 1, 3)
+    kc_mean = kc_bh.mean(dim=2, dtype=torch.float32)
+    kc_second_moment = torch.matmul(
+        kc_bh.transpose(-1, -2),
+        kc_bh,
+    )
+    kc_second_moment.div_(blocks)
+    q_bar = torch.empty(
+        (batch_heads, blocks, head_dim),
+        device=q.device,
+        dtype=torch.bfloat16,
+    )
+    threshold = torch.empty(
+        (batch, blocks, heads),
+        device=q.device,
+        dtype=torch.float32,
+    )
+    _pool_query_kernel[(blocks, batch_heads)](
+        q,
+        q_bar,
+        tokens,
+        padded_tokens,
+        heads,
+        blocks,
+        head_dim,
+        BLOCK_SIZE,
+        num_warps=4,
+        num_stages=1,
+    )
+    block_m = 64
+    _exact_fused_threshold_kernel[
+        (triton.cdiv(blocks, block_m), batch_heads)
+    ](
+        q_bar,
+        kc_mean,
+        kc_second_moment,
+        threshold,
+        scale,
+        heads,
+        blocks,
+        head_dim,
+        block_m,
+        tau,
+        num_warps=4,
+        num_stages=1,
+    )
+    return threshold
+
+
+def prepare(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    tau: float,
+    scale: float,
+    thresh_type: str = "diag",
+    tokens: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    kc, vc = _reduce_kv(k, v, tokens=tokens)
+    if thresh_type == "exact":
+        threshold = _compute_exact_threshold(
+            q,
+            kc,
+            tau=tau,
+            scale=scale,
+            tokens=tokens,
+        )
+    else:
+        threshold = _compute_diag_threshold(
+            q,
+            kc,
+            tau=tau,
+            scale=scale,
+            tokens=tokens,
+        )
+    return kc, vc, threshold
+
+
+__all__ = ["prepare"]

--- a/techniques/sparse_backends/sol_attn_backend.py
+++ b/techniques/sparse_backends/sol_attn_backend.py
@@ -60,7 +60,7 @@ def _load_sol_attn() -> Callable:
 
 
 def sol_attn_supported(q) -> bool:
-    """Whether ``q`` satisfies the public Sol-Attn tensor/device contract."""
+    """Whether ``q`` can use a CuTe or portable Triton Sol-Attn backend."""
 
     try:
         import torch
@@ -71,13 +71,22 @@ def sol_attn_supported(q) -> bool:
     if q.ndim != 4 or q.shape[-1] != HEAD_DIM or q.dtype != torch.bfloat16:
         return False
     try:
-        return tuple(torch.cuda.get_device_capability(q.device)) in {
-            (9, 0),
-            (10, 0),
-            (12, 0),
-        }
+        arch = tuple(torch.cuda.get_device_capability(q.device))
+        return arch[0] >= 8
     except Exception:
         return False
+
+
+@functools.lru_cache(maxsize=1)
+def _cute_runtime_available() -> bool:
+    """Whether model dispatch can use one of the optional CuTe kernels."""
+
+    try:
+        import cuda.bindings.driver  # noqa: F401
+        import cutlass.cute  # noqa: F401
+    except ImportError:
+        return False
+    return True
 
 
 def _resolve_kv_splits(q, kv_splits: int | str | None) -> int:
@@ -88,7 +97,11 @@ def _resolve_kv_splits(q, kv_splits: int | str | None) -> int:
     if kv_splits not in (None, "auto"):
         return int(kv_splits)
     arch = tuple(torch.cuda.get_device_capability(q.device))
-    if arch == (9, 0) and q.shape[1] >= 65536:
+    if (
+        arch == (9, 0)
+        and q.shape[1] >= 65536
+        and _cute_runtime_available()
+    ):
         return 4
     return 1
 
@@ -103,7 +116,7 @@ def _dense_bthd(q, k, v):
     ).transpose(1, 2)
 
 
-def sol_attn_attention(
+def _run_sol_attn_bthd(
     q,
     k,
     v,
@@ -308,7 +321,7 @@ def _ensure_self_op() -> None:
     def self_attention(q, k, v):
         if _use_dense_layer():
             return _dense_bthd(q, k, v)
-        return sol_attn_attention(
+        return _run_sol_attn_bthd(
             q,
             k,
             v,
@@ -416,7 +429,7 @@ def _dense_hunyuan(q, k, v, key_valid):
     )
 
 
-def sol_attn_hunyuan(
+def _run_mmdit_sol_attn_bthd(
     q,
     k,
     v,
@@ -429,7 +442,7 @@ def sol_attn_hunyuan(
     grid=None,
     morton: bool = False,
 ):
-    """Run Hunyuan MMDiT attention with exact text K/V and dense text Q.
+    """Run joint MMDiT attention with exact text K/V and dense text Q.
 
     Inputs use BHSD and the model's native ``[video, padded-text]`` order.
     Padding is cropped before the kernel. Sol-Attn computes the valid joint
@@ -501,7 +514,7 @@ def sol_attn_hunyuan(
             .transpose(1, 2)
             .contiguous()
         )
-        out_joint = sol_attn_attention(
+        out_joint = _run_sol_attn_bthd(
             q_joint,
             k_joint,
             v_joint,
@@ -559,7 +572,7 @@ def _ensure_hunyuan_op() -> None:
     def hunyuan_attention(q, k, v, key_valid):
         if _use_dense_layer():
             return _dense_hunyuan(q, k, v, key_valid.bool())
-        return sol_attn_hunyuan(
+        return _run_mmdit_sol_attn_bthd(
             q,
             k,
             v,
@@ -579,7 +592,7 @@ def _ensure_hunyuan_op() -> None:
     _HUNYUAN_OP_REGISTERED = True
 
 
-def make_hunyuan_sol_attn_dispatch(
+def make_mmdit_sol_attn_dispatch(
     original_dispatch,
     *,
     video_len: int,
@@ -591,7 +604,7 @@ def make_hunyuan_sol_attn_dispatch(
     grid=None,
     morton: bool = False,
 ):
-    """Wrap Hunyuan's joint masked attention with the exact-text adapter."""
+    """Wrap joint MMDiT attention with exact text K/V and dense text Q."""
 
     _SOL_CTX.video_len = int(video_len)
     _SOL_CTX.tau = float(tau)
@@ -679,13 +692,6 @@ def make_hunyuan_sol_attn_dispatch(
 
 
 __all__ = [
-    "get_sol_attn_stats",
-    "install_wan_morton_forward",
-    "make_hunyuan_sol_attn_dispatch",
+    "make_mmdit_sol_attn_dispatch",
     "make_sol_attn_dispatch",
-    "reset_sol_attn_state",
-    "sol_attn_attention",
-    "sol_attn_begin_forward",
-    "sol_attn_hunyuan",
-    "sol_attn_supported",
 ]

--- a/tests/test_sol_attn_integration.py
+++ b/tests/test_sol_attn_integration.py
@@ -8,6 +8,7 @@ import sys
 import tomllib
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -36,6 +37,15 @@ def test_release_api_and_integration_defaults() -> None:
     assert backend._parse_layer_ranges("0,2-4,7") == frozenset(
         {0, 2, 3, 4, 7}
     )
+    assert set(backend.__all__) == {
+        "make_sol_attn_dispatch",
+        "make_mmdit_sol_attn_dispatch",
+    }
+    assert hasattr(backend, "_run_sol_attn_bthd")
+    assert hasattr(backend, "_run_mmdit_sol_attn_bthd")
+    assert not hasattr(backend, "sol_attn_attention")
+    assert not hasattr(backend, "sol_attn_hunyuan")
+    assert not hasattr(backend, "make_hunyuan_sol_attn_dispatch")
 
     interface = BACKENDS / "sol_attn" / "interface.py"
     tree = ast.parse(interface.read_text())
@@ -54,6 +64,91 @@ def test_release_api_and_integration_defaults() -> None:
     } <= keyword_names
 
 
+def test_sol_attn_backend_dispatch_contract() -> None:
+    interface = BACKENDS / "sol_attn" / "interface.py"
+    source = interface.read_text()
+    tree = ast.parse(source)
+
+    top_level_imports = {
+        alias.name
+        for node in tree.body
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    assert "cutlass.cute" not in top_level_imports
+    assert "cuda.bindings.driver" not in top_level_imports
+
+    dispatch = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_backend_for_arch"
+    )
+    namespace = {
+        "_CUTE_BACKENDS": {
+            (9, 0): "cute_sm90",
+            (10, 0): "cute_sm100",
+            (12, 0): "cute_sm120",
+        },
+        "_cute_runtime_available": lambda: True,
+    }
+    dispatch_module = ast.fix_missing_locations(
+        ast.Module(body=[dispatch], type_ignores=[])
+    )
+    exec(compile(dispatch_module, str(interface), "exec"), namespace)
+    backend_for_arch = namespace["_backend_for_arch"]
+    assert backend_for_arch((9, 0), cute_available=True) == "cute_sm90"
+    assert backend_for_arch((10, 0), cute_available=True) == "cute_sm100"
+    assert backend_for_arch((12, 0), cute_available=True) == "cute_sm120"
+    assert backend_for_arch((8, 0), cute_available=True) == "triton"
+    assert backend_for_arch((8, 9), cute_available=True) == "triton"
+    assert backend_for_arch((9, 0), cute_available=False) == "triton"
+    assert backend_for_arch((10, 0), cute_available=False) == "triton"
+    assert backend_for_arch((12, 0), cute_available=False) == "triton"
+
+    triton_forward = (
+        BACKENDS / "sol_attn" / "triton_ref" / "fwd.py"
+    ).read_text()
+    triton_preprocess = (
+        BACKENDS / "sol_attn" / "triton_ref" / "preprocess.py"
+    ).read_text()
+    assert "_forward_tma" in triton_forward
+    assert "_forward_ptr" in triton_forward
+    assert "TensorDescriptor" in triton_forward
+    assert "TensorDescriptor" not in triton_preprocess
+    assert "from ..preprocess import prepare as prepare_tma" in triton_forward
+    assert "from .preprocess import prepare as prepare_ptr" in triton_forward
+    assert "HAS_SINK: tl.constexpr" in triton_forward
+    assert "if HAS_SINK:" in triton_forward
+    assert "_pad_to_block" not in triton_forward
+    assert "tokens % BLOCK == 0" not in triton_forward
+
+    backend_source = (BACKENDS / "sol_attn_backend.py").read_text()
+    assert "arch[0] >= 8" in backend_source
+
+    bf16 = object()
+    fake_torch = SimpleNamespace(
+        bfloat16=bf16,
+        cuda=SimpleNamespace(
+            get_device_capability=lambda _device: (8, 9),
+        ),
+    )
+    fake_q = SimpleNamespace(
+        is_cuda=True,
+        ndim=4,
+        shape=(1, 256, 2, 128),
+        dtype=bf16,
+        device="cuda:0",
+    )
+    backend = load_backend()
+    with patch.dict(sys.modules, {"torch": fake_torch}):
+        assert backend.sol_attn_supported(fake_q)
+        fake_torch.cuda.get_device_capability = lambda _device: (12, 0)
+        assert backend.sol_attn_supported(fake_q)
+        fake_torch.cuda.get_device_capability = lambda _device: (7, 5)
+        assert not backend.sol_attn_supported(fake_q)
+
+
 def test_only_one_sol_attn_backend_tree_remains() -> None:
     legacy = (
         "pisa_hyvideo",
@@ -69,9 +164,19 @@ def test_only_one_sol_attn_backend_tree_remains() -> None:
     assert (BACKENDS / "sol_attn" / "sm120").is_dir()
     readme = (BACKENDS / "README.md").read_text()
     assert "sink_start" in readme
-    assert "text query rows with dense attention" in " ".join(
-        readme.lower().split()
-    )
+    assert "RTX 4090" in readme and "SM89" in readme
+    assert "RTX 5090" in readme and "SM120" in readme
+    assert "A100" in readme and "SM80" in readme
+    assert "Triton research implementation" in readme
+    normalized_readme = " ".join(readme.lower().split())
+    assert "text-query rows" in normalized_readme
+    assert "dense" in normalized_readme
+
+    root_readme = (ROOT / "README.md").read_text()
+    root_readme = " ".join(root_readme.split())
+    assert "A100 (SM80)" in root_readme
+    assert "RTX 4090 (SM89)" in root_readme
+    assert "RTX 5090 (SM120)" in root_readme
 
 
 def test_sm120_is_eligible_and_keeps_single_kv_split(monkeypatch) -> None:
@@ -93,6 +198,12 @@ def test_sm120_is_eligible_and_keeps_single_kv_split(monkeypatch) -> None:
     assert backend.sol_attn_supported(q)
     assert backend._resolve_kv_splits(q, "auto") == 1
 
+    fake_torch.cuda.get_device_capability = lambda _device: (9, 0)
+    monkeypatch.setattr(backend, "_cute_runtime_available", lambda: True)
+    assert backend._resolve_kv_splits(q, "auto") == 4
+    monkeypatch.setattr(backend, "_cute_runtime_available", lambda: False)
+    assert backend._resolve_kv_splits(q, "auto") == 1
+
 
 def test_core_interface_defines_sm120_compile_dispatch() -> None:
     tree = ast.parse((BACKENDS / "sol_attn" / "interface.py").read_text())
@@ -103,8 +214,10 @@ def test_core_interface_defines_sm120_compile_dispatch() -> None:
     }
 
     assert "_compile_sm120" in functions
-    assert "(12, 0)" in ast.unparse(functions["_validate"])
-    assert "_compile_sm120" in ast.unparse(functions["sol_attn"])
+    assert "cute_sm120" in (
+        BACKENDS / "sol_attn" / "interface.py"
+    ).read_text()
+    assert "_compile_sm120" in ast.unparse(functions["_sol_attn_cute"])
 
 
 def test_model_callers_use_the_release_configuration() -> None:
@@ -123,7 +236,7 @@ def test_model_callers_use_the_release_configuration() -> None:
     )
     combined = "\n".join(path.read_text() for path in paths)
     assert all(token not in combined for token in forbidden)
-    assert "make_hunyuan_sol_attn_dispatch" in paths[0].read_text()
+    assert "make_mmdit_sol_attn_dispatch" in paths[0].read_text()
 
     sol_candidates = []
     for path in sorted((ROOT / "candidates").glob("*.toml")):


### PR DESCRIPTION
## Summary

- dispatch the public Sol-Attn API from the input GPU and optional CuTe DSL availability
- preserve the CuTe SM90, SM100, and newly merged SM120 fast paths on H100, B200, and RTX 5090
- use Triton on older supported GPUs such as A100 and RTX 4090, and as an automatic fallback when CuTe DSL is not installed
- keep the Triton implementation directly importable as a research/reference backend
- preserve descriptor-backed TMA on SM90 and newer for arbitrary sequence lengths; non-64-aligned tails use descriptor-managed zero padding rather than switching to the pointer path
- preserve the existing TMA preprocessing and online-softmax path; pointer preprocessing is isolated to devices where descriptor-backed TMA is unavailable
- add arbitrary exact KV sink ranges as a compile-time Triton specialization, so the no-sink TMA fast path has no runtime sink checks
- import CuTe DSL and cuda-python lazily so Triton-only installations do not require them
- document automatic backend selection, keep `sol_attn(...)` as the public kernel API, and expose only `make_sol_attn_dispatch(...)` / `make_mmdit_sol_attn_dispatch(...)` from the Sol-Engine integration module
- keep the BTHD and MMDiT runners private as `_run_sol_attn_bthd(...)` and `_run_mmdit_sol_attn_bthd(...)`
- retain the published HunyuanVideo and Wan2.1 speedups

## Automatic dispatch

| Device | Preferred backend | Fallback |
| --- | --- | --- |
| H100 (SM90) | CuTe SM90 | Triton TMA |
| B200 (SM100) | CuTe SM100 | Triton TMA |
| RTX 5090 (SM120) | CuTe SM120 | Triton TMA |
| A100 (SM80), RTX 4090 (SM89) | Triton pointer | — |
| Other NVIDIA GPUs with compute capability >= 8.0 | Triton | — |

The dispatcher selects the backend from `q.device`. CuTe is optional and only imported after the dispatcher selects a specialized CuTe path. Researchers can bypass automatic dispatch with `from sol_attn.triton_ref import sol_attn`.

## Validation

- dependency-light Sol-Attn integration tests: 6 passed
- Python syntax compilation and `git diff --check`: passed
- H100 no-sink A/B against the exact pre-PR Triton kernel: bitwise-identical output at `T=257`, `8192`, and the HunyuanVideo length `119056`
- H100 forward latency, new versus pre-PR: `0.01294` vs `0.01307` ms (`T=257`), `0.04981` vs `0.04966` ms (`T=8192`), and `3.46166` vs `3.45622` ms (`T=119056`); all differences are within 0.3%
- middle-position sink versus an independent block-sparse reference: max absolute error `0.001953125`, mean absolute error `1.2796e-4`
- full-sink TMA versus dense attention: max absolute error `0.001953125`, mean absolute error `1.1004e-4`
- forced pointer full sink versus dense attention: max absolute error `0.001953125`, mean absolute error `1.1189e-4`
