### PR TITLE
Publish Sol-Attn on Hugging Face Kernel Hub

### DIFF
--- a/.github/workflows/publish-sol-attn-kernel.yml
+++ b/.github/workflows/publish-sol-attn-kernel.yml
@@ -1,0 +1,80 @@
+name: Publish Sol-Attn kernel
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_gpu_tests:
+        description: Test the uploaded kernel on the available GPU architectures
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-sol-attn-kernel
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and upload with HF Jobs
+        uses: huggingface/kernel-builder-job@main
+        with:
+          token: ${{ secrets.HF_TOKEN }}
+          namespace: ${{ vars.SOL_ATTN_HF_JOBS_NAMESPACE || 'Efficient-Large-Model' }}
+          flavor: cpu-xl
+          timeout: "21600"
+          script: |
+            set +x
+            export HF_TOKEN="${{ secrets.HF_TOKEN }}"
+            export GIT_LFS_SKIP_SMUDGE=1
+
+            git clone "${{ github.server_url }}/${{ github.repository }}" Sana
+            cd Sana
+            git checkout "${{ github.sha }}"
+
+            python kernels/sol-attn/prepare.py \
+              --output /tmp/sol-attn-kernel \
+              --source-commit "${{ github.sha }}"
+
+            git -C /tmp/sol-attn-kernel init
+            git -C /tmp/sol-attn-kernel config user.name "Sol-Attn Builder"
+            git -C /tmp/sol-attn-kernel config user.email "sol-attn-builder@noreply.github.com"
+            git -C /tmp/sol-attn-kernel add .
+            git -C /tmp/sol-attn-kernel commit -m "Package Sol-Attn from ${{ github.sha }}"
+
+            kernel-builder check-config /tmp/sol-attn-kernel
+            kernel-builder build-and-upload \
+              --max-jobs 4 \
+              --cores 8 \
+              --repo-id Efficient-Large-Model/sol-attn \
+              /tmp/sol-attn-kernel
+
+  test:
+    if: ${{ inputs.run_gpu_tests }}
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [a100-large, h200, rtx-pro-6000]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test uploaded kernel on ${{ matrix.flavor }}
+        uses: huggingface/hf-jobs-action@main
+        with:
+          token: ${{ secrets.HF_TOKEN }}
+          namespace: ${{ vars.SOL_ATTN_HF_JOBS_NAMESPACE || 'Efficient-Large-Model' }}
+          flavor: ${{ matrix.flavor }}
+          image: ghcr.io/astral-sh/uv:python3.12-bookworm
+          timeout: "3600"
+          files: kernels/sol-attn/scripts/test_hub.py
+          script: |
+            set +x
+            export HF_TOKEN="${{ secrets.HF_TOKEN }}"
+            export SOL_ATTN_HF_REPO="Efficient-Large-Model/sol-attn"
+            uv run /tmp/files/test_hub.py

