### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Thanks go to these wonderful contributors:
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=NVlabs/sana&type=Date)](https://www.star-history.com/#NVlabs/sana&Date)
+[![NVlabs/Sana star history chart](https://raw.githubusercontent.com/NVlabs/Sana/page/star-history/chart.svg)](https://github.com/NVlabs/Sana/stargazers)
 
 # 📖 BibTeX
 


### PR DESCRIPTION
## Summary

Replace the broken third-party Star History image with the exact SVG already hosted on the existing `page` branch.

This PR intentionally changes only one README line. The generated chart and aggregate data live outside the default branch:

- https://raw.githubusercontent.com/NVlabs/Sana/page/star-history/chart.svg
- https://raw.githubusercontent.com/NVlabs/Sana/page/star-history/history.json
- page commit: https://github.com/NVlabs/Sana/commit/b2af8fb343bda661fe0d86a49eb779d7dbb22fb2

## Why

GitHub's July 2026 stargazer API restrictions prevent the external Star History service from retrieving NVlabs/Sana's timestamped stargazer listing, leaving a broken image in the README.

The replacement was bootstrapped from GitHub's official `starred_at` data. It contains 8,707 unique current stargazers, matching GitHub's reported total, across 655 UTC days from 2024-10-21 through 2026-08-06. No GitHub account names or credentials are stored.

The chart is a static snapshot and will be refreshed manually on the `page` branch when needed; this PR does not add repository automation.

## Validation

- README trailing-whitespace, end-of-file, and mdformat hooks passed
- PR diff is one insertion and one deletion in `README.md`
- published SVG returns HTTP 200 with `image/svg+xml`
