### PR TITLE
Add P19 lookahead to SM120 Sol-Attn

### DIFF
--- a/techniques/sparse_backends/sol_attn/sm120/kernel.py
+++ b/techniques/sparse_backends/sol_attn/sm120/kernel.py
@@ -3,8 +3,17 @@
 from .mainloop import SolAttnForwardSm120
 
 
-def make_kernel(*, debug_route_trace: bool = False):
-    return SolAttnForwardSm120(debug_route_trace=debug_route_trace)
+def make_kernel(
+    *,
+    debug_route_trace: bool = False,
+    prefetch_first_exact_k: bool = True,
+    prefetch_next_route_k: bool = True,
+):
+    return SolAttnForwardSm120(
+        debug_route_trace=debug_route_trace,
+        prefetch_first_exact_k=prefetch_first_exact_k,
+        prefetch_next_route_k=prefetch_next_route_k,
+    )
 
 
 __all__ = ["make_kernel"]

--- a/techniques/sparse_backends/sol_attn/sm120/mainloop.py
+++ b/techniques/sparse_backends/sol_attn/sm120/mainloop.py
@@ -38,7 +38,13 @@ STAGES = 1
 class SolAttnForwardSm120:
     """M64/N64 warp-MMA Sol-Attn kernel for BF16 D128 inputs."""
 
-    def __init__(self, *, debug_route_trace: bool = False):
+    def __init__(
+        self,
+        *,
+        debug_route_trace: bool = False,
+        prefetch_first_exact_k: bool = True,
+        prefetch_next_route_k: bool = True,
+    ):
         self.dtype = cutlass.BFloat16
         self.acc_dtype = cutlass.Float32
         self.tile_shape_qk = (M, N, D)
@@ -47,6 +53,8 @@ class SolAttnForwardSm120:
         self.q_stage = 1
         self.kv_stage = STAGES
         self.debug_route_trace = debug_route_trace