--- a/kernels/sol-attn/CARD.md
+++ b/kernels/sol-attn/CARD.md
@@ -1,0 +1,55 @@
+---
+library_name: kernels
+{% if license %}license: {{ license }}
+{% endif %}tags:
+- kernels
+- cuda
+- attention
+- triton
+- cute-dsl
+---
+
+# Sol-Attn
+
+Sol-Attn accelerates image and video generation with on-the-fly attention
+sparsification. It automatically dispatches to CuTe DSL kernels on SM90,
+SM100, and SM120, and to Triton on SM80 and SM89 or when CuTe DSL is not
+available.
+
+## Usage
+
+```python
+from kernels import get_kernel
+
+kernel = get_kernel(
+    "{{ repo_id }}",
+    version={{ version }},
+    trust_remote_code=True,
+)
+
+out = kernel.sol_attn(
+    q,  # Contiguous BF16 [batch, tokens, heads, 128].
+    k,  # Same shape, dtype, layout, and device as q.
+    v,  # Same shape, dtype, layout, and device as q.
+    tau=1.0,
+    thresh_type="exact",
+)
+```
+
+The released implementation is noncausal and forward-only. An optional exact
+KV sink is available through `sink_start` and `sink_tokens`.
+
+## Backends
+
+| Architecture | Example GPU | Backend |
+|---|---|---|
+| SM90 | H100 | CuTe DSL |
+| SM100 | GB200 | CuTe DSL |
+| SM120 | RTX 5090 | CuTe DSL |
+| SM80 / SM89 | A100 / RTX 4090 | Triton |
+
+## Paper and source
+
+- [Paper](https://arxiv.org/abs/2607.24027)
+- [Source](https://github.com/NVlabs/Sana/tree/sol-engine/techniques/sparse_backends/sol_attn)
+- [Documentation](https://nvlabs.github.io/Sana/Sol-Engine/docs/techniques/sparse/)

--- a/kernels/sol-attn/README.md
+++ b/kernels/sol-attn/README.md
@@ -1,0 +1,27 @@
+# Sol-Attn Hub packaging
+
+This directory contains the Hugging Face Kernel Hub metadata, tests, and
+publishing workflow inputs for Sol-Attn. The maintained implementation remains
+in `techniques/sparse_backends/sol_attn`; `prepare.py` copies that exact tree
+into the `torch-ext/sol_attn` layout expected by `kernel-builder`.
+
+Prepare a local source tree with:
+
+```bash
+python kernels/sol-attn/prepare.py --output /tmp/sol-attn-kernel
+kernel-builder check-config /tmp/sol-attn-kernel
+```
+
+The `Publish Sol-Attn kernel` GitHub Actions workflow builds and uploads
+version 1 to `Efficient-Large-Model/sol-attn`, then tests the uploaded package
+on A100, H200, and RTX PRO 6000 GPU jobs.
+
+The repository must provide:
+
+- an `HF_TOKEN` Actions secret with `job.write` and permission to create or
+  update kernels in `Efficient-Large-Model`;
+- optionally, a `SOL_ATTN_HF_JOBS_NAMESPACE` Actions variable when Jobs should
+  consume quota from a namespace other than `Efficient-Large-Model`.
+
+The workflow is manual for the first release. Trigger it from the Actions tab
+after the Hub organization permissions are confirmed.

--- a/kernels/sol-attn/build.toml
+++ b/kernels/sol-attn/build.toml
@@ -1,0 +1,19 @@
+[general]
+name = "sol-attn"
+version = 1
+edition = 5
+license = "Apache-2.0"
+backends = ["cuda"]
+upstream = "https://github.com/NVlabs/Sana.git"
+
+[general.cuda]
+minver = "12.8"
+python-depends = ["nvidia-cutlass-dsl"]
+
+[general.hub]
+repo-id = "Efficient-Large-Model/sol-attn"
+
+[torch-noarch]
+cuda-capabilities = ["8.0", "8.9", "9.0", "10.0", "12.0"]
+
+[kernel]

--- a/kernels/sol-attn/flake.lock
+++ b/kernels/sol-attn/flake.lock
@@ -1,0 +1,117 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "kernel-builder": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1785782967,
+        "narHash": "sha256-5Esv3PsgzKfP6I3Te1n4Ge4kQG69WQETPJoxGB9WKpk=",
+        "owner": "huggingface",
+        "repo": "kernels",
+        "rev": "a6564d1f481adcbd3273099c0f4432e7b833e846",
+        "type": "github"
+      },
+      "original": {
+        "owner": "huggingface",
+        "repo": "kernels",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1783284758,
+        "narHash": "sha256-tiQ8/qi8I45OOaBBYlVbXoAVkeQzvvTQOv5I45rMw5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ec1a11210589d294f0ac99d3290a27e6c73dfa1d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ec1a11210589d294f0ac99d3290a27e6c73dfa1d",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "kernel-builder": "kernel-builder"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "kernel-builder",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783320166,
+        "narHash": "sha256-l7C/OsjcnWDOk2K3ssj+SBduwL67LashjBqis9+t468=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "20ee15370c9256669d66968b89ee20a4b0a4e673",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/kernels/sol-attn/flake.nix
+++ b/kernels/sol-attn/flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "Flake for Sol-Attn kernels";
+
+  inputs = {
+    kernel-builder.url = "github:huggingface/kernels";
+  };
+
+  outputs =
+    {
+      self,
+      kernel-builder,
+    }:
+    kernel-builder.lib.genKernelFlakeOutputs {
+      inherit self;
+      path = ./.;
+    };
+}

--- a/kernels/sol-attn/prepare.py
+++ b/kernels/sol-attn/prepare.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Stage the maintained Sol-Engine package for Hugging Face kernel-builder."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+
+
+PACKAGE_FILES = (
+    "build.toml",
+    "CARD.md",
+    "flake.lock",
+    "flake.nix",
+    "README.md",
+)
+
+
+def _source_commit(repository: Path) -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository,
+        text=True,
+    ).strip()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--source-commit")
+    args = parser.parse_args()
+
+    package_root = Path(__file__).resolve().parent
+    repository = package_root.parents[1]
+    source = repository / "techniques" / "sparse_backends" / "sol_attn"
+    output = args.output.resolve()
+
+    if output.exists() and any(output.iterdir()):
+        parser.error(f"output directory is not empty: {output}")
+    output.mkdir(parents=True, exist_ok=True)
+
+    for name in PACKAGE_FILES:
+        shutil.copy2(package_root / name, output / name)
+    ignored = shutil.ignore_patterns("__pycache__", "*.pyc", "._*")
+    shutil.copytree(
+        package_root / "tests",
+        output / "tests",
+        ignore=ignored,
+    )
+    shutil.copytree(
+        source,
+        output / "torch-ext" / "sol_attn",
+        ignore=ignored,
+    )
+
+    source_commit = args.source_commit or _source_commit(repository)
+    (output / "SOURCE_COMMIT").write_text(source_commit + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/kernels/sol-attn/scripts/test_hub.py
+++ b/kernels/sol-attn/scripts/test_hub.py
@@ -1,0 +1,58 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["kernels[curated]>=0.16.0", "torch>=2.10"]
+# ///
+
+import os
+
+import torch
+import torch.nn.functional as F
+from kernels import get_kernel
+
+
+repo_id = os.environ.get(
+    "SOL_ATTN_HF_REPO",
+    "Efficient-Large-Model/sol-attn",
+)
+kernel = get_kernel(repo_id, version=1, trust_remote_code=True)
+
+torch.manual_seed(42)
+q = torch.randn(1, 256, 4, 128, device="cuda", dtype=torch.bfloat16)
+k = torch.randn_like(q)
+v = torch.randn_like(q)
+
+expected = F.scaled_dot_product_attention(
+    q.transpose(1, 2),
+    k.transpose(1, 2),
+    v.transpose(1, 2),
+).transpose(1, 2)
+actual = kernel.sol_attn(
+    q,
+    k,
+    v,
+    tau=1.0,
+    thresh_type="exact",
+    sink_start=0,
+    sink_tokens=q.shape[1],
+)
+torch.testing.assert_close(actual, expected, atol=2e-2, rtol=3e-2)
+
+sparse = kernel.sol_attn(
+    q,
+    k,
+    v,
+    tau=1.0,
+    thresh_type="exact",
+)
+assert sparse.shape == q.shape
+assert sparse.dtype == q.dtype
+assert torch.isfinite(sparse).all()
+
+print(
+    {
+        "repo_id": repo_id,
+        "gpu": torch.cuda.get_device_name(),
+        "capability": torch.cuda.get_device_capability(),
+        "max_abs_full_sink": (actual.float() - expected.float()).abs().max().item(),
+    }
+)

--- a/kernels/sol-attn/tests/test_kernel.py
+++ b/kernels/sol-attn/tests/test_kernel.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import sol_attn
+from sol_attn import interface
+from sol_attn.triton_ref import sol_attn as triton_sol_attn
+
+
+def _inputs(tokens=256, heads=4):
+    torch.manual_seed(42)
+    q = torch.randn(
+        1,
+        tokens,
+        heads,
+        128,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    return q, torch.randn_like(q), torch.randn_like(q)
+
+
+def test_package_uses_isolation_safe_imports():
+    package_root = Path(sol_attn.__file__).resolve().parent
+    offenders = []
+    for path in package_root.rglob("*.py"):
+        if path.name.startswith("._"):
+            continue
+        for line_number, line in enumerate(path.read_text().splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("from sol_attn") or stripped.startswith(
+                "import sol_attn"
+            ):
+                offenders.append(f"{path.relative_to(package_root)}:{line_number}")
+    assert offenders == []
+
+
+def test_backend_dispatch_contract():
+    assert interface._backend_for_arch((8, 0), cute_available=True) == "triton"
+    assert interface._backend_for_arch((8, 9), cute_available=True) == "triton"
+    assert interface._backend_for_arch((9, 0), cute_available=True) == "cute_sm90"
+    assert interface._backend_for_arch((10, 0), cute_available=True) == "cute_sm100"
+    assert interface._backend_for_arch((12, 0), cute_available=True) == "cute_sm120"
+    assert interface._backend_for_arch((9, 0), cute_available=False) == "triton"
+    assert interface._backend_for_arch((10, 0), cute_available=False) == "triton"
+    assert interface._backend_for_arch((12, 0), cute_available=False) == "triton"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_full_sink_matches_sdpa():
+    if torch.cuda.get_device_capability()[0] < 8:
+        pytest.skip("Sol-Attn requires compute capability 8.0 or newer")
+
+    q, k, v = _inputs()
+    expected = F.scaled_dot_product_attention(
+        q.transpose(1, 2),
+        k.transpose(1, 2),
+        v.transpose(1, 2),
+    ).transpose(1, 2)
+    actual = sol_attn.sol_attn(
+        q,
+        k,
+        v,
+        tau=1.0,
+        thresh_type="exact",
+        sink_start=0,
+        sink_tokens=q.shape[1],
+    )
+
+    torch.testing.assert_close(actual, expected, atol=2e-2, rtol=3e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_sparse_matches_triton_reference():
+    if torch.cuda.get_device_capability()[0] < 8:
+        pytest.skip("Sol-Attn requires compute capability 8.0 or newer")
+
+    q, k, v = _inputs()
+    expected = triton_sol_attn(
+        q,
+        k,
+        v,
+        tau=1.0,
+        thresh_type="exact",
+    )
+    actual = sol_attn.sol_attn(
+        q,
+        k,
+        v,
+        tau=1.0,
+        thresh_type="exact",
+    )
+
+    torch.testing.assert_close(actual, expected, atol=2e-2, rtol=3e-2)

--- a/techniques/sparse_backends/sol_attn/_vendor/flash_attn/cute/block_info.py
+++ b/techniques/sparse_backends/sol_attn/_vendor/flash_attn/cute/block_info.py
@@ -6,7 +6,7 @@ import cutlass
 import cutlass.cute as cute
 from cutlass import Int32, const_expr
 
-from sol_attn._vendor.flash_attn.cute.seqlen_info import SeqlenInfoQK, SeqlenInfoQKNewK
+from .seqlen_info import SeqlenInfoQK, SeqlenInfoQKNewK
 
 
 @dataclass(frozen=True)

--- a/techniques/sparse_backends/sol_attn/_vendor/flash_attn/cute/block_sparsity.py
+++ b/techniques/sparse_backends/sol_attn/_vendor/flash_attn/cute/block_sparsity.py
@@ -7,7 +7,7 @@ from typing import Callable, NamedTuple, Tuple
 import cutlass.cute as cute
 import torch
 
-from sol_attn._vendor.flash_attn.cute.cute_dsl_utils import get_broadcast_dims, to_cute_tensor
+from .cute_dsl_utils import get_broadcast_dims, to_cute_tensor
 
 
 def ceildiv(a: int, b: int) -> int:

--- a/techniques/sparse_backends/sol_attn/_vendor/flash_attn/cute/flash_fwd.py
+++ b/techniques/sparse_backends/sol_attn/_vendor/flash_attn/cute/flash_fwd.py
@@ -20,20 +20,20 @@ import cutlass.utils as utils_basic
 from cutlass.base_dsl.arch import Arch
 from cutlass.cutlass_dsl import BaseDSL
 
-from sol_attn.sm90._compat import copy_utils
-from sol_attn.sm90._compat import layout_utils
+from ....sm90._compat import copy_utils
+from ....sm90._compat import layout_utils
 
-from sol_attn._vendor.flash_attn.cute import ampere_helpers as sm80_utils
-from sol_attn._vendor.flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
-from sol_attn._vendor.flash_attn.cute import utils
-from sol_attn._vendor.flash_attn.cute.mask import AttentionMask
-from sol_attn._vendor.flash_attn.cute.softmax import Softmax
-from sol_attn._vendor.flash_attn.cute.seqlen_info import SeqlenInfoQK
-from sol_attn._vendor.flash_attn.cute.block_info import BlockInfo
-from sol_attn._vendor.flash_attn.cute.pack_gqa import PackGQA
-from sol_attn._vendor.flash_attn.cute.named_barrier import NamedBarrierFwd
-from sol_attn._vendor.flash_attn.cute.block_sparsity import BlockSparseTensors
-from sol_attn._vendor.flash_attn.cute.tile_scheduler import (
+from . import ampere_helpers as sm80_utils
+from .cute_dsl_utils import assume_tensor_aligned
+from . import utils
+from .mask import AttentionMask
+from .softmax import Softmax
+from .seqlen_info import SeqlenInfoQK
+from .block_info import BlockInfo
+from .pack_gqa import PackGQA
+from .named_barrier import NamedBarrierFwd
+from .block_sparsity import BlockSparseTensors
+from .tile_scheduler import (
     SingleTileScheduler,
     SingleTileVarlenScheduler,
     TileSchedulerArguments,

--- a/techniques/sparse_backends/sol_attn/_vendor/flash_attn/cute/mask.py
+++ b/techniques/sparse_backends/sol_attn/_vendor/flash_attn/cute/mask.py
@@ -7,9 +7,9 @@ import cutlass
 import cutlass.cute as cute
 from cutlass import Float32, Int32, Uint32, const_expr
 
-from sol_attn.sm90._compat import layout_utils
-import sol_attn._vendor.flash_attn.cute.utils as utils
-from sol_attn._vendor.flash_attn.cute.seqlen_info import SeqlenInfoQK
+from ....sm90._compat import layout_utils
+from . import utils
+from .seqlen_info import SeqlenInfoQK
 
 MaskGenFn: TypeAlias = Callable[[int], Uint32]
 MASK_R2P_CHUNK_SIZE: int = 32

--- a/techniques/sparse_backends/sol_attn/_vendor/flash_attn/cute/pack_gqa.py
+++ b/techniques/sparse_backends/sol_attn/_vendor/flash_attn/cute/pack_gqa.py
@@ -8,8 +8,8 @@ import cutlass.cute as cute
 from cutlass.cute.nvgpu import cpasync
 
 
-from sol_attn.sm90._compat import layout_utils
-import sol_attn._vendor.flash_attn.cute.utils as utils
+from ....sm90._compat import layout_utils
+from . import utils
 
 
 def pack_gqa_layout(T, qhead_per_kvhead, nheads_kv, head_idx):

--- a/techniques/sparse_backends/sol_attn/_vendor/flash_attn/cute/seqlen_info.py
+++ b/techniques/sparse_backends/sol_attn/_vendor/flash_attn/cute/seqlen_info.py
@@ -5,7 +5,7 @@ import cutlass
 import cutlass.cute as cute
 from cutlass import Int32, const_expr
 
-from sol_attn.sm90._compat import copy_utils
+from ....sm90._compat import copy_utils
 
 """
 This consolidates all the info related to sequence length. This is so that we can do all

--- a/techniques/sparse_backends/sol_attn/_vendor/flash_attn/cute/softmax.py
+++ b/techniques/sparse_backends/sol_attn/_vendor/flash_attn/cute/softmax.py
@@ -9,10 +9,10 @@ import cutlass
 import cutlass.cute as cute
 from cutlass import Float32
 
-from sol_attn.sm90._compat import layout_utils
-import sol_attn._vendor.flash_attn.cute.utils as utils
-from sol_attn.sm90._compat.cute_dsl_utils import ParamsBase
-from sol_attn._vendor.flash_attn.cute.seqlen_info import SeqlenInfoQK
+from ....sm90._compat import layout_utils
+from . import utils
+from ....sm90._compat.cute_dsl_utils import ParamsBase
+from .seqlen_info import SeqlenInfoQK
 
 
 @dataclass

--- a/techniques/sparse_backends/sol_attn/_vendor/flash_attn/cute/tile_scheduler.py
+++ b/techniques/sparse_backends/sol_attn/_vendor/flash_attn/cute/tile_scheduler.py
@@ -17,10 +17,10 @@ from cutlass import Int32, const_expr
 from cutlass.cute import FastDivmodDivisor
 from cutlass.utils import ClcDynamicPersistentTileScheduler, ClcDynamicPersistentTileSchedulerParams
 
-from sol_attn.sm90._compat.cute_dsl_utils import ParamsBase
+from ....sm90._compat.cute_dsl_utils import ParamsBase
 
-import sol_attn._vendor.flash_attn.cute.utils as utils
-from sol_attn._vendor.flash_attn.cute.fast_math import clz
+from . import utils
+from .fast_math import clz
 
 
 class SchedulingMode(IntEnum):

--- a/techniques/sparse_backends/sol_attn/_vendor/flash_attn/cute/utils.py
+++ b/techniques/sparse_backends/sol_attn/_vendor/flash_attn/cute/utils.py
@@ -16,7 +16,7 @@ from cutlass._mlir.dialects import nvvm, llvm
 from cutlass.cute.runtime import from_dlpack
 
 
-from sol_attn.sm90._compat import activation
+from ....sm90._compat import activation
 
 _MIXER_ATTRS = ("__vec_size__",)
 

--- a/techniques/sparse_backends/sol_attn/sm100/mainloop.py
+++ b/techniques/sparse_backends/sol_attn/sm100/mainloop.py
@@ -12,13 +12,13 @@ import cutlass.cute as cute
 import cutlass.pipeline as pipeline
 import cutlass.utils as utils
 import cutlass.utils.blackwell_helpers as sm100_utils
-import sol_attn._vendor.flash_attn.cute.pipeline as fa_pipeline
-import sol_attn._vendor.flash_attn.cute.utils as fa_utils
+from .._vendor.flash_attn.cute import pipeline as fa_pipeline
+from .._vendor.flash_attn.cute import utils as fa_utils
 from cutlass import BFloat16, Float32, Int32
 from cutlass._mlir.dialects import llvm
 from cutlass.cute.nvgpu import cpasync, tcgen05
 from cutlass.cutlass_dsl import T, dsl_user_op
-from sol_attn._vendor.flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
+from .._vendor.flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
 
 from .softmax import (
     _load_m64_n128_score as _load_pair_score,
@@ -27,8 +27,8 @@ from .softmax import (
 )
 from . import math as mma_utils
 
-from sol_attn.common import layout_utils
-from sol_attn.common.selector import (
+from ..common import layout_utils
+from ..common.selector import (
     sol_attn_popc_b32,
     sol_attn_route_is_exact,
 )

--- a/techniques/sparse_backends/sol_attn/sm100/softmax.py
+++ b/techniques/sparse_backends/sol_attn/sm100/softmax.py
@@ -7,7 +7,7 @@ import cutlass.cute as cute
 from cutlass import Float32, Int32
 from cutlass.cute.nvgpu import tcgen05
 
-from sol_attn._vendor.flash_attn.cute import utils as fa_utils
+from .._vendor.flash_attn.cute import utils as fa_utils
 
 from .tmem import (
     _add_physical_tmem_base,

--- a/techniques/sparse_backends/sol_attn/sm120/mainloop.py
+++ b/techniques/sparse_backends/sol_attn/sm120/mainloop.py
@@ -19,9 +19,9 @@ import cutlass.pipeline as pipeline
 import cutlass.utils as utils
 import cutlass.utils.hopper_helpers as sm90_utils
 
-from sol_attn._vendor.flash_attn.cute import utils as kernel_utils
-from sol_attn.common import layout_utils
-from sol_attn.common.selector import (
+from .._vendor.flash_attn.cute import utils as kernel_utils
+from ..common import layout_utils
+from ..common.selector import (
     sol_attn_popc_b32,
     sol_attn_route_is_exact,
 )

--- a/techniques/sparse_backends/sol_attn/sm90/_compat/layout_utils.py
+++ b/techniques/sparse_backends/sol_attn/sm90/_compat/layout_utils.py
@@ -1,3 +1,3 @@
 """Compatibility import for shared CuTe layout helpers."""
 
-from sol_attn.common.layout_utils import *  # noqa: F403
+from ...common.layout_utils import *  # noqa: F403

--- a/techniques/sparse_backends/sol_attn/sm90/exact.py
+++ b/techniques/sparse_backends/sol_attn/sm90/exact.py
@@ -9,7 +9,7 @@ import cutlass
 import cutlass.cute as cute
 from cutlass import Int32, const_expr
 
-from sol_attn.common import selector
+from ..common import selector
 
 
 @cute.jit

--- a/techniques/sparse_backends/sol_attn/sm90/mainloop.py
+++ b/techniques/sparse_backends/sol_attn/sm90/mainloop.py
@@ -21,27 +21,27 @@ from ._compat import copy_utils
 from ._compat import layout_utils
 from ._compat import sm90_utils
 
-from sol_attn._vendor.flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
-from sol_attn._vendor.flash_attn.cute import utils
-from sol_attn._vendor.flash_attn.cute.mask import AttentionMask
-from sol_attn._vendor.flash_attn.cute.softmax import Softmax, apply_score_mod_inner
-from sol_attn._vendor.flash_attn.cute.seqlen_info import SeqlenInfoQK
-from sol_attn._vendor.flash_attn.cute.block_info import BlockInfo
-from sol_attn._vendor.flash_attn.cute.block_sparsity import BlockSparseTensors
-from sol_attn._vendor.flash_attn.cute import pipeline as pipeline_custom
-from sol_attn._vendor.flash_attn.cute.pack_gqa import PackGQA, pack_gqa_layout, make_packgqa_tiled_tma_atom
-from sol_attn._vendor.flash_attn.cute.named_barrier import NamedBarrierFwd
+from .._vendor.flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
+from .._vendor.flash_attn.cute import utils
+from .._vendor.flash_attn.cute.mask import AttentionMask
+from .._vendor.flash_attn.cute.softmax import Softmax, apply_score_mod_inner
+from .._vendor.flash_attn.cute.seqlen_info import SeqlenInfoQK
+from .._vendor.flash_attn.cute.block_info import BlockInfo
+from .._vendor.flash_attn.cute.block_sparsity import BlockSparseTensors
+from .._vendor.flash_attn.cute import pipeline as pipeline_custom
+from .._vendor.flash_attn.cute.pack_gqa import PackGQA, pack_gqa_layout, make_packgqa_tiled_tma_atom
+from .._vendor.flash_attn.cute.named_barrier import NamedBarrierFwd
 from ._compat.cute_dsl_utils import ParamsBase
-from sol_attn._vendor.flash_attn.cute.tile_scheduler import (
+from .._vendor.flash_attn.cute.tile_scheduler import (
     TileSchedulerArguments,
     SingleTileScheduler,
     SingleTileLPTScheduler,
     SingleTileVarlenScheduler,
 )
-from sol_attn._vendor.flash_attn.cute.flash_fwd import FlashAttentionForwardBase
+from .._vendor.flash_attn.cute.flash_fwd import FlashAttentionForwardBase
 from . import atoms as sol_attn_atoms
 from . import exact as exact_stream
-from sol_attn.common import selector as sol_attn_selector
+from ..common import selector as sol_attn_selector
 
 
 SOL_ATTN_ROUTE_MASK_BARRIER_ID = 7

--- a/techniques/sparse_backends/sol_attn/sm90/split_combine.py
+++ b/techniques/sparse_backends/sol_attn/sm90/split_combine.py
@@ -14,9 +14,9 @@ import cutlass.cute as cute
 from cutlass.cute.nvgpu import cpasync
 from cutlass import Float32, Int32, Boolean, const_expr
 
-from sol_attn._vendor.flash_attn.cute import utils
-from sol_attn._vendor.flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
-from sol_attn._vendor.flash_attn.cute.seqlen_info import SeqlenInfo
+from .._vendor.flash_attn.cute import utils
+from .._vendor.flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
+from .._vendor.flash_attn.cute.seqlen_info import SeqlenInfo
 from cutlass.cute import FastDivmodDivisor
 
 

--- a/techniques/sparse_backends/sol_attn/triton_ref/fwd.py
+++ b/techniques/sparse_backends/sol_attn/triton_ref/fwd.py
@@ -9,7 +9,7 @@ try:
 except ImportError:  # Pointer path remains usable without descriptors.
     TensorDescriptor = None
 
-from sol_attn.interface import (
+from ..interface import (
     _sink_block_range,
     _validate_inputs,
 )

--- a/tests/test_sol_attn_integration.py
+++ b/tests/test_sol_attn_integration.py
@@ -179,6 +179,45 @@ def test_only_one_sol_attn_backend_tree_remains() -> None:
     assert "RTX 5090 (SM120)" in root_readme
 
 
+def test_sol_attn_package_uses_relative_self_imports() -> None:
+    package = BACKENDS / "sol_attn"
+    offenders = []
+    for path in package.rglob("*.py"):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.level == 0:
+                names = [node.module or ""]
+            else:
+                continue
+            if any(name == "sol_attn" or name.startswith("sol_attn.") for name in names):
+                offenders.append(str(path.relative_to(package)))
+    assert offenders == []
+
+
+def test_hf_kernel_packaging_contract() -> None:
+    package = ROOT / "kernels" / "sol-attn"
+    build = tomllib.loads((package / "build.toml").read_text())
+    assert build["general"]["hub"]["repo-id"] == (
+        "Efficient-Large-Model/sol-attn"
+    )
+    assert build["general"]["cuda"]["python-depends"] == [
+        "nvidia-cutlass-dsl"
+    ]
+    assert build["torch-noarch"]["cuda-capabilities"] == [
+        "8.0",
+        "8.9",
+        "9.0",
+        "10.0",
+        "12.0",
+    ]
+    assert (package / "CARD.md").is_file()
+    assert (package / "flake.lock").is_file()
+    assert (package / "flake.nix").is_file()
+    assert (package / "prepare.py").is_file()
+
+
 def test_sm120_is_eligible_and_keeps_single_kv_split(monkeypatch) -> None:
     backend = load_backend()
     bf16 = object()


### PR DESCRIPTION
## Summary

- add Hugging Face Kernel Hub metadata and a reproducible staging step for the maintained Sol-Engine implementation
- publish version 1 to `Efficient-Large-Model/sol-attn` through a manually triggered HF Jobs workflow
- test the uploaded package on A100, H200, and RTX PRO 6000
- convert package-internal imports to relative imports so Hub version isolation works correctly

The kernel implementation continues to have a single source of truth under `techniques/sparse_backends/sol_attn`; the publishing step creates the required `torch-ext/sol_attn` layout without checking in a second source copy.

## Why

Hugging Face Kernel Hub loads different kernel versions under isolated module names. Absolute self-imports can escape that namespace and resolve an unrelated globally installed `sol_attn` package. Relative imports preserve the existing objects and kernel behavior while making the package safe for Hub loading.

## Validation

- HKUST H100, PyTorch 2.10.0+cu128, Triton 3.6.0, CuTe DSL 4.5.2
- isolated Hub-style module load: passed
- full exact sink vs. PyTorch SDPA: max absolute error `0.001953125`, cosine `0.9999978542`
- SM90 CuTe sparse vs. Triton sparse: max absolute error `0.0009765625`, cosine `1.0`
- Hub package tests: `4 passed`
- Sol-Engine integration tests: `9 passed`
- `git diff --check`: passed

## Rollout

The workflow is `workflow_dispatch` only, so merging this PR does not publish anything automatically. Before the first run, configure an `HF_TOKEN` Actions secret with `job.write` and write access to the `Efficient-Large-Model` Hub organization. Set `SOL_ATTN_HF_JOBS_NAMESPACE` if the HF Jobs quota should be charged to a different namespace.