+        self.prefetch_first_exact_k = prefetch_first_exact_k
+        self.prefetch_next_route_k = prefetch_next_route_k
 
     @cute.kernel
     def kernel(
@@ -332,15 +340,50 @@ class SolAttnForwardSm120:
                 valid_blocks = cutlass.Int32(N)
 
             if warp == 0:
-                K_pipeline.producer_acquire(K_producer)
-                cute.copy(
-                    tma_atom_KC,
-                    tKCgKC[None, route_group],
-                    tKCsK[None, K_producer.index],
-                    tma_bar_ptr=K_pipeline.producer_get_barrier(K_producer),
-                )
-                K_pipeline.producer_commit(K_producer)
-                K_producer.advance()
+                if cutlass.const_expr(self.prefetch_next_route_k):
+                    # P19-style terminal handoff: when the previous route
+                    # group had an exact block, its final exact QK already
+                    # refilled this K stage with the current group's KC.
+                    if route_group == 0:
+                        K_pipeline.producer_acquire(K_producer)
+                        cute.copy(
+                            tma_atom_KC,
+                            tKCgKC[None, route_group],
+                            tKCsK[None, K_producer.index],
+                            tma_bar_ptr=K_pipeline.producer_get_barrier(
+                                K_producer
+                            ),
+                        )
+                        K_pipeline.producer_commit(K_producer)
+                        K_producer.advance()
+                    else:
+                        previous_group_exact_count = cutlass.Int32(
+                            route_meta[0]
+                        )
+                        if previous_group_exact_count == 0:
+                            K_pipeline.producer_acquire(K_producer)
+                            cute.copy(
+                                tma_atom_KC,
+                                tKCgKC[None, route_group],
+                                tKCsK[None, K_producer.index],
+                                tma_bar_ptr=K_pipeline.producer_get_barrier(
+                                    K_producer
+                                ),
+                            )
+                            K_pipeline.producer_commit(K_producer)
+                            K_producer.advance()
+                else:
+                    K_pipeline.producer_acquire(K_producer)
+                    cute.copy(
+                        tma_atom_KC,
+                        tKCgKC[None, route_group],
+                        tKCsK[None, K_producer.index],
+                        tma_bar_ptr=K_pipeline.producer_get_barrier(
+                            K_producer
+                        ),
+                    )
+                    K_pipeline.producer_commit(K_producer)
+                    K_producer.advance()
                 V_pipeline.producer_acquire(V_producer)
                 cute.copy(
                     tma_atom_VC,
@@ -439,6 +482,23 @@ class SolAttnForwardSm120:
 
             exact_count = cutlass.Int32(route_meta[0])
             has_approx = exact_count < valid_blocks
+            if cutlass.const_expr(self.prefetch_first_exact_k):
+                # Once routing identifies the first exact block, the route KC
+                # stage is free.  Refill it before the approximate softmax/PV
+                # so the first exact K transfer overlaps that work.
+                if warp == 0 and exact_count > 0:
+                    first_exact = cutlass.Int32(route_indices[0])
+                    K_pipeline.producer_acquire(K_producer)
+                    cute.copy(
+                        tma_atom_K,
+                        tKgK[None, first_exact],
+                        tKsK[None, K_producer.index],
+                        tma_bar_ptr=K_pipeline.producer_get_barrier(
+                            K_producer
+                        ),
+                    )
+                    K_pipeline.producer_commit(K_producer)
+                    K_producer.advance()
             v_wait = V_pipeline.consumer_try_wait(V_consumer)
             V_pipeline.consumer_wait(V_consumer, v_wait)
             if has_approx:
@@ -471,15 +531,18 @@ class SolAttnForwardSm120:
 
             if warp == 0 and exact_count > 0:
                 first_exact = cutlass.Int32(route_indices[0])
-                K_pipeline.producer_acquire(K_producer)
-                cute.copy(
-                    tma_atom_K,
-                    tKgK[None, first_exact],
-                    tKsK[None, K_producer.index],
-                    tma_bar_ptr=K_pipeline.producer_get_barrier(K_producer),
-                )
-                K_pipeline.producer_commit(K_producer)
-                K_producer.advance()
+                if cutlass.const_expr(not self.prefetch_first_exact_k):
+                    K_pipeline.producer_acquire(K_producer)
+                    cute.copy(
+                        tma_atom_K,
+                        tKgK[None, first_exact],
+                        tKsK[None, K_producer.index],
+                        tma_bar_ptr=K_pipeline.producer_get_barrier(
+                            K_producer
+                        ),
+                    )
+                    K_pipeline.producer_commit(K_producer)
+                    K_producer.advance()
                 V_pipeline.producer_acquire(V_producer)
                 cute.copy(
                     tma_atom_V,
@@ -505,19 +568,44 @@ class SolAttnForwardSm120:
                 K_pipeline.consumer_release(K_consumer)
                 K_consumer.advance()
                 next_ordinal = ordinal + cutlass.Int32(1)
-                if warp == 0 and next_ordinal < exact_count:
-                    next_exact = cutlass.Int32(route_indices[next_ordinal])
-                    K_pipeline.producer_acquire(K_producer)
-                    cute.copy(
-                        tma_atom_K,
-                        tKgK[None, next_exact],
-                        tKsK[None, K_producer.index],
-                        tma_bar_ptr=K_pipeline.producer_get_barrier(
-                            K_producer
-                        ),
-                    )
-                    K_pipeline.producer_commit(K_producer)
-                    K_producer.advance()
+                if warp == 0:
+                    if next_ordinal < exact_count:
+                        next_exact = cutlass.Int32(
+                            route_indices[next_ordinal]
+                        )
+                        K_pipeline.producer_acquire(K_producer)
+                        cute.copy(
+                            tma_atom_K,
+                            tKgK[None, next_exact],
+                            tKsK[None, K_producer.index],
+                            tma_bar_ptr=K_pipeline.producer_get_barrier(
+                                K_producer
+                            ),
+                        )
+                        K_pipeline.producer_commit(K_producer)
+                        K_producer.advance()
+                    else:
+                        if cutlass.const_expr(
+                            self.prefetch_next_route_k
+                        ):
+                            next_route_group = route_group + cutlass.Int32(1)
+                            if next_route_group < num_route_groups:
+                                # Reuse the K stage released by the final
+                                # exact QK.  The next outer prologue supplies
+                                # VC, matching the SM90 P19 partial handoff.
+                                K_pipeline.producer_acquire(K_producer)
+                                cute.copy(
+                                    tma_atom_KC,
+                                    tKCgKC[None, next_route_group],
+                                    tKCsK[None, K_producer.index],
+                                    tma_bar_ptr=(
+                                        K_pipeline.producer_get_barrier(
+                                            K_producer
+                                        )
+                                    ),
+                                )
+                                K_pipeline.producer_commit(K_producer)
+                                K_producer.advance()
                 block_len = token_count - exact_block * cutlass.Int32(N)
                 if block_len > N:
                     block_len = cutlass.Int32(N)

--- a/tests/test_sol_attn_integration.py
+++ b/tests/test_sol_attn_integration.py
@@ -220,6 +220,58 @@ def test_core_interface_defines_sm120_compile_dispatch() -> None:
     assert "_compile_sm120" in ast.unparse(functions["_sol_attn_cute"])
 
 
+def test_sm120_p19_lookahead_is_the_release_default() -> None:
+    sm120 = BACKENDS / "sol_attn" / "sm120"
+    mainloop_path = sm120 / "mainloop.py"
+    kernel_path = sm120 / "kernel.py"
+
+    mainloop_tree = ast.parse(mainloop_path.read_text())
+    kernel_tree = ast.parse(kernel_path.read_text())
+    mainloop_class = next(
+        node
+        for node in mainloop_tree.body
+        if isinstance(node, ast.ClassDef)
+        and node.name == "SolAttnForwardSm120"
+    )
+    constructor = next(
+        node
+        for node in mainloop_class.body
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+    )
+    make_kernel = next(
+        node
+        for node in kernel_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "make_kernel"
+    )
+
+    for function in (constructor, make_kernel):
+        defaults = {
+            arg.arg: default
+            for arg, default in zip(
+                function.args.kwonlyargs,
+                function.args.kw_defaults,
+            )
+        }
+        for flag in (
+            "prefetch_first_exact_k",
+            "prefetch_next_route_k",
+        ):
+            assert isinstance(defaults[flag], ast.Constant)
+            assert defaults[flag].value is True
+
+    source = mainloop_path.read_text()
+    first_exact_prefetch = source.index(
+        "if cutlass.const_expr(self.prefetch_first_exact_k):"
+    )
+    approximate_v_wait = source.index(
+        "v_wait = V_pipeline.consumer_try_wait(V_consumer)",
+        first_exact_prefetch,
+    )
+    assert first_exact_prefetch < approximate_v_wait
+    assert "previous_group_exact_count" in source
+    assert "tKCgKC[None, next_route_group]" in source
+
+
 def test_model_callers_use_the_release_configuration() -> None:
     forbidden = (
         "HUNYUAN_SOL_V2",


### PR DESCRIPTION
## Summary

- prefetch the first exact K tile while the approximate softmax/PV phase runs
- reuse the K stage released by the final exact QK to fetch the next G64 KC tile
- keep next-group VC in its existing prologue and preserve the general ragged/sink path
- make both P19 pieces the SM120 release defaults, with compile-time switches for A/B and rollback
- add a dependency-light release-contract test

## Why

The SM120 kernel previously serialized the first exact K transfer after approximate PV and reloaded the next route KC in the following group prologue. This ports the proven SM90 P19 handoff without adding sequence-length, density, or sink-specific dispatch.

## RTX 5090 validation

BF16, B=1, H=32, D=128, same-process rotating CUDA-event A/B:

| Tokens | Exact density | Before | P19 | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| 8,192 | 14.9334% | 0.877312 ms | 0.873184 ms | 1.00473x |
| 65,536 | 13.2246% | 47.474064 ms | 47.157631 ms | 1.00671x |
| 131,072 | 13.0937% | 189.553276 ms | 188.213936 ms | 1.00712x |

At 64K, calibrated 5% / 10% / 15% exact density improves by 1.01821x / 1.00990x / 1.00592x.

Correctness:
- output and LSE are bitwise identical to the pre-lookahead path
- T=8192, H=2 route trace: 0/1024 word mismatches
- T=2050, H=2 ragged tail passes
- 32/32 sink boundary cases pass

## Checks

- SM120 mainloop and kernel compile with `py_compile`
- `tests/test_sol_attn_integration.py`: 7 passed
- production SM120 source hashes match the RTX 5090-validated A009 source
