### PR TITLE
Add MiniMax-H3 RTX 5090 BF16 runtime

### DIFF
--- a/candidates/minimax_h3_rtx5090_dense.toml
+++ b/candidates/minimax_h3_rtx5090_dense.toml
@@ -1,0 +1,40 @@
+id = "minimax_h3_rtx5090_dense"
+kind = "baseline"
+purpose = "control"
+description = "Released BF16 MiniMax-H3 FL2VA on one RTX 5090 with SGLang layerwise offload and dense attention."
+model_profile = "minimax_h3"
+submodule = "models/minimax_h3/rtx5090"
+run_script = "scripts/run_minimax_h3_gpu.sh"
+
+[runtime]
+root = "models/minimax_h3/rtx5090"
+
+[official_config]
+model = "MiniMaxAI/MiniMax-H3"
+task = "t2va"
+width = 1344
+height = 768
+duration_s = 5
+steps = 50
+seed = 1101
+num_gpus = 1
+transformer_dtype = "bf16"
+vae_dtype = "bf16"
+
+[env]
+H3_ROOT = "/home/xieenze/codex/minimax_h3_5090_20260805"
+H3_SGLANG_ROOT = "/home/xieenze/codex/minimax_h3_5090_20260805/sglang"
+H3_MODEL_PATH = "/home/xieenze/codex/minimax_h3_5090_20260805/model/FL2VA"
+PYTHON_BIN = "/home/xieenze/codex/minimax_h3_5090_20260805/.venv/bin/python"
+H3_RTX5090_PROFILE = "dense"
+H3_CUDA_VISIBLE_DEVICES = "0"
+H3_WARMUP_NUM_STEPS = "5"
+H3_MEASURED_NUM_STEPS = "50"
+H3_DURATION_SECONDS = "5"
+H3_SEED = "1101"
+
+[artifacts]
+output_dir = "outputs"
+video = "measured/minimax_h3_t2va_1344x768_5s_50step_seed1101.mp4"
+log = "server.log"
+benchmark = "summary.json"

--- a/candidates/minimax_h3_rtx5090_fullopt.toml
+++ b/candidates/minimax_h3_rtx5090_fullopt.toml
@@ -1,0 +1,56 @@
+id = "minimax_h3_rtx5090_fullopt"
+kind = "patch"
+purpose = "delivery"
+description = "RTX 5090 BF16 stack: SM120 Sol-Attn, TeaCache, regional torch.compile, and a full BF16 video VAE resident after denoising."
+model_profile = "minimax_h3"
+submodule = "models/minimax_h3/rtx5090"
+run_script = "scripts/run_minimax_h3_gpu.sh"
+
+[runtime]
+root = "models/minimax_h3/rtx5090"
+
+[official_config]
+model = "MiniMaxAI/MiniMax-H3"
+task = "t2va"
+width = 1344
+height = 768
+duration_s = 5
+steps = 50
+seed = 1101
+num_gpus = 1
+transformer_dtype = "bf16"
+vae_dtype = "bf16"
+
+[env]
+H3_ROOT = "/home/xieenze/codex/minimax_h3_5090_20260805"
+H3_SGLANG_ROOT = "/home/xieenze/codex/minimax_h3_5090_20260805/sglang"
+H3_MODEL_PATH = "/home/xieenze/codex/minimax_h3_5090_20260805/model/FL2VA"
+PYTHON_BIN = "/home/xieenze/codex/minimax_h3_5090_20260805/.venv/bin/python"
+H3_RTX5090_PROFILE = "fullopt"
+H3_CUDA_VISIBLE_DEVICES = "0"
+H3_WARMUP_NUM_STEPS = "50"
+H3_MEASURED_NUM_STEPS = "50"
+H3_DURATION_SECONDS = "5"
+H3_SEED = "1101"
+SOL_ATTN_TAU = "1.0"
+SOL_ATTN_THRESH_TYPE = "diag"
+SOL_ATTN_FIRST_DENSE_STEPS = "10"
+SOL_ATTN_FIRST_DENSE_LAYERS = "2"
+SOL_ATTN_CORRECTNESS_GATE = "1"
+H3_TEACACHE_ENABLED = "1"
+H3_TEACACHE_THRESHOLD = "0.10"
+H3_TEACACHE_RETAIN_STEPS = "5"
+H3_TEACACHE_COOLDOWN_STEPS = "1"
+H3_TEACACHE_NUM_FORWARDS = "49"
+H3_TEACACHE_COEFFICIENTS = "1.0,0.0"
+H3_FULL_OPT_COMPILE = "true"
+H3_FULL_OPT_REGIONAL_COMPILE = "true"
+H3_FULL_VAE_AFTER_DENOISE = "1"
+H3_FULL_VAE_DTYPE = "bfloat16"
+H3_FULL_VAE_TILE_BATCH_SIZE = "0"
+
+[artifacts]
+output_dir = "outputs"
+video = "measured/minimax_h3_t2va_1344x768_5s_50step_seed1101.mp4"
+log = "server.log"
+benchmark = "summary.json"

--- a/candidates/minimax_h3_rtx5090_sol.toml
+++ b/candidates/minimax_h3_rtx5090_sol.toml
@@ -1,0 +1,45 @@
+id = "minimax_h3_rtx5090_sol"
+kind = "patch"
+purpose = "evidence"
+description = "Single-card RTX 5090 BF16 baseline plus SM120 Sol-Attn, with exact text KV sink and dense text-query rows."
+model_profile = "minimax_h3"
+submodule = "models/minimax_h3/rtx5090"
+run_script = "scripts/run_minimax_h3_gpu.sh"
+
+[runtime]
+root = "models/minimax_h3/rtx5090"
+
+[official_config]
+model = "MiniMaxAI/MiniMax-H3"
+task = "t2va"
+width = 1344
+height = 768
+duration_s = 5
+steps = 50
+seed = 1101
+num_gpus = 1
+transformer_dtype = "bf16"
+vae_dtype = "bf16"
+
+[env]
+H3_ROOT = "/home/xieenze/codex/minimax_h3_5090_20260805"
+H3_SGLANG_ROOT = "/home/xieenze/codex/minimax_h3_5090_20260805/sglang"
+H3_MODEL_PATH = "/home/xieenze/codex/minimax_h3_5090_20260805/model/FL2VA"
+PYTHON_BIN = "/home/xieenze/codex/minimax_h3_5090_20260805/.venv/bin/python"
+H3_RTX5090_PROFILE = "sol"
+H3_CUDA_VISIBLE_DEVICES = "0"
+H3_WARMUP_NUM_STEPS = "50"
+H3_MEASURED_NUM_STEPS = "50"
+H3_DURATION_SECONDS = "5"
+H3_SEED = "1101"
+SOL_ATTN_TAU = "1.0"
+SOL_ATTN_THRESH_TYPE = "diag"
+SOL_ATTN_FIRST_DENSE_STEPS = "10"
+SOL_ATTN_FIRST_DENSE_LAYERS = "2"
+SOL_ATTN_CORRECTNESS_GATE = "1"
+
+[artifacts]
+output_dir = "outputs"
+video = "measured/minimax_h3_t2va_1344x768_5s_50step_seed1101.mp4"
+log = "server.log"
+benchmark = "summary.json"

--- a/models/minimax_h3.toml
+++ b/models/minimax_h3.toml
@@ -132,6 +132,44 @@ upstream_pull_request = "https://github.com/huggingface/diffusers/pull/14355"
 upstream_commit = "abc5e9bf71fd38f53cd471bc3acaa84bc5ecbfdc"
 source_snapshot = "models/minimax_h3/gb200/baseline/diffusers_src"
 
+[rtx5090]
+variant = "sglang_released_bf16_single_rtx5090"
+status = "measured_single_gpu_layerwise_offload"
+runtime_root = "models/minimax_h3/rtx5090"
+run_script = "models/minimax_h3/rtx5090/scripts/run_minimax_h3_gpu.sh"
+candidates = [
+  "candidates/minimax_h3_rtx5090_dense.toml",
+  "candidates/minimax_h3_rtx5090_sol.toml",
+  "candidates/minimax_h3_rtx5090_fullopt.toml",
+]
+hardware = "1x NVIDIA RTX 5090, 32 GiB GDDR7, SM120; 188 GiB host RAM"
+cell = "1344x768, 124 frames, 5 seconds, 50 steps, released BF16 FL2VA"
+timing_scope = "SGLang video API final_status.inference_time_s after profile-specific warmup"
+memory_scope = "SGLang video API final_status.peak_memory_mb"
+source_snapshot = "models/minimax_h3/rtx5090/SOURCE_SNAPSHOT.json"
+note = "All components use layerwise CPU offload. Sol and fullopt receive one complete same-shape warmup request for SM120 compilation and autotuning before measurement."
+
+[rtx5090.policy]
+tau = 1.0
+threshold = "diag"
+first_dense_steps = 10
+first_dense_layers = 2
+reorder = false
+text_kv_sink = "exact"
+text_query_rows = "dense"
+teacache_threshold = 0.10
+teacache_retain_steps = 5
+teacache_cooldown_steps = 1
+
+[rtx5090.results]
+dense_single_case_e2e_s = 1045.409
+sol_single_case_e2e_s = 781.783
+sol_single_case_speedup = 1.3372
+dense_three_prompt_mean_e2e_s = 1055.1008
+fullopt_three_prompt_mean_e2e_s = 250.8820
+fullopt_three_prompt_speedup = 4.2056
+raw = "models/minimax_h3/rtx5090/results/bf16_5090_20260805.json"
+
 # ============================================================================================
 # Append to models/minimax_h3.toml. A second measured runtime, not a replacement for [baseline]:
 # different hardware, different checkpoint, and a tenth of the canvas, so the two tables are not

--- a/models/minimax_h3/README.md
+++ b/models/minimax_h3/README.md
@@ -10,6 +10,20 @@ That shape decides the whole acceleration line. There is no CFG branch to elide 
 attention to cache, so the only parallel axis is the sequence itself, and attention is 70% of the
 hot path.
 
+## Hardware runtimes
+
+MiniMax-H3 implementations are grouped by the hardware they were adapted and
+measured on:
+
+- `gb200/`: the original resident baseline and the multi-GPU optimized line.
+  The nested `optimized/` name is historical; it is the GB200 implementation.
+- `gb10/`: the single-GB10 constrained-memory port.
+- `rtx5090/`: the single-RTX-5090 BF16 SGLang port with layerwise offload,
+  SM120 Sol-Attn, TeaCache, regional compile, and post-denoise VAE residency.
+
+Do not mix runtime files across these directories. Candidate manifests select
+the matching hardware directory explicitly.
+
 ## Acceleration line
 
 8xGB200 (two nodes in one NVL72 rack), 1344x768, 124 frames, 50 steps. Times are the **hot path** —

--- a/models/minimax_h3/rtx5090/README.md
+++ b/models/minimax_h3/rtx5090/README.md
@@ -1,0 +1,129 @@
+# MiniMax-H3 on one RTX 5090
+
+This directory is the RTX 5090 hardware port of MiniMax-H3. It is a sibling of
+`../gb200/` and `../gb10/`; the early `gb200/optimized/` name predates the
+hardware split and should not be copied as a new top-level model variant.
+
+The port runs the released FL2VA model in BF16 on one 32 GiB RTX 5090. It does
+not replace model weights or modify the driver, system Python, or the checked-out
+SGLang source. Source changes are installed in a SHA-guarded Python overlay.
+
+## Profiles
+
+| Profile | Attention | Cache | Compile | Video VAE |
+| --- | --- | --- | --- | --- |
+| `dense` | SGLang dense backend | off | off | layerwise offload |
+| `sol` | SM120 Sol-Attn | off | off | layerwise offload |
+| `fullopt` | SM120 Sol-Attn | TeaCache 0.10 | regional | full BF16 residency after denoise |
+
+All three profiles use SGLang's fast fused QK-norm/RoPE path when its runtime
+capability check passes. All three also use the same single-rank placement:
+DiT, text encoder, and VAE are layerwise-offloaded, with one prefetched DiT
+layer and zero resident DiT layers. This is component/layer offload, not expert
+offload.
+
+The Sol-Attn policy is fixed across `sol` and `fullopt`:
+
+- `tau=1.0`, `diag` threshold, no token reorder;
+- first 10 denoise forwards and first 2 DiT blocks dense;
+- valid text K/V rows form an exact sink;
+- valid text query rows are recomputed densely;
+- the real-QKV correctness gate is enabled;
+- one complete 50-step, same-shape request warms compilation and autotuning;
+  only the following request is measured.
+
+## Source contract
+
+The patches target SGLang commit
+`6fa3f9df11c8bdbc0e3b4ddc87a3d873343aca72`. The launcher verifies the three
+upstream source hashes before constructing an overlay, so a changed SGLang
+checkout fails closed instead of silently applying stale model glue.
+
+The measured environment was:
+
+- one RTX 5090, SM120, 32 GiB;
+- Python virtual environment with PyTorch `2.11.0+cu130` and Triton `3.6.0`;
+- NVIDIA CuTe DSL / CUTLASS Python and `cuda-python` for the SM120 kernel;
+- 188 GiB host RAM;
+- released `MiniMaxAI/MiniMax-H3` FL2VA layout at `model/FL2VA`.
+
+Install this repository's Sol-Attn package into the same environment:
+
+```bash
+uv pip install --python "$H3_ROOT/.venv/bin/python" \
+  -e techniques/sparse_backends
+```
+
+The SGLang console command must come from the pinned checkout's environment.
+Do not update the GPU driver as part of this setup.
+
+## Run
+
+The checked-in candidates record the original host paths. On another machine,
+override `H3_ROOT`, `H3_SGLANG_ROOT`, `H3_MODEL_PATH`, and `PYTHON_BIN`.
+
+```bash
+python scripts/launch_candidate.py \
+  candidates/minimax_h3_rtx5090_dense.toml \
+  --mode local
+
+python scripts/launch_candidate.py \
+  candidates/minimax_h3_rtx5090_sol.toml \
+  --mode local
+
+python scripts/launch_candidate.py \
+  candidates/minimax_h3_rtx5090_fullopt.toml \
+  --mode local
+```
+
+The runtime can also be called directly:
+
+```bash
+H3_ROOT=/path/to/h3-runtime \
+H3_SGLANG_ROOT=/path/to/sglang \
+H3_MODEL_PATH=/path/to/FL2VA \
+H3_RTX5090_PROFILE=fullopt \
+OUT_DIR=/path/to/output \
+bash models/minimax_h3/rtx5090/scripts/run_minimax_h3_gpu.sh
+```
+
+Each output contains the warmup and measured videos, API metadata,
+`server.log`, one-second `resources.csv`, Sol-Attn/TeaCache events, and
+`summary.json`. Quote `final_status.inference_time_s` and
+`final_status.peak_memory_mb` from SGLang's API metadata; client wall time and
+the `nvidia-smi` process sample are retained as separate diagnostics.
+
+## Measured BF16 results
+
+Official 1344x768, 5-second, 50-step T2VA requests were run through one
+persistent server per profile. The three-prompt suite used aligned prompts and
+seeds for dense and full-opt.
+
+| Prompt | Dense E2E | Full-opt E2E | Speedup | Dense peak | Full-opt peak |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Flamenco dancer | 1047.791 s | 271.129 s | 3.864x | 16,584 MB | 22,388 MB |
+| Garage mechanics | 1051.134 s | 237.622 s | 4.424x | 16,568 MB | 22,380 MB |
+| Official starship | 1066.377 s | 243.895 s | 4.372x | 17,132 MB | 22,390 MB |
+| Mean | 1055.101 s | 250.882 s | **4.206x** | 16,761 MB | 22,386 MB |
+
+On the seed-1101 single case, dense was 1045.409 seconds and Sol-Attn-only was
+781.783 seconds, a 1.337x E2E speedup. The complete raw values and provenance
+are in `results/bf16_5090_20260805.json`.
+
+## Files
+
+- `adapter.py`: packed H3 self-attention routing, text sink, dense text queries,
+  request/step tracking, density logging, and correctness gate.
+- `teacache.py`: residual reuse controller used only by `fullopt`.
+- `patches/minimax_h3.py`: minimal DiT hooks for the adapter and TeaCache.
+- `patches/denoising.py`: preserves user-requested DiT offload across compile
+  warmup.
+- `patches/minimax_h3_decoding.py`: makes the complete BF16 video VAE resident
+  only after denoising, then restores layerwise offload.
+- `scripts/launch_server.sh`: validates sources, builds the overlay, and starts
+  the single-rank server.
+- `scripts/run_minimax_h3_gpu.sh`: scoped server lifecycle, warmup, measurement,
+  resource sampling, and summary generation.
+
+The runtime intentionally contains no alternative checkpoint loader. Its
+contract is the released BF16 FL2VA model only.

--- a/models/minimax_h3/rtx5090/SOURCE_SNAPSHOT.json
+++ b/models/minimax_h3/rtx5090/SOURCE_SNAPSHOT.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "captured_at_utc": "2026-08-08T00:00:00Z",
+  "source_root": ".",
+  "core_sha256": {
+    "adapter.py": "7faccb4ea59a1543561e62998fee44dc65cdc9b249dde9838bd097d4fb01a745",
+    "teacache.py": "878bb72a38677fbf39cb4b041588f38990579d3eb9f49cdf7c6e31e71853bf99",
+    "patches/minimax_h3.py": "7f5553b963252969fcbcc752a5c44bf9b91d683276b7a10de66c0e075059f1ed",
+    "patches/denoising.py": "284a17202841a6efef3219cbc5771fc33ef8815d1637fa06fa4d524a86482f9a",
+    "patches/minimax_h3_decoding.py": "923d8e50255b1d5f2c143fc083ffa86b2cfd4990d4834717306fcfe317bd8eb2"
+  },
+  "hardware": {
+    "gpu": "NVIDIA GeForce RTX 5090",
+    "gpu_count": 1,
+    "cuda_capability": "12.0",
+    "gpu_memory_gib": 32,
+    "host_memory_gib": 188
+  },
+  "runtime": {
+    "python_environment": "/home/xieenze/codex/minimax_h3_5090_20260805/.venv",
+    "torch": "2.11.0+cu130",
+    "triton": "3.6.0",
+    "sglang_repo": "https://github.com/sgl-project/sglang.git",
+    "sglang_commit": "6fa3f9df11c8bdbc0e3b4ddc87a3d873343aca72"
+  },
+  "model": {
+    "repo": "MiniMaxAI/MiniMax-H3",
+    "partition": "FL2VA",
+    "dtype": "bfloat16",
+    "local_layout": "/home/xieenze/codex/minimax_h3_5090_20260805/model/FL2VA"
+  },
+  "sana": {
+    "repo": "https://github.com/NVlabs/Sana.git",
+    "branch": "sol-engine",
+    "base_commit": "57196971c857ab4c593c4c632acdcb39f00fb885"
+  },
+  "upstream_source_sha256": {
+    "minimax_h3.py": "5f87319969c446685ee93d422fc34a7c040defb238eff2274d664f2f8310e997",
+    "denoising.py": "2325b039c055d2db8c320a00f65e2880816888fd5fa107b72cfd6a85be104399",
+    "minimax_h3_decoding.py": "5e2cf87da11e0c744d6c7703d8151abd7da7937e1ad67d576fdbf6c678380954"
+  },
+  "rtx5090_source_sha256": {
+    "adapter.py": "7faccb4ea59a1543561e62998fee44dc65cdc9b249dde9838bd097d4fb01a745",
+    "teacache.py": "878bb72a38677fbf39cb4b041588f38990579d3eb9f49cdf7c6e31e71853bf99",
+    "patches/minimax_h3.py": "7f5553b963252969fcbcc752a5c44bf9b91d683276b7a10de66c0e075059f1ed",
+    "patches/denoising.py": "284a17202841a6efef3219cbc5771fc33ef8815d1637fa06fa4d524a86482f9a",
+    "patches/minimax_h3_decoding.py": "923d8e50255b1d5f2c143fc083ffa86b2cfd4990d4834717306fcfe317bd8eb2"
+  }
+}

--- a/models/minimax_h3/rtx5090/__init__.py
+++ b/models/minimax_h3/rtx5090/__init__.py
@@ -1,0 +1,1 @@
+"""Single-card RTX 5090 runtime for MiniMax-H3."""

--- a/models/minimax_h3/rtx5090/adapter.py
+++ b/models/minimax_h3/rtx5090/adapter.py
@@ -1,0 +1,623 @@
+"""Sol-Attn adapter for MiniMax-H3 packed multimodal attention."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import math
+import os
+from pathlib import Path
+import re
+import time
+from typing import Any, Iterable
+
+import torch
+import torch.nn.functional as F
+
+
+_LAYER_PATTERN = re.compile(r"(?:^|\.)blocks\.(\d+)\.attn$")
+_LOG_PREFIX = "MINIMAX_H3_SOL_ATTN "
+_MAIN_DIT_LAYER_INDICES: set[int] = set()
+
+
+@dataclass(frozen=True)
+class StepContext:
+    request_epoch: str
+    request_index: int
+    step_index: int
+    total_tokens: int
+    live_tokens: int
+    text_start: int
+    text_tokens: int
+    cu_seqlens_host: tuple[int, ...]
+    num_layers: int
+    timestep_max: float | None
+
+
+@dataclass
+class _RuntimeState:
+    context: StepContext | None = None
+    request_index: int = -1
+    previous_epoch: str | None = None
+    previous_timestep_max: float | None = None
+    density_logged_shapes: set[tuple[int, int, int]] = field(default_factory=set)
+    gate_shapes: set[tuple[int, int, int]] = field(default_factory=set)
+    first_sparse_logged_shapes: set[tuple[int, int, int]] = field(default_factory=set)
+    dense_backend_logged: bool = False
+
+
+_STATE = _RuntimeState()
+
+
+def parse_layer_index(prefix: str) -> int | None:
+    """Return the main DiT block index, excluding token-refiner blocks."""
+
+    if "token_refiner" in prefix:
+        return None
+    match = _LAYER_PATTERN.search(prefix)
+    if match is None:
+        return None
+    layer_index = int(match.group(1))
+    _MAIN_DIT_LAYER_INDICES.add(layer_index)
+    return layer_index
+
+
+def _host_positions(values: torch.Tensor | Iterable[int]) -> tuple[int, ...]:
+    if torch.is_tensor(values):
+        values = values.detach().reshape(-1).to(device="cpu").tolist()
+    return tuple(int(value) for value in values if int(value) >= 0)
+
+
+def _contiguous_range(values: tuple[int, ...], name: str) -> tuple[int, int]:
+    if not values:
+        return 0, 0
+    ordered = tuple(sorted(set(values)))
+    start = ordered[0]
+    if ordered != tuple(range(start, start + len(ordered))):
+        raise ValueError(f"MiniMax-H3 {name} positions must be contiguous")
+    return start, len(ordered)
+
+
+def _normalize_boundaries(
+    boundaries: Iterable[int] | None,
+    total_tokens: int,
+) -> tuple[int, ...]:
+    if boundaries is None:
+        return (0, total_tokens)
+    result = tuple(int(value) for value in boundaries)
+    if not result or result[0] != 0:
+        raise ValueError(f"cu_seqlens_host must start at 0, got {result}")
+    if any(left > right for left, right in zip(result, result[1:])):
+        raise ValueError(f"cu_seqlens_host must be nondecreasing, got {result}")
+    if result[-1] > total_tokens:
+        raise ValueError(
+            f"cu_seqlens_host ends at {result[-1]}, beyond T={total_tokens}"
+        )
+    if result[-1] < total_tokens:
+        result = (*result, total_tokens)
+    return result
+
+
+def _request_epoch() -> str | None:
+    path = os.getenv("SOL_ATTN_REQUEST_EPOCH_FILE")
+    if not path:
+        return None
+    try:
+        return Path(path).read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+
+
+def _timestep_max(unique_timesteps: torch.Tensor) -> float | None:
+    if not torch.is_tensor(unique_timesteps) or not unique_timesteps.numel():
+        return None
+    return float(unique_timesteps.detach().float().max().to(device="cpu").item())
+
+
+def _rank() -> int:
+    return int(os.getenv("RANK", os.getenv("LOCAL_RANK", "0")))
+
+
+def _emit(event: str, **payload: Any) -> None:
+    record = {"event": event, "rank": _rank(), **payload}
+    line = json.dumps(record, sort_keys=True)
+    print(_LOG_PREFIX + line, flush=True)
+    path_template = os.getenv("SOL_ATTN_EVENT_LOG")
+    if path_template:
+        path = Path(path_template.format(rank=_rank()))
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+
+
+def emit_event(event: str, **payload: Any) -> None:
+    """Write an integration event to the shared per-rank log."""
+
+    _emit(event, **payload)
+
+
+@torch.no_grad()
+def begin_model_forward(
+    *,
+    unique_timesteps: torch.Tensor,
+    text_positions: torch.Tensor | Iterable[int],
+    image_positions: torch.Tensor | Iterable[int],
+    audio_positions: torch.Tensor | Iterable[int],
+    cu_seqlens_host: Iterable[int] | None,
+    total_tokens: int,
+    num_layers: int,
+) -> StepContext:
+    """Record request-static layout and advance the denoise-step counter."""
+
+    registered_num_layers = max(_MAIN_DIT_LAYER_INDICES, default=-1) + 1
+    num_layers = max(int(num_layers), registered_num_layers)
+
+    text = _host_positions(text_positions)
+    image = _host_positions(image_positions)
+    audio = _host_positions(audio_positions)
+    text_start, text_tokens = _contiguous_range(text, "text")
+    live_positions = text + image + audio
+    live_tokens = max(live_positions, default=-1) + 1
+    if live_tokens <= 0 or live_tokens > total_tokens:
+        raise ValueError(
+            f"invalid MiniMax-H3 live token count {live_tokens} for T={total_tokens}"
+        )
+    if len(set(live_positions)) != len(live_positions):
+        raise ValueError("MiniMax-H3 text/video/audio token positions overlap")
+
+    boundaries = _normalize_boundaries(cu_seqlens_host, total_tokens)
+    timestep_max = _timestep_max(unique_timesteps)
+    epoch = _request_epoch()
+    layout_key = (total_tokens, live_tokens, text_start, text_tokens, boundaries)
+    previous = _STATE.context
+    layout_changed = previous is None or (
+        previous.total_tokens,
+        previous.live_tokens,
+        previous.text_start,
+        previous.text_tokens,
+        previous.cu_seqlens_host,
+    ) != layout_key
+    epoch_changed = epoch is not None and epoch != _STATE.previous_epoch
+    # MiniMax-H3 traverses its denoise schedule in increasing timestep order.
+    # A decrease therefore marks the next request; treating an increase as a
+    # reset would keep every denoise iteration at step zero and force dense.
+    timestep_reset = (
+        epoch is None
+        and previous is not None
+        and timestep_max is not None
+        and _STATE.previous_timestep_max is not None
+        and timestep_max < _STATE.previous_timestep_max - 1.0e-6
+    )
+    new_request = layout_changed or epoch_changed or timestep_reset
+    if new_request:
+        _STATE.request_index += 1
+        step_index = 0
+    else:
+        step_index = previous.step_index + 1 if previous is not None else 0
+
+    request_epoch = epoch if epoch is not None else f"auto-{_STATE.request_index}"
+    _STATE.context = StepContext(
+        request_epoch=request_epoch,
+        request_index=_STATE.request_index,
+        step_index=step_index,
+        total_tokens=total_tokens,
+        live_tokens=live_tokens,
+        text_start=text_start,
+        text_tokens=text_tokens,
+        cu_seqlens_host=boundaries,
+        num_layers=num_layers,
+        timestep_max=timestep_max,
+    )
+    _STATE.previous_epoch = epoch
+    _STATE.previous_timestep_max = timestep_max
+
+    if new_request or step_index < 2:
+        _emit(
+            "step_context",
+            request_epoch=request_epoch,
+            request_index=_STATE.request_index,
+            step_index=step_index,
+            timestep_max=timestep_max,
+            total_tokens=total_tokens,
+            live_tokens=live_tokens,
+            padding_tokens=total_tokens - live_tokens,
+            text_start=text_start,
+            text_tokens=text_tokens,
+            image_tokens=len(image),
+            audio_tokens=len(audio),
+            cu_seqlens_host=list(boundaries),
+            num_layers=num_layers,
+        )
+    return _STATE.context
+
+
+def _set_dense_backend(attention: Any, q: torch.Tensor) -> None:
+    if attention._attention_impl is not None:
+        return
+    from sglang.multimodal_gen.runtime.layers.attention.selector import (
+        get_attn_backend,
+    )
+
+    attention._set_attention_backend(
+        get_attn_backend(
+            attention.head_dim,
+            q.dtype,
+            supported_attention_backends=attention._supported_attention_backends,
+        )
+    )
+
+
+def _dense_varlen(
+    attention: Any,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor,
+    cu_seqlens_host: tuple[int, ...] | None,
+    max_seqlen: int,
+) -> torch.Tensor:
+    global _STATE
+    _set_dense_backend(attention, q)
+    if not _STATE.dense_backend_logged:
+        _emit(
+            "dense_backend",
+            backend=type(attention._attention_impl).__name__,
+            q_shape=list(q.shape),
+        )
+        _STATE.dense_backend_logged = True
+    return attention._attention_impl.forward_varlen(
+        q,
+        k,
+        v,
+        cu_seqlens=cu_seqlens,
+        max_seqlen=max_seqlen,
+        cu_seqlens_host=cu_seqlens_host,
+    )
+
+
+def _dense_text_queries(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    start: int,
+    tokens: int,
+    scale: float,
+) -> torch.Tensor:
+    q_text = q[:, start : start + tokens].transpose(1, 2)
+    k_heads = k.transpose(1, 2)
+    v_heads = v.transpose(1, 2)
+    output = F.scaled_dot_product_attention(
+        q_text,
+        k_heads,
+        v_heads,
+        dropout_p=0.0,
+        is_causal=False,
+        scale=scale,
+    )
+    return output.transpose(1, 2)
+
+
+def _error_stats(
+    actual: torch.Tensor, expected: torch.Tensor
+) -> dict[str, float | int]:
+    difference = actual.float() - expected.float()
+    absolute = difference.abs()
+    denominator = torch.linalg.vector_norm(expected.float()).clamp_min(1.0e-12)
+    flat_index = int(absolute.argmax().item())
+    actual_flat = actual.float().reshape(-1)
+    expected_flat = expected.float().reshape(-1)
+    return {
+        "max_abs": float(absolute.reshape(-1)[flat_index].item()),
+        "mean_abs": float(absolute.mean().item()),
+        "rel_l2": float(
+            (torch.linalg.vector_norm(difference) / denominator).item()
+        ),
+        "max_error_flat_index": flat_index,
+        "actual_at_max_error": float(actual_flat[flat_index].item()),
+        "expected_at_max_error": float(expected_flat[flat_index].item()),
+    }
+
+
+@torch.no_grad()
+def _real_qkv_gate(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    scale: float,
+) -> None:
+    shape_key = (int(q.shape[1]), int(q.shape[2]), int(q.shape[3]))
+    if (
+        shape_key in _STATE.gate_shapes
+        or os.getenv("SOL_ATTN_CORRECTNESS_GATE", "1") != "1"
+    ):
+        return
+    from sol_attn import sol_attn
+
+    gate_heads = min(int(os.getenv("SOL_ATTN_GATE_HEADS", "1")), q.shape[2])
+    q_gate = q[:, :, :gate_heads].contiguous()
+    k_gate = k[:, :, :gate_heads].contiguous()
+    v_gate = v[:, :, :gate_heads].contiguous()
+    candidate = sol_attn(
+        q_gate,
+        k_gate,
+        v_gate,
+        scale=scale,
+        tau=-1000.0,
+        thresh_type="diag",
+    )
+    reference = F.scaled_dot_product_attention(
+        q_gate.transpose(1, 2),
+        k_gate.transpose(1, 2),
+        v_gate.transpose(1, 2),
+        dropout_p=0.0,
+        is_causal=False,
+        scale=scale,
+    ).transpose(1, 2)
+    torch.cuda.synchronize(q.device)
+    stats = _error_stats(candidate, reference)
+    limits = {
+        "max_abs": float(
+            os.getenv(
+                "SOL_ATTN_GATE_MAX_ABS",
+                "0.15" if q.shape[1] >= 32768 else "0.08",
+            )
+        ),
+        "mean_abs": float(os.getenv("SOL_ATTN_GATE_MEAN_ABS", "0.002")),
+        "rel_l2": float(os.getenv("SOL_ATTN_GATE_REL_L2", "0.005")),
+    }
+    passed = all(stats[name] <= limit for name, limit in limits.items())
+    _emit(
+        "real_qkv_correctness_gate",
+        passed=passed,
+        shape=list(q_gate.shape),
+        stats=stats,
+        limits=limits,
+    )
+    if not passed:
+        raise RuntimeError(f"MiniMax-H3 Sol-Attn correctness gate failed: {stats}")
+    _STATE.gate_shapes.add(shape_key)
+
+
+@torch.no_grad()
+def _estimate_density(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    scale: float,
+    tau: float,
+    thresh_type: str,
+    sink_start: int,
+    sink_tokens: int,
+) -> dict[str, float | int]:
+    from sol_attn.preprocess import BLOCK_SIZE, prepare
+
+    sample_heads = min(int(os.getenv("SOL_ATTN_DENSITY_SAMPLE_HEADS", "1")), q.shape[2])
+    q_sample = q[:, :, :sample_heads].contiguous()
+    k_sample = k[:, :, :sample_heads].contiguous()
+    v_sample = v[:, :, :sample_heads].contiguous()
+    kc, _, threshold = prepare(
+        q_sample,
+        k_sample,
+        v_sample,
+        scale=scale,
+        tau=tau,
+        thresh_type=thresh_type,
+    )
+    tokens = q_sample.shape[1]
+    blocks = math.ceil(tokens / BLOCK_SIZE)
+    pad = blocks * BLOCK_SIZE - tokens
+    q_padded = F.pad(q_sample, (0, 0, 0, 0, 0, pad))
+    q_sum = q_padded.view(
+        q_sample.shape[0], blocks, BLOCK_SIZE, sample_heads, q_sample.shape[3]
+    ).float().sum(dim=2)
+    counts = torch.full(
+        (blocks,),
+        BLOCK_SIZE,
+        device=q.device,
+        dtype=torch.float32,
+    )
+    counts[-1] = tokens - (blocks - 1) * BLOCK_SIZE
+    q_bar = q_sum / counts.view(1, blocks, 1, 1)
+    scores = torch.einsum("bqhd,bkhd->bqkh", q_bar, kc.float())
+    scores.mul_(scale * math.log2(math.e))
+    routed = scores > threshold[:, :, None, :]
+    threshold_density = float(routed.float().mean().item())
+
+    block_ids = torch.arange(blocks, device=q.device)
+    local_band = (block_ids[:, None] - block_ids[None, :]).abs() <= 1
+    routed |= local_band[None, :, :, None]
+    sink_blocks = 0
+    if sink_tokens:
+        sink_first = sink_start // BLOCK_SIZE
+        sink_last = math.ceil((sink_start + sink_tokens) / BLOCK_SIZE)
+        routed[:, :, sink_first:sink_last, :] = True
+        sink_blocks = sink_last - sink_first
+    return {
+        "sample_heads": sample_heads,
+        "blocks": blocks,
+        "sink_blocks": sink_blocks,
+        "threshold_density": threshold_density,
+        "effective_density": float(routed.float().mean().item()),
+    }
+
+
+def _dense_policy(layer_index: int | None, context: StepContext | None) -> bool:
+    if layer_index is None or context is None:
+        return True
+    if os.getenv("SOL_ATTN_FORCE_DENSE", "0") == "1":
+        return True
+    first_steps = int(os.getenv("SOL_ATTN_FIRST_DENSE_STEPS", "10"))
+    layer_ratio = float(os.getenv("SOL_ATTN_FIRST_DENSE_LAYER_RATIO", "0.03"))
+    default_layers = max(1, math.ceil(context.num_layers * layer_ratio))
+    first_layers = int(os.getenv("SOL_ATTN_FIRST_DENSE_LAYERS", str(default_layers)))
+    return context.step_index < first_steps or layer_index < first_layers
+
+
+@torch.no_grad()
+def _sol_varlen(
+    attention: Any,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    boundaries: tuple[int, ...],
+    context: StepContext,
+) -> torch.Tensor:
+    from sol_attn import sol_attn
+
+    tau = float(os.getenv("SOL_ATTN_TAU", "1.0"))
+    thresh_type = os.getenv("SOL_ATTN_THRESH_TYPE", "diag")
+    output = torch.zeros_like(q)
+    for raw_start, raw_end in zip(boundaries, boundaries[1:]):
+        start = min(raw_start, context.live_tokens)
+        end = min(raw_end, context.live_tokens)
+        if end <= start:
+            continue
+        q_segment = q[start:end].unsqueeze(0).contiguous()
+        k_segment = k[start:end].unsqueeze(0).contiguous()
+        v_segment = v[start:end].unsqueeze(0).contiguous()
+        text_global_start = context.text_start
+        text_global_end = context.text_start + context.text_tokens
+        sink_global_start = max(start, text_global_start)
+        sink_global_end = min(end, text_global_end)
+        sink_tokens = max(0, sink_global_end - sink_global_start)
+        sink_start = sink_global_start - start if sink_tokens else 0
+
+        _real_qkv_gate(
+            q_segment,
+            k_segment,
+            v_segment,
+            scale=attention.softmax_scale,
+        )
+        shape_key = (
+            int(q_segment.shape[1]),
+            int(q_segment.shape[2]),
+            int(q_segment.shape[3]),
+        )
+        if shape_key not in _STATE.density_logged_shapes:
+            density = _estimate_density(
+                q_segment,
+                k_segment,
+                v_segment,
+                scale=attention.softmax_scale,
+                tau=tau,
+                thresh_type=thresh_type,
+                sink_start=sink_start,
+                sink_tokens=sink_tokens,
+            )
+            _emit(
+                "route_density",
+                tau=tau,
+                thresh_type=thresh_type,
+                sequence_tokens=end - start,
+                sink_start=sink_start,
+                sink_tokens=sink_tokens,
+                **density,
+            )
+            _STATE.density_logged_shapes.add(shape_key)
+
+        started = time.perf_counter()
+        segment_output = sol_attn(
+            q_segment,
+            k_segment,
+            v_segment,
+            scale=attention.softmax_scale,
+            tau=tau,
+            thresh_type=thresh_type,
+            sink_start=sink_start,
+            sink_tokens=sink_tokens,
+        )
+        if sink_tokens:
+            segment_output[:, sink_start : sink_start + sink_tokens] = (
+                _dense_text_queries(
+                    q_segment,
+                    k_segment,
+                    v_segment,
+                    start=sink_start,
+                    tokens=sink_tokens,
+                    scale=attention.softmax_scale,
+                )
+            )
+        output[start:end].copy_(segment_output[0])
+
+        if shape_key not in _STATE.first_sparse_logged_shapes:
+            torch.cuda.synchronize(q.device)
+            _emit(
+                "first_sparse_forward",
+                q_shape=list(q_segment.shape),
+                elapsed_s=time.perf_counter() - started,
+                tau=tau,
+                thresh_type=thresh_type,
+                sink_start=sink_start,
+                sink_tokens=sink_tokens,
+            )
+            _STATE.first_sparse_logged_shapes.add(shape_key)
+    return output
+
+
+@torch.no_grad()
+def forward_attention(
+    attention: Any,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor,
+    cu_seqlens_host: tuple[int, ...] | None,
+    max_seqlen: int,
+    ulysses_active: bool,
+) -> torch.Tensor:
+    """Replace only the H3 main DiT attention core."""
+
+    if ulysses_active:
+        from sglang.multimodal_gen.runtime.layers.usp import (
+            _usp_input_all_to_all_packed_qkv,
+            _usp_output_all_to_all,
+        )
+
+        q, k, v = _usp_input_all_to_all_packed_qkv(q, k, v)
+
+    layer_index = getattr(attention, "_sol_attn_layer_index", None)
+    context = _STATE.context
+    if _dense_policy(layer_index, context):
+        output = _dense_varlen(
+            attention,
+            q,
+            k,
+            v,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_host=cu_seqlens_host,
+            max_seqlen=max_seqlen,
+        )
+    else:
+        if context is None:
+            raise RuntimeError("MiniMax-H3 Sol-Attn context was not initialized")
+        boundaries = _normalize_boundaries(
+            cu_seqlens_host or context.cu_seqlens_host,
+            q.shape[0],
+        )
+        output = _sol_varlen(
+            attention,
+            q,
+            k,
+            v,
+            boundaries=boundaries,
+            context=context,
+        )
+
+    if ulysses_active:
+        output = _usp_output_all_to_all(output[None], head_dim=2)[0]
+    return output
+
+
+__all__ = [
+    "StepContext",
+    "begin_model_forward",
+    "emit_event",
+    "forward_attention",
+    "parse_layer_index",
+]

--- a/models/minimax_h3/rtx5090/patches/__init__.py
+++ b/models/minimax_h3/rtx5090/patches/__init__.py
@@ -1,0 +1,1 @@
+"""Pinned SGLang source overlays used by the RTX 5090 runtime."""

--- a/models/minimax_h3/rtx5090/patches/denoising.py
+++ b/models/minimax_h3/rtx5090/patches/denoising.py
@@ -1,0 +1,2381 @@
+# Copied and adapted from: https://github.com/hao-ai-lab/FastVideo
+
+# SPDX-License-Identifier: Apache-2.0
+"""
+Denoising stage for diffusion pipelines.
+"""
+
+import gc
+import inspect
+import math
+import time
+import weakref
+from collections.abc import Callable
+from contextlib import contextmanager
+from dataclasses import dataclass, field, fields
+from enum import Enum
+from functools import lru_cache
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from sglang.kernels.ops.diffusion.fused_linear_gelu import (
+    mount_fused_linear_gelu,
+    unmount_fused_linear_gelu,
+)
+from sglang.multimodal_gen import envs
+from sglang.multimodal_gen.configs.pipeline_configs.base import ModelTaskType, STA_Mode
+from sglang.multimodal_gen.configs.pipeline_configs.flux import (
+    Flux2PipelineConfig,
+    FluxPipelineConfig,
+)
+from sglang.multimodal_gen.configs.pipeline_configs.zimage import ZImagePipelineConfig
+from sglang.multimodal_gen.runtime.breakable_cuda_graph import (
+    prompt_padding as bcg_utils,
+)
+from sglang.multimodal_gen.runtime.cache.cache_dit_integration import (
+    CacheDitConfig,
+    enable_cache_on_dual_transformer,
+    enable_cache_on_transformer,
+    get_scm_mask,
+    refresh_context_on_dual_transformer,
+    refresh_context_on_transformer,
+)
+from sglang.multimodal_gen.runtime.disaggregation.roles import RoleType
+from sglang.multimodal_gen.runtime.distributed import (
+    get_local_torch_device,
+    get_sp_group,
+    get_sp_world_size,
+    get_tp_group,
+    get_world_group,
+    get_world_size,
+    model_parallel_is_initialized,
+)
+from sglang.multimodal_gen.runtime.distributed.cfg_parallel_utils import (
+    run_cfg_parallel,
+    run_two_branch_cfg_parallel,
+)
+from sglang.multimodal_gen.runtime.distributed.cfg_policy import (
+    CFGPolicy,
+    _unwrap,
+    _wrap,
+)
+from sglang.multimodal_gen.runtime.distributed.communication_op import (
+    sequence_model_parallel_all_gather,
+)
+from sglang.multimodal_gen.runtime.distributed.parallel_state import (
+    get_classifier_free_guidance_world_size,
+    world_group_is_initialized,
+)
+from sglang.multimodal_gen.runtime.layers.attention.selector import get_attn_backend
+from sglang.multimodal_gen.runtime.layers.attention.STA_configuration import (
+    configure_sta,
+    save_mask_search_results,
+)
+from sglang.multimodal_gen.runtime.loader.component_loaders.transformer_loader import (
+    TransformerLoader,
+)
+from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
+from sglang.multimodal_gen.runtime.managers.memory_managers.component_manager import (
+    ComponentUse,
+)
+from sglang.multimodal_gen.runtime.managers.memory_managers.component_resident_strategies import (
+    is_fsdp_managed_module,
+)
+from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload import (
+    LayerwiseOffloadableModuleMixin,
+    is_layerwise_offloaded_module,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
+from sglang.multimodal_gen.runtime.pipelines_core.stages.base import (
+    PipelineStage,
+    StageParallelismType,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.wan_ti2v import (
+    blend_wan_ti2v_latents,
+    expand_wan_ti2v_timestep,
+    prepare_wan_ti2v_latents,
+    prepare_wan_ti2v_sp_inputs,
+    should_apply_wan_ti2v,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
+    StageValidators as V,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
+    VerificationResult,
+)
+from sglang.multimodal_gen.runtime.platforms import (
+    AttentionBackendEnum,
+    current_platform,
+)
+from sglang.multimodal_gen.runtime.post_training.rollout_denoising_mixin import (
+    RolloutDenoisingMixin,
+)
+from sglang.multimodal_gen.runtime.server_args import ServerArgs
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.nvtx_pytorch_hooks import maybe_nvtx_range
+from sglang.multimodal_gen.runtime.utils.perf_logger import StageProfiler
+from sglang.multimodal_gen.runtime.utils.precision import (
+    autocast_context as precision_autocast_context,
+)
+from sglang.multimodal_gen.runtime.utils.precision import (
+    autocast_enabled as precision_autocast_enabled,
+)
+from sglang.multimodal_gen.runtime.utils.precision import (
+    resolve_precision,
+)
+from sglang.multimodal_gen.runtime.utils.profiler import SGLDiffusionProfiler
+from sglang.multimodal_gen.runtime.utils.torch_compile import (
+    CompiledModuleRegistry,
+    build_torch_compile_kwargs,
+    maybe_enable_inductor_compute_comm_overlap,
+    resolve_torch_compile_mode,
+)
+from sglang.multimodal_gen.utils import dict_to_3d_list
+
+logger = init_logger(__name__)
+
+
+def _ensure_tensor_model_output(model_output):
+    sample = getattr(model_output, "sample", None)
+    if isinstance(sample, torch.Tensor):
+        return sample
+    return model_output
+
+
+@dataclass(slots=True)
+class DenoisingContext:
+    """Loop-scoped state shared across the denoising skeleton and its hooks."""
+
+    scheduler: Any
+    extra_step_kwargs: dict[str, Any]
+    target_dtype: torch.dtype
+    autocast_enabled: bool
+    timesteps: torch.Tensor
+    num_inference_steps: int
+    num_warmup_steps: int
+    image_kwargs: dict[str, Any]
+    pos_cond_kwargs: dict[str, Any]
+    neg_cond_kwargs: dict[str, Any]
+    latents: torch.Tensor
+    boundary_timestep: float | None
+    z: torch.Tensor | None
+    reserved_frames_mask: torch.Tensor | None
+    seq_len: int | None
+    guidance: torch.Tensor
+    is_warmup: bool
+    cfg_policy: CFGPolicy | None = None
+    trajectory_timesteps: list[torch.Tensor] = field(default_factory=list)
+    trajectory_latents: list[torch.Tensor] = field(default_factory=list)
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def __getitem__(self, key: str) -> Any:
+        return getattr(self, key)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return getattr(self, key, default)
+
+    def to_kwargs(self) -> dict[str, Any]:
+        """Return a shallow field mapping for derived context construction."""
+        return {item.name: getattr(self, item.name) for item in fields(self)}
+
+
+@dataclass(slots=True)
+class DenoisingStepState:
+    """Per-step hot-path state computed once and reused within a denoising step."""
+
+    step_index: int
+    t_host: torch.Tensor
+    t_device: torch.Tensor
+    t_int: int
+    current_model: Any
+    current_guidance_scale: Any
+    attn_metadata: Any | None
+
+
+class DualTransformerExecutionMode(str, Enum):
+    """How a denoising stage uses a second DiT.
+
+    BOUNDARY_EXPERTS means one transformer is selected per timestep.
+    PAIRED_PER_STEP means both transformers participate in each denoising step.
+    """
+
+    BOUNDARY_EXPERTS = "boundary_experts"
+    PAIRED_PER_STEP = "paired_per_step"
+
+
+class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
+    """
+    Stage for running the denoising loop in diffusion pipelines.
+
+    This stage handles the iterative denoising process that transforms
+    the initial noise into the final output.
+    """
+
+    @property
+    def role_affinity(self):
+        return RoleType.DENOISER
+
+    def __init__(
+        self, transformer, scheduler, pipeline=None, transformer_2=None, vae=None
+    ) -> None:
+        super().__init__()
+        self.transformer = transformer
+        self.transformer_2 = transformer_2
+        # cache-dit state (for delayed mounting and idempotent control)
+        self._cache_dit_enabled = False
+        self._cached_num_steps = None
+        # fused linear+GELU state: whether the cublasLt-epilogue fusion is
+        # currently mounted on the transformers (quality="high" batches only).
+        self._fused_gelu_mounted = False
+        self._torch_compile_registry = CompiledModuleRegistry()
+        # Breakable CUDA graph runners, one per transformer module (lazy).
+        self._bcg_runners: dict[int, Any] = {}
+
+        hidden_size = self.server_args.pipeline_config.dit_config.hidden_size
+        num_attention_heads = (
+            self.server_args.pipeline_config.dit_config.num_attention_heads
+        )
+        attn_head_size = getattr(
+            self.server_args.pipeline_config.dit_config,
+            "attention_head_dim",
+            hidden_size // num_attention_heads,
+        )
+
+        # torch compile
+        # list of offloaded dit modules if torch compile is enabled. cleared after compile and warmup
+        self._offloaded_dit_modules_for_compile: list[torch.nn.Module] = []
+        # layerwise-offload and then compile to avoid OOM
+        for transformer in filter(None, [self.transformer, self.transformer_2]):
+            self._maybe_offload_during_compile(transformer)
+            self._maybe_torch_compile(transformer)
+
+        self.scheduler = scheduler
+        self.vae = vae
+        self.pipeline = weakref.ref(pipeline) if pipeline else None
+
+        selected_attention_backend = self._infer_transformer_attention_backend()
+        # precision-constraint: attention backend metadata allocation currently assumes fp16;
+        # do not replace with user precision policy without auditing backend support.
+        self.attn_backend = get_attn_backend(
+            head_size=attn_head_size,
+            dtype=torch.float16,
+            selected_attention_backend=selected_attention_backend,
+        )
+
+        # cfg
+        self.guidance = None
+
+        # misc
+        self.profiler = None
+        self._is_warmed_up = False
+        self._extra_func_kwarg_names_cache: dict[int, tuple[bool, frozenset[str]]] = {}
+
+    def _infer_transformer_attention_backend(self) -> AttentionBackendEnum | None:
+        backends = {
+            backend
+            for transformer in (self.transformer, self.transformer_2)
+            if transformer is not None
+            for module in transformer.modules()
+            if isinstance(
+                (backend := getattr(module, "backend", None)), AttentionBackendEnum
+            )
+        }
+        if not backends:
+            return None
+        if len(backends) > 1:
+            sparse_backends = {backend for backend in backends if backend.is_sparse}
+            selected_backend = (
+                sorted(sparse_backends, key=lambda backend: backend.name)[0]
+                if sparse_backends
+                else sorted(backends, key=lambda backend: backend.name)[0]
+            )
+            logger.warning(
+                "Multiple transformer attention backends detected: %s. "
+                "Using %s for denoising metadata.",
+                sorted(backend.name.lower() for backend in backends),
+                selected_backend.name.lower(),
+            )
+            return selected_backend
+        return next(iter(backends))
+
+    def component_uses(
+        self, server_args: ServerArgs, stage_name: str | None = None
+    ) -> list[ComponentUse]:
+        stage_name = self._component_stage_name(stage_name)
+        uses: list[ComponentUse] = []
+        if self.vae is not None:
+            vae_dtype = resolve_precision(
+                server_args, "vae", precision_attr="vae_precision"
+            )
+            uses.append(
+                ComponentUse(
+                    stage_name=stage_name,
+                    component_name="vae",
+                    target_dtype=vae_dtype,
+                )
+            )
+        for default_name, module in (
+            ("transformer", self.transformer),
+            ("transformer_2", self.transformer_2),
+        ):
+            if module is None:
+                continue
+            component_name = self._component_name_for_stage_module(module, default_name)
+            uses.append(
+                ComponentUse(
+                    stage_name=stage_name,
+                    component_name=component_name,
+                    phase=component_name,
+                    preferred_ready_after_request=component_name == "transformer",
+                    memory_intensive=True,
+                )
+            )
+        return uses
+
+    def _component_name_for_stage_module(
+        self, module: nn.Module | None, default_name: str
+    ) -> str:
+        pipeline = self.pipeline() if self.pipeline else None
+        if pipeline is None or module is None:
+            return default_name
+        for name, candidate in pipeline.modules.items():
+            if candidate is module:
+                return name
+        return default_name
+
+    def _maybe_offload_during_compile(self, module: object) -> None:
+        """
+        Layerwise-offload the DiT so the compile warmup autotunes each layer
+        with only itself resident; forward() restores it after the warmup.
+        """
+        args = self.server_args
+        requested_layerwise = set(args.layerwise_offload_components or ())
+        if "dit" in requested_layerwise:
+            # The pipeline configures this permanent user-requested offload
+            # after stage construction. Do not register it as a temporary
+            # compile-only offload that the first real request would disable.
+            return
+        if (
+            not args.enable_torch_compile
+            or not args.offload_during_compile
+            or not args.warmup
+            or not self._owns_compile_warmup_lifecycle()
+            or args.use_fsdp_inference
+            or self._cache_dit_requested()
+            or not isinstance(module, LayerwiseOffloadableModuleMixin)
+            or is_layerwise_offloaded_module(module)
+        ):
+            return
+        module.configure_layerwise_offload(args)
+        if is_layerwise_offloaded_module(module):
+            self._offloaded_dit_modules_for_compile.append(module)
+
+    def _owns_compile_warmup_lifecycle(self) -> bool:
+        """Whether ``forward`` enters ``_offload_for_torch_compile_warmup``.
+
+        Custom denoising loops opt in explicitly after wiring the same restore
+        lifecycle. This keeps the safety guard without silently disabling the
+        optimization solely because a model overrides ``forward``.
+        """
+        return type(self).forward is DenoisingStage.forward
+
+    def _move_resident_components_for_warmup(self) -> list[torch.nn.Module]:
+        """Move resident non-DiT components off-device while the warmup
+        denoising (the compile/autotune peak) runs; forward() moves them back."""
+        pipeline = self.pipeline() if self.pipeline is not None else None
+        if pipeline is None:
+            return []
+        dit_ids = {id(self.transformer), id(self.transformer_2)}
+        moved = []
+        for module in pipeline.modules.values():
+            if (
+                isinstance(module, torch.nn.Module)
+                and id(module) not in dit_ids
+                and not is_fsdp_managed_module(module)
+                and not is_layerwise_offloaded_module(module)
+            ):
+                param = next(module.parameters(), None)
+                if param is not None and param.device.type != "cpu":
+                    module.to("cpu")
+                    moved.append(module)
+        return moved
+
+    def _maybe_torch_compile(self, module: object) -> None:
+        """
+        Compile a module with torch.compile, and enable inductor overlap tweak if available.
+        No-op if torch compile is disabled or the object is not a nn.Module.
+        """
+        if self.server_args.enable_breakable_cuda_graph:
+            # BCG captures the eager kernel stream itself; compiling first
+            # would capture inductor's own cudagraph trees / guards.
+            return
+        if not getattr(
+            self.server_args, "enable_torch_compile", False
+        ) or not isinstance(module, nn.Module):
+            return
+        if self._cache_dit_requested() and not self._cache_dit_enabled:
+            logger.debug("Deferring torch.compile until cache-dit is enabled")
+            return
+        if self._torch_compile_registry.is_compiled(module):
+            return
+
+        if current_platform.is_npu():
+            compile_kwargs = build_torch_compile_kwargs(mode=None)
+            logger.info("Compiling transformer with torchair backend on NPU")
+        else:
+            maybe_enable_inductor_compute_comm_overlap()
+            dit_config = getattr(self.server_args.pipeline_config, "dit_config", None)
+            mode = resolve_torch_compile_mode(
+                "SGLANG_TORCH_COMPILE_MODE",
+                config=dit_config,
+                default="max-autotune-no-cudagraphs",
+            )
+            compile_kwargs = build_torch_compile_kwargs(mode=mode)
+            logger.info(f"Compiling transformer with mode: {mode}")
+
+        if getattr(self.server_args, "regional_compile", False):
+            compiled_count = self._torch_compile_registry.compile_regions_once(
+                module,
+                compile_kwargs=compile_kwargs,
+            )
+            logger.info(
+                "Enabled regional torch.compile for %d submodules in %s",
+                compiled_count,
+                type(module).__name__,
+            )
+        else:
+            # TODO(triple-mu): support customized fullgraph and dynamic in the future
+            self._torch_compile_registry.compile_once(
+                module,
+                compile_kwargs=compile_kwargs,
+            )
+
+    def _maybe_enable_cache_dit_and_torch_compile(
+        self, num_inference_steps: int | tuple[int, int], batch: Req
+    ) -> None:
+        """Apply request-dependent transformer acceleration in trace-safe order."""
+        self._maybe_toggle_fused_gelu(batch)
+        self._maybe_enable_cache_dit(num_inference_steps, batch)
+        for transformer in filter(None, [self.transformer, self.transformer_2]):
+            self._maybe_torch_compile(transformer)
+
+    def _maybe_toggle_fused_gelu(self, batch: Req) -> None:
+        """Mount/unmount the cublasLt linear+GELU fusion for this batch.
+
+        The fused epilogue is numerically equivalent only at half-precision
+        rounding level (not bit-exact), so it is mounted for
+        ``quality="high"`` requests and unmounted otherwise -- the
+        ``"lossless"`` default runs the unmodified reference path bit-for-bit.
+        ``quality`` participates in the dynamic-batch signature, so a worker
+        batch is uniform in ``quality`` and this process-wide transition is
+        safe at the batch boundary. Mounting is all-or-nothing per
+        transformer (any ineligible marked site keeps the whole transformer
+        on the reference path); models without marked sites are no-ops.
+        """
+        want = getattr(batch.sampling_params, "quality", "lossless") == "high"
+        if want == self._fused_gelu_mounted:
+            return
+        mounted = False
+        for transformer in filter(None, [self.transformer, self.transformer_2]):
+            if want:
+                mounted |= mount_fused_linear_gelu(transformer)
+            else:
+                unmount_fused_linear_gelu(transformer)
+        self._fused_gelu_mounted = want
+        if want and mounted:
+            logger.info(
+                "Mounted fused linear+GELU (cublasLt epilogue) for quality=high"
+            )
+
+    def _cache_dit_dual_model_name(self) -> str:
+        return "wan2.2"
+
+    def _cache_dit_requested(self) -> bool:
+        return envs.SGLANG_CACHE_DIT_ENABLED
+
+    def _cache_dit_secondary_uses_primary_config(self) -> bool:
+        return False
+
+    def _dual_transformer_execution_mode(self) -> DualTransformerExecutionMode | None:
+        if self.transformer_2 is None:
+            return None
+        return DualTransformerExecutionMode.BOUNDARY_EXPERTS
+
+    def _cache_dit_step_counts(
+        self, num_inference_steps: int | tuple[int, int]
+    ) -> tuple[int, int | None]:
+        if isinstance(num_inference_steps, tuple):
+            primary_steps, secondary_steps = num_inference_steps
+            return int(primary_steps), int(secondary_steps)
+        steps = int(num_inference_steps)
+        mode = self._dual_transformer_execution_mode()
+        if mode is None:
+            return steps, None
+        if mode == DualTransformerExecutionMode.PAIRED_PER_STEP:
+            return steps, steps
+        raise ValueError("Boundary-expert dual transformers require split step counts.")
+
+    @staticmethod
+    def _parse_cache_dit_scm_bins() -> tuple[list[int] | None, list[int] | None, str]:
+        scm_preset = envs.SGLANG_CACHE_DIT_SCM_PRESET
+        compute_bins_str = envs.SGLANG_CACHE_DIT_SCM_COMPUTE_BINS
+        cache_bins_str = envs.SGLANG_CACHE_DIT_SCM_CACHE_BINS
+        compute_bins = None
+        cache_bins = None
+        if compute_bins_str and cache_bins_str:
+            try:
+                compute_bins = [int(x.strip()) for x in compute_bins_str.split(",")]
+                cache_bins = [int(x.strip()) for x in cache_bins_str.split(",")]
+            except ValueError as exc:
+                logger.warning("Failed to parse SCM bins: %s. SCM disabled.", exc)
+                scm_preset = "none"
+        elif compute_bins_str or cache_bins_str:
+            logger.warning(
+                "SCM custom bins require both compute_bins and cache_bins. "
+                "Only one was provided (compute=%s, cache=%s). Falling back to preset '%s'.",
+                compute_bins_str,
+                cache_bins_str,
+                scm_preset,
+            )
+        return compute_bins, cache_bins, scm_preset
+
+    def _cache_dit_scm_masks(
+        self, primary_num_steps: int, secondary_num_steps: int | None = None
+    ) -> tuple[str, str, list[int] | None, list[int] | None]:
+        scm_compute_bins, scm_cache_bins, scm_preset = self._parse_cache_dit_scm_bins()
+        scm_policy = envs.SGLANG_CACHE_DIT_SCM_POLICY
+        steps_computation_mask = get_scm_mask(
+            preset=scm_preset,
+            num_inference_steps=primary_num_steps,
+            compute_bins=scm_compute_bins,
+            cache_bins=scm_cache_bins,
+        )
+
+        steps_computation_mask_2 = None
+        if secondary_num_steps is not None:
+            if (
+                self._cache_dit_secondary_uses_primary_config()
+                and secondary_num_steps == primary_num_steps
+            ):
+                steps_computation_mask_2 = steps_computation_mask
+            else:
+                steps_computation_mask_2 = get_scm_mask(
+                    preset=scm_preset,
+                    num_inference_steps=secondary_num_steps,
+                    compute_bins=scm_compute_bins,
+                    cache_bins=scm_cache_bins,
+                )
+        return scm_preset, scm_policy, steps_computation_mask, steps_computation_mask_2
+
+    @staticmethod
+    def _build_cache_dit_config(
+        num_inference_steps: int,
+        steps_computation_mask: list[int] | None,
+        scm_policy: str,
+        *,
+        secondary: bool = False,
+    ) -> CacheDitConfig:
+        return CacheDitConfig(
+            enabled=True,
+            Fn_compute_blocks=(
+                envs.SGLANG_CACHE_DIT_SECONDARY_FN
+                if secondary
+                else envs.SGLANG_CACHE_DIT_FN
+            ),
+            Bn_compute_blocks=(
+                envs.SGLANG_CACHE_DIT_SECONDARY_BN
+                if secondary
+                else envs.SGLANG_CACHE_DIT_BN
+            ),
+            max_warmup_steps=(
+                envs.SGLANG_CACHE_DIT_SECONDARY_WARMUP
+                if secondary
+                else envs.SGLANG_CACHE_DIT_WARMUP
+            ),
+            residual_diff_threshold=(
+                envs.SGLANG_CACHE_DIT_SECONDARY_RDT
+                if secondary
+                else envs.SGLANG_CACHE_DIT_RDT
+            ),
+            max_continuous_cached_steps=(
+                envs.SGLANG_CACHE_DIT_SECONDARY_MC
+                if secondary
+                else envs.SGLANG_CACHE_DIT_MC
+            ),
+            enable_taylorseer=(
+                envs.SGLANG_CACHE_DIT_SECONDARY_TAYLORSEER
+                if secondary
+                else envs.SGLANG_CACHE_DIT_TAYLORSEER
+            ),
+            taylorseer_order=(
+                envs.SGLANG_CACHE_DIT_SECONDARY_TS_ORDER
+                if secondary
+                else envs.SGLANG_CACHE_DIT_TS_ORDER
+            ),
+            num_inference_steps=num_inference_steps,
+            steps_computation_mask=steps_computation_mask,
+            steps_computation_policy=scm_policy,
+        )
+
+    def _maybe_enable_cache_dit(
+        self, num_inference_steps: int | tuple[int, int], batch: Req
+    ) -> None:
+        """Enable cache-dit on the transformers if configured (idempotent).
+
+        This method should be called after the transformer is fully loaded
+        and before torch.compile is applied.
+
+        For dual-transformer models (e.g., Wan2.2), this enables cache-dit on both
+        transformers with (potentially) different configurations.
+
+        """
+        if self.server_args.enable_breakable_cuda_graph:
+            # Cache-DiT wraps transformer.forward with step-skipping control
+            # flow that must not be baked into a captured CUDA graph.
+            return
+        # NOTE: When a new request arrives, we need to refresh the cache-dit context.
+        if self._cache_dit_enabled:
+            primary_num_steps, secondary_num_steps = self._cache_dit_step_counts(
+                num_inference_steps
+            )
+            scm_preset, scm_policy, steps_computation_mask, steps_computation_mask_2 = (
+                self._cache_dit_scm_masks(primary_num_steps, secondary_num_steps)
+            )
+            if self.transformer_2 is not None:
+                assert secondary_num_steps is not None
+                refresh_context_on_dual_transformer(
+                    self.transformer,
+                    self.transformer_2,
+                    primary_num_steps,
+                    secondary_num_steps,
+                    steps_computation_mask=steps_computation_mask,
+                    steps_computation_mask_2=steps_computation_mask_2,
+                    steps_computation_policy=scm_policy,
+                )
+            else:
+                scm_preset = None if scm_preset == "none" else scm_preset
+                refresh_context_on_transformer(
+                    self.transformer,
+                    primary_num_steps,
+                    scm_preset=scm_preset,
+                )
+            return
+
+        # Keep cache-dit disabled for ordinary warmup, but allow torch.compile
+        # warmup to mount cache-dit before Dynamo traces the transformer.
+        if not self._cache_dit_requested():
+            return
+        if batch.is_warmup and not getattr(
+            self.server_args, "enable_torch_compile", False
+        ):
+            return
+
+        primary_num_steps, secondary_num_steps = self._cache_dit_step_counts(
+            num_inference_steps
+        )
+        world_size = get_world_size()
+        parallelized = world_size > 1
+
+        sp_group = None
+        tp_group = None
+        if parallelized:
+            sp_group_candidate = get_sp_group()
+            tp_group_candidate = get_tp_group()
+
+            sp_world_size = sp_group_candidate.world_size if sp_group_candidate else 1
+            tp_world_size = tp_group_candidate.world_size if tp_group_candidate else 1
+
+            has_sp = sp_world_size > 1
+            has_tp = tp_world_size > 1
+
+            sp_group = sp_group_candidate.device_group if has_sp else None
+            tp_group = tp_group_candidate.device_group if has_tp else None
+
+            logger.info(
+                "cache-dit enabled in distributed environment (world_size=%d, has_sp=%s, has_tp=%s)",
+                world_size,
+                has_sp,
+                has_tp,
+            )
+        _, scm_policy, steps_computation_mask, steps_computation_mask_2 = (
+            self._cache_dit_scm_masks(primary_num_steps, secondary_num_steps)
+        )
+        primary_config = self._build_cache_dit_config(
+            primary_num_steps,
+            steps_computation_mask=steps_computation_mask,
+            scm_policy=scm_policy,
+        )
+
+        if self.transformer_2 is not None:
+            # dual transformer
+            # build config for secondary transformer (low-noise expert)
+            # uses secondary parameters which inherit from primary if not explicitly set
+            assert secondary_num_steps is not None
+            secondary_config = (
+                primary_config
+                if self._cache_dit_secondary_uses_primary_config()
+                else self._build_cache_dit_config(
+                    secondary_num_steps,
+                    steps_computation_mask=steps_computation_mask_2,
+                    scm_policy=scm_policy,
+                    secondary=True,
+                )
+            )
+
+            # for dual transformers, must use BlockAdapter to enable cache on both simultaneously.
+            # Don't call enable_cache separately on each transformer.
+            self.transformer, self.transformer_2 = enable_cache_on_dual_transformer(
+                self.transformer,
+                self.transformer_2,
+                primary_config,
+                secondary_config,
+                model_name=self._cache_dit_dual_model_name(),
+                sp_group=sp_group,
+                tp_group=tp_group,
+            )
+            logger.info(
+                "cache-dit enabled on dual transformers (steps=%d, %d)",
+                primary_num_steps,
+                secondary_num_steps,
+            )
+        else:
+            # single transformer
+            self.transformer = enable_cache_on_transformer(
+                self.transformer,
+                primary_config,
+                model_name="transformer",
+                sp_group=sp_group,
+                tp_group=tp_group,
+                has_separate_cfg=batch.do_classifier_free_guidance,
+            )
+            logger.info(
+                "cache-dit enabled on transformer (steps=%d, Fn=%d, Bn=%d, rdt=%.3f)",
+                primary_num_steps,
+                primary_config.Fn_compute_blocks,
+                primary_config.Bn_compute_blocks,
+                primary_config.residual_diff_threshold,
+            )
+
+        self._cache_dit_enabled = True
+        self._cached_num_steps = num_inference_steps
+
+    @lru_cache(maxsize=8)
+    def _build_guidance(self, batch_size, target_dtype, device, guidance_val):
+        """Builds a guidance tensor. This method is cached."""
+        if isinstance(
+            self.server_args.pipeline_config, FluxPipelineConfig
+        ) and not isinstance(self.server_args.pipeline_config, Flux2PipelineConfig):
+            guidance_val = guidance_val * 1000.0
+        return torch.full(
+            (batch_size,),
+            guidance_val,
+            dtype=target_dtype,
+            device=device,
+        )
+
+    def get_or_build_guidance(self, bsz: int, dtype, device):
+        """
+        Get the guidance tensor, using a cached version if available.
+
+        This method retrieves a cached guidance tensor using `_build_guidance`.
+        The caching is based on batch size, dtype, device, and the guidance value,
+        preventing repeated tensor creation within the denoising loop.
+        """
+        if self.server_args.pipeline_config.should_use_guidance:
+            # TODO: should the guidance_scale be picked-up from sampling_params?
+            guidance_val = self.server_args.pipeline_config.embedded_cfg_scale
+            return self._build_guidance(bsz, dtype, device, guidance_val)
+        else:
+            return None
+
+    @property
+    def parallelism_type(self) -> StageParallelismType:
+        # return StageParallelismType.CFG_PARALLEL if get_global_server_args().enable_cfg_parallel else StageParallelismType.REPLICATED
+        return StageParallelismType.REPLICATED
+
+    def _handle_boundary_ratio(
+        self,
+        server_args,
+        batch,
+        scheduler,
+    ):
+        """
+        (Wan2.2) Calculate timestep to switch from high noise expert to low noise expert
+        """
+        boundary_ratio = server_args.pipeline_config.dit_config.boundary_ratio
+        if batch.boundary_ratio is not None:
+            logger.info(
+                "Overriding boundary ratio from %s to %s",
+                boundary_ratio,
+                batch.boundary_ratio,
+            )
+            boundary_ratio = batch.boundary_ratio
+
+        if boundary_ratio is not None:
+            num_train_timesteps = getattr(scheduler, "num_train_timesteps", None)
+            if num_train_timesteps is None:
+                num_train_timesteps = scheduler.config.num_train_timesteps
+            boundary_timestep = boundary_ratio * num_train_timesteps
+        else:
+            boundary_timestep = None
+
+        return boundary_timestep
+
+    def _prepare_denoising_loop(self, batch: Req, server_args: ServerArgs):
+        """
+        Prepare all necessary invariant variables for the denoising loop.
+
+        Returns:
+            A context object containing the invariant state for the denoising loop.
+        """
+        batch = server_args.pipeline_config.expand_conditioning_to_sample_batch(batch)
+
+        assert self.transformer is not None
+        pipeline = self.pipeline() if self.pipeline else None
+        scheduler = batch.scheduler
+        assert scheduler is not None
+
+        dual_transformer_mode = self._dual_transformer_execution_mode()
+        uses_boundary_transformer_2 = (
+            dual_transformer_mode == DualTransformerExecutionMode.BOUNDARY_EXPERTS
+        )
+        boundary_timestep = (
+            self._handle_boundary_ratio(server_args, batch, scheduler)
+            if uses_boundary_transformer_2
+            else None
+        )
+        # Get timesteps and calculate warmup steps
+        timesteps = batch.timesteps
+        num_inference_steps = batch.num_inference_steps
+        num_warmup_steps = len(timesteps) - num_inference_steps * scheduler.order
+
+        if uses_boundary_transformer_2:
+            assert boundary_timestep is not None, "boundary_timestep must be provided"
+            num_high_noise_steps = (timesteps >= boundary_timestep).sum().item()
+            num_low_noise_steps = num_inference_steps - num_high_noise_steps
+            cache_dit_num_inference_steps = (num_high_noise_steps, num_low_noise_steps)
+        else:
+            cache_dit_num_inference_steps = num_inference_steps
+
+        transformer_was_loaded = server_args.model_loaded["transformer"]
+        if not transformer_was_loaded:
+            # FIXME: reuse more code
+            loader = TransformerLoader()
+            self.transformer = loader.load(
+                server_args.model_paths["transformer"], server_args, "transformer"
+            )
+
+        self._maybe_enable_cache_dit_and_torch_compile(
+            cache_dit_num_inference_steps, batch
+        )
+
+        if not transformer_was_loaded:
+            if pipeline:
+                pipeline.add_module("transformer", self.transformer)
+            server_args.model_loaded["transformer"] = True
+
+        if batch.rollout:
+            self._maybe_prepare_rollout(batch)
+
+        # Prepare extra step kwargs for scheduler
+        extra_step_kwargs = self.prepare_extra_func_kwargs(
+            scheduler.step,
+            {"generator": batch.generator, "eta": batch.eta, "batch": batch},
+        )
+
+        # Setup precision and autocast settings
+        target_dtype = resolve_precision(
+            server_args, "dit", precision_attr="dit_precision"
+        )
+        autocast_enabled = precision_autocast_enabled(
+            target_dtype, server_args.disable_autocast
+        )
+
+        # Prepare image latents and embeddings for I2V generation
+        image_embeds = batch.image_embeds
+        if len(image_embeds) > 0:
+            image_embeds = [
+                image_embed.to(target_dtype) for image_embed in image_embeds
+            ]
+
+        # Prepare STA parameters
+        if self.attn_backend.get_enum() == AttentionBackendEnum.SLIDING_TILE_ATTN:
+            self.prepare_sta_param(batch, server_args)
+
+        # Get latents and embeddings
+        latents = batch.latents
+        # Removed Tensor truthiness assert to avoid GPU sync
+        if batch.do_classifier_free_guidance:
+            assert batch.negative_prompt_embeds is not None
+            # Removed Tensor truthiness assert to avoid GPU sync
+
+        should_preprocess_for_wan_ti2v = should_apply_wan_ti2v(batch, server_args)
+
+        # TI2V specific preparations - before SP sharding
+        if should_preprocess_for_wan_ti2v:
+            vae_dtype = resolve_precision(
+                server_args, "vae", precision_attr="vae_precision"
+            )
+            with self.use_declared_component(
+                component_name="vae",
+                module=self.vae,
+                target_dtype=vae_dtype,
+            ) as vae:
+                assert vae is not None
+                self.vae = vae
+                seq_len, z, reserved_frames_masks = prepare_wan_ti2v_latents(
+                    self.vae,
+                    latents,
+                    target_dtype,
+                    vae_dtype,
+                    batch,
+                    server_args,
+                )
+        else:
+            seq_len, z, reserved_frames_masks = (
+                None,
+                None,
+                None,
+            )
+
+        # Handle sequence parallelism after TI2V processing
+        self._preprocess_sp_latents(batch, server_args)
+        latents = batch.latents
+
+        # Shard z and reserved_frames_mask for TI2V if SP is enabled
+        if should_preprocess_for_wan_ti2v:
+            reserved_frames_mask_sp, z_sp = prepare_wan_ti2v_sp_inputs(
+                z, reserved_frames_masks, batch
+            )
+        else:
+            reserved_frames_mask_sp, z_sp = (
+                (
+                    reserved_frames_masks[0]
+                    if reserved_frames_masks is not None
+                    else None
+                ),
+                z,
+            )
+
+        guidance = self.get_or_build_guidance(
+            # TODO: replace with raw_latent_shape?
+            latents.shape[0],
+            latents.dtype,
+            latents.device,
+        )
+
+        image_kwargs = self.prepare_extra_func_kwargs(
+            getattr(self.transformer, "forward", self.transformer),
+            {
+                # TODO: make sure on-device
+                "encoder_hidden_states_image": image_embeds,
+                "mask_strategy": dict_to_3d_list(None, t_max=50, l_max=60, h_max=24),
+            },
+        )
+
+        pos_cond_kwargs = self.prepare_extra_func_kwargs(
+            getattr(self.transformer, "forward", self.transformer),
+            {
+                "encoder_hidden_states_2": batch.clip_embedding_pos,
+                "encoder_attention_mask": batch.prompt_attention_mask,
+                "encoder_hidden_states_mask": (
+                    batch.prompt_embeds_mask
+                    if batch.prompt_embeds_mask is not None
+                    else batch.prompt_attention_mask
+                ),
+            }
+            | server_args.pipeline_config.prepare_pos_cond_kwargs(
+                batch,
+                self.device,
+                self._get_transformer_attr("rotary_emb"),
+                dtype=target_dtype,
+            )
+            | dict(
+                encoder_hidden_states=server_args.pipeline_config.get_pos_prompt_embeds(
+                    batch
+                )
+            ),
+        )
+
+        if batch.do_classifier_free_guidance:
+            neg_cond_kwargs = self.prepare_extra_func_kwargs(
+                getattr(self.transformer, "forward", self.transformer),
+                {
+                    "encoder_hidden_states_2": batch.clip_embedding_neg,
+                    "encoder_attention_mask": batch.negative_attention_mask,
+                    "encoder_hidden_states_mask": (
+                        batch.negative_prompt_embeds_mask
+                        if batch.negative_prompt_embeds_mask is not None
+                        else batch.negative_attention_mask
+                    ),
+                }
+                | server_args.pipeline_config.prepare_neg_cond_kwargs(
+                    batch,
+                    self.device,
+                    self._get_transformer_attr("rotary_emb"),
+                    dtype=target_dtype,
+                )
+                | dict(
+                    encoder_hidden_states=server_args.pipeline_config.get_neg_prompt_embeds(
+                        batch
+                    )
+                ),
+            )
+        else:
+            neg_cond_kwargs = {}
+
+        cfg_policy = server_args.pipeline_config.cfg_policy.build(
+            batch, image_kwargs, pos_cond_kwargs, neg_cond_kwargs
+        )
+
+        return DenoisingContext(
+            scheduler=scheduler,
+            extra_step_kwargs=extra_step_kwargs,
+            target_dtype=target_dtype,
+            autocast_enabled=autocast_enabled,
+            timesteps=timesteps,
+            num_inference_steps=num_inference_steps,
+            num_warmup_steps=num_warmup_steps,
+            image_kwargs=image_kwargs,
+            pos_cond_kwargs=pos_cond_kwargs,
+            neg_cond_kwargs=neg_cond_kwargs,
+            latents=latents,
+            boundary_timestep=boundary_timestep,
+            z=z_sp,
+            reserved_frames_mask=reserved_frames_mask_sp,
+            seq_len=seq_len,
+            guidance=guidance,
+            is_warmup=batch.is_warmup,
+            cfg_policy=cfg_policy,
+        )
+
+    def _before_denoising_loop(
+        self, ctx: DenoisingContext, batch: Req, server_args: ServerArgs
+    ) -> None:
+        """Prepare scheduler state before entering the shared denoising loop."""
+        self._reset_scheduler_loop_state(ctx.scheduler)
+        ctx.scheduler.set_begin_index(0)
+        self._init_cfg_gate_state(ctx, batch, server_args)
+
+    def _reset_scheduler_loop_state(self, scheduler) -> None:
+        if hasattr(scheduler, "_step_index"):
+            scheduler._step_index = None
+        if hasattr(scheduler, "_begin_index"):
+            scheduler._begin_index = None
+        if hasattr(scheduler, "lower_order_nums"):
+            scheduler.lower_order_nums = 0
+        if hasattr(scheduler, "last_sample"):
+            scheduler.last_sample = None
+        if hasattr(scheduler, "this_order"):
+            scheduler.this_order = 0
+
+        solver_order = getattr(getattr(scheduler, "config", None), "solver_order", 0)
+        if solver_order:
+            if hasattr(scheduler, "model_outputs"):
+                scheduler.model_outputs = [None] * solver_order
+            if hasattr(scheduler, "timestep_list"):
+                scheduler.timestep_list = [None] * solver_order
+
+    def _init_cfg_gate_state(
+        self, ctx: DenoisingContext, batch: Req, server_args: ServerArgs
+    ) -> None:
+        """Initialize optional CFG residual reuse for the current denoising loop."""
+        fraction = envs.SGLANG_DIFFUSION_CFG_GATE_STEP
+        if not 0.0 <= fraction <= 1.0:
+            raise ValueError(
+                "SGLANG_DIFFUSION_CFG_GATE_STEP must be between 0.0 and 1.0, "
+                f"got {fraction}."
+            )
+
+        num_steps = len(ctx.timesteps)
+        requested = fraction < 1.0 and batch.do_classifier_free_guidance
+        active = requested and not server_args.enable_cfg_parallel
+        gate_step = int(num_steps * fraction) if active else num_steps + 1
+        ctx.extra["cfg_gate_state"] = {
+            "fraction": fraction,
+            "requested": requested,
+            "active": active,
+            "gate_step": gate_step,
+            "delta": None,
+            "model_id": None,
+            "fresh_uncond": 0,
+            "reused": 0,
+            "invalidations": 0,
+        }
+
+        if not (active or requested):
+            return
+
+        if ctx.is_warmup or (
+            world_group_is_initialized() and get_world_group().local_rank != 0
+        ):
+            return
+
+        if active:
+            logger.info(
+                "CFG gating enabled: reuse unconditioned residual after step %d/%d "
+                "(fraction=%.3f).",
+                gate_step,
+                num_steps,
+                fraction,
+            )
+            if batch.guidance_rescale > 0:
+                logger.warning(
+                    "CFG gating is enabled with guidance_rescale=%s; benchmark image "
+                    "quality before using this setting in production.",
+                    batch.guidance_rescale,
+                )
+        elif requested:
+            logger.info(
+                "CFG gating requested but skipped because CFG parallel is enabled."
+            )
+
+    def _get_transformer_attr(self, name: str) -> Any:
+        seen: set[int] = set()
+        stack = [self.transformer]
+        while stack:
+            module = stack.pop()
+            if module is None or id(module) in seen:
+                continue
+            seen.add(id(module))
+
+            value = getattr(module, name, None)
+            if value is not None:
+                return value
+
+            for wrapper_attr in ("_fsdp_wrapped_module", "module", "_orig_mod"):
+                wrapped = getattr(module, wrapper_attr, None)
+                if wrapped is not None:
+                    stack.append(wrapped)
+        return None
+
+    def _prepare_step_state(
+        self,
+        ctx: DenoisingContext,
+        batch: Req,
+        server_args: ServerArgs,
+        step_index: int,
+        t_host: torch.Tensor,
+        timesteps_cpu: torch.Tensor,
+    ) -> DenoisingStepState:
+        """Build the per-step state shared by the loop and model-specific hooks."""
+        t_int = int(t_host.item())
+        t_device = ctx.timesteps[step_index]
+        current_model, current_guidance_scale = self._select_and_manage_model(
+            t_int=t_int,
+            boundary_timestep=ctx.boundary_timestep,
+            server_args=server_args,
+            batch=batch,
+        )
+        attn_metadata = self._prepare_step_attn_metadata(
+            ctx=ctx,
+            batch=batch,
+            server_args=server_args,
+            step_index=step_index,
+            t_int=t_int,
+            timesteps_cpu=timesteps_cpu,
+        )
+        return DenoisingStepState(
+            step_index=step_index,
+            t_host=t_host,
+            t_device=t_device,
+            t_int=t_int,
+            current_model=current_model,
+            current_guidance_scale=current_guidance_scale,
+            attn_metadata=attn_metadata,
+        )
+
+    def _prepare_step_attn_metadata(
+        self,
+        ctx: DenoisingContext,
+        batch: Req,
+        server_args: ServerArgs,
+        step_index: int,
+        t_int: int,
+        timesteps_cpu: torch.Tensor,
+    ) -> Any | None:
+        """Build attention metadata for the current denoising step."""
+        # Keep attention metadata preparation overridable so model-specific stages
+        # can preserve their original semantics without duplicating step state setup.
+        return self._build_attn_metadata(
+            step_index,
+            batch,
+            server_args,
+            timestep_value=t_int,
+            timesteps=timesteps_cpu,
+        )
+
+    def _get_prompt_embeds_validator(
+        self, batch: Req
+    ) -> Callable[[Any], bool] | list[Callable[[Any], bool]]:
+        """Return the prompt-embedding validator used by verify_input."""
+        return V.list_not_empty
+
+    def _get_negative_prompt_embeds_validator(
+        self, batch: Req
+    ) -> Callable[[Any], bool] | list[Callable[[Any], bool]]:
+        """Return the negative-prompt validator used by verify_input."""
+        return lambda x: not batch.do_classifier_free_guidance or V.list_not_empty(x)
+
+    def _run_denoising_step(
+        self,
+        ctx: DenoisingContext,
+        step: DenoisingStepState,
+        batch: Req,
+        server_args: ServerArgs,
+    ) -> None:
+        """Run one scheduler-backed denoising step in the shared base path.
+
+        Model-specific stages should override this instead of the whole loop
+        whenever possible to achieve better performance. Overrides that bypass
+        ``_predict_noise_with_cfg`` / ``ctx.scheduler.step`` will lose the
+        inner ``predict_noise`` / ``scheduler_step`` NVTX markers emitted
+        below; mirror them in the override if those markers are needed.
+        """
+        use_nvtx = self.current_use_nvtx
+        # 1. Prepare latent inputs in the model's compute dtype.
+        latent_model_input = ctx.latents.to(ctx.target_dtype)
+        if batch.image_latent is not None:
+            assert (
+                not server_args.pipeline_config.task_type == ModelTaskType.TI2V
+            ), "image latents should not be provided for TI2V task"
+            latent_model_input = torch.cat(
+                [latent_model_input, batch.image_latent], dim=1
+            ).to(ctx.target_dtype)
+
+        # 2. Expand the timestep to the shape expected by the current model.
+        timestep = self.expand_timestep_before_forward(
+            batch,
+            server_args,
+            step.t_device,
+            ctx.target_dtype,
+            ctx.seq_len,
+            ctx.reserved_frames_mask,
+        )
+
+        # 3. Apply scheduler-side input scaling before the model forward.
+        latent_model_input = ctx.scheduler.scale_model_input(
+            latent_model_input, step.t_device
+        )
+
+        # 4. Run the model prediction path, including CFG when enabled.
+        with maybe_nvtx_range("predict_noise", use_nvtx):
+            noise_pred = self._predict_noise_with_cfg(
+                current_model=step.current_model,
+                latent_model_input=latent_model_input,
+                timestep=timestep,
+                batch=batch,
+                timestep_index=step.step_index,
+                attn_metadata=step.attn_metadata,
+                target_dtype=ctx.target_dtype,
+                current_guidance_scale=step.current_guidance_scale,
+                cfg_policy=ctx.cfg_policy,
+                cfg_gate_state=ctx.extra.get("cfg_gate_state"),
+                server_args=server_args,
+                guidance=ctx.guidance,
+                latents=ctx.latents,
+            )
+        if server_args.comfyui_mode:
+            batch.noise_pred = noise_pred
+
+        # 5. Advance the scheduler state with the predicted noise.
+        with maybe_nvtx_range("scheduler_step", use_nvtx):
+            latents_dtype = ctx.latents.dtype
+            latents = ctx.scheduler.step(
+                model_output=noise_pred,
+                timestep=step.t_device,
+                sample=ctx.latents,
+                **ctx.extra_step_kwargs,
+                return_dict=False,
+            )[0]
+            if latents.dtype != latents_dtype and latents.device.type == "mps":
+                latents = latents.to(latents_dtype)
+            ctx.latents = latents
+
+        # 6. Re-apply any model-specific latent constraints after the update.
+        ctx.latents = self.post_forward_for_ti2v_task(
+            batch,
+            server_args,
+            ctx.reserved_frames_mask,
+            ctx.latents,
+            ctx.z,
+        )
+
+    def _record_trajectory(
+        self,
+        ctx: DenoisingContext,
+        step: DenoisingStepState,
+        batch: Req,
+        server_args: ServerArgs,
+    ) -> None:
+        """Append the current step to the returned latent trajectory, if requested."""
+        if not batch.return_trajectory_latents:
+            return
+        ctx.trajectory_timesteps.append(step.t_host)
+        ctx.trajectory_latents.append(ctx.latents)
+
+    def _finalize_denoising_loop(
+        self, ctx: DenoisingContext, batch: Req, server_args: ServerArgs
+    ) -> None:
+        """Finalize the shared loop by handing state to post-denoising processing."""
+        self._log_cfg_gate_summary(ctx, batch)
+        self._post_denoising_loop(
+            batch=batch,
+            latents=ctx.latents,
+            trajectory_latents=ctx.trajectory_latents,
+            trajectory_timesteps=ctx.trajectory_timesteps,
+            server_args=server_args,
+            is_warmup=ctx.is_warmup,
+        )
+
+    def _log_cfg_gate_summary(self, ctx: DenoisingContext, batch: Req) -> None:
+        state = ctx.extra.get("cfg_gate_state")
+        if (
+            not state
+            or not state["requested"]
+            or ctx.is_warmup
+            or (world_group_is_initialized() and get_world_group().local_rank != 0)
+        ):
+            return
+
+        logger.info(
+            "CFG gating summary: fraction=%.3f, gate_step=%d/%d, "
+            "fresh_uncond=%d, reused=%d, invalidations=%d, guidance_rescale=%s.",
+            state["fraction"],
+            state["gate_step"],
+            len(ctx.timesteps),
+            state["fresh_uncond"],
+            state["reused"],
+            state["invalidations"],
+            batch.guidance_rescale,
+        )
+
+    def _post_denoising_loop(
+        self,
+        batch: Req,
+        latents: torch.Tensor,
+        trajectory_latents: list,
+        trajectory_timesteps: list,
+        server_args: ServerArgs,
+        is_warmup: bool = False,
+        *args,
+        **kwargs,
+    ):
+        # Gather results if using sequence parallelism
+        if trajectory_latents:
+            trajectory_tensor = torch.stack(trajectory_latents, dim=1)
+            trajectory_timesteps_tensor = torch.stack(trajectory_timesteps, dim=0)
+        else:
+            trajectory_tensor = None
+            trajectory_timesteps_tensor = None
+
+        # Gather results if using sequence parallelism
+        latents, trajectory_tensor = self._postprocess_sp_latents(
+            batch, latents, trajectory_tensor
+        )
+
+        # Gather noise_pred if using sequence parallelism
+        # noise_pred has the same shape as latents (sharded along sequence dimension)
+        if (
+            self._sp_world_size() > 1
+            and getattr(batch, "did_sp_shard_latents", False)
+            and server_args.comfyui_mode
+            and hasattr(batch, "noise_pred")
+            and batch.noise_pred is not None
+        ):
+            batch.noise_pred = server_args.pipeline_config.gather_noise_pred_for_sp(
+                batch, batch.noise_pred
+            )
+
+        if trajectory_tensor is not None and trajectory_timesteps_tensor is not None:
+            batch.trajectory_timesteps = trajectory_timesteps_tensor.cpu()
+            batch.trajectory_latents = trajectory_tensor.cpu()
+
+        # Update batch with final latents
+        batch.latents = self.server_args.pipeline_config.post_denoising_loop(
+            latents, batch
+        )
+
+        # Save STA mask search results if needed
+        if (
+            not is_warmup
+            and self.attn_backend.get_enum() == AttentionBackendEnum.SLIDING_TILE_ATTN
+            and server_args.attention_backend_config.STA_mode == "STA_SEARCHING"
+        ):
+            self.save_sta_search_results(batch)
+
+        # deallocate transformer if on mps
+        pipeline = self.pipeline() if self.pipeline else None
+        if torch.backends.mps.is_available() and not is_warmup:
+            logger.info(
+                "Memory before deallocating transformer: %s",
+                torch.mps.current_allocated_memory(),
+            )
+            if self._component_residency_manager is not None:
+                self._component_residency_manager.remove_nvtx_hooks_for_module(
+                    self.transformer
+                )
+                self._component_residency_manager.strategy_for.cache_clear()
+            del self.transformer
+            if pipeline is not None and "transformer" in pipeline.modules:
+                del pipeline.modules["transformer"]
+            server_args.model_loaded["transformer"] = False
+            gc.collect()
+            torch.mps.empty_cache()
+            logger.info(
+                "Memory after deallocating transformer: %s",
+                torch.mps.current_allocated_memory(),
+            )
+
+    def _preprocess_sp_latents(self, batch: Req, server_args: ServerArgs):
+        """Shard latents for Sequence Parallelism if applicable."""
+        if self._sp_world_size() <= 1:
+            return
+
+        if batch.latents is not None:
+            (
+                batch.latents,
+                did_shard,
+            ) = server_args.pipeline_config.shard_latents_for_sp(batch, batch.latents)
+            batch.did_sp_shard_latents = did_shard
+        else:
+            batch.did_sp_shard_latents = False
+
+        # image_latent must be sharded consistently with latents when it is
+        # concatenated along the sequence dimension in the denoising loop.
+        if batch.image_latent is not None:
+            sp_video_metadata = {
+                name: getattr(batch, name)
+                for name in (
+                    "sp_video_latent_num_frames",
+                    "sp_video_start_frame",
+                    "sp_video_tokens_per_frame",
+                    "sp_video_valid_token_count",
+                )
+                if hasattr(batch, name)
+            }
+            batch.image_latent, _ = server_args.pipeline_config.shard_latents_for_sp(
+                batch, batch.image_latent
+            )
+            for name, value in sp_video_metadata.items():
+                setattr(batch, name, value)
+
+    def _postprocess_sp_latents(
+        self,
+        batch: Req,
+        latents: torch.Tensor,
+        trajectory_tensor: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Gather latents after Sequence Parallelism if they were sharded."""
+        if self._sp_world_size() > 1 and getattr(batch, "did_sp_shard_latents", False):
+            latents = self.server_args.pipeline_config.gather_latents_for_sp(
+                latents, batch=batch
+            )
+            if trajectory_tensor is not None:
+                # trajectory_tensor shapes:
+                # - video: [b, num_steps, c, t_local, h, w] -> gather on dim=3
+                # - image: [b, num_steps, s_local, d] -> gather on dim=2
+                trajectory_tensor = trajectory_tensor.to(get_local_torch_device())
+                if isinstance(self.server_args.pipeline_config, ZImagePipelineConfig):
+                    trajectory_tensor = (
+                        self.server_args.pipeline_config.gather_latents_for_sp(
+                            trajectory_tensor, batch=batch
+                        )
+                    )
+                else:
+                    gather_dim = 3 if trajectory_tensor.dim() >= 5 else 2
+                    trajectory_tensor = sequence_model_parallel_all_gather(
+                        trajectory_tensor, dim=gather_dim
+                    )
+                    if gather_dim == 2 and hasattr(batch, "raw_latent_shape"):
+                        orig_s = batch.raw_latent_shape[1]
+                        if trajectory_tensor.shape[2] > orig_s:
+                            trajectory_tensor = trajectory_tensor[:, :, :orig_s, :]
+        return latents, trajectory_tensor
+
+    def _sp_world_size(self) -> int:
+        if not model_parallel_is_initialized():
+            return 1
+        return get_sp_world_size()
+
+    def step_profile(self):
+        profiler = SGLDiffusionProfiler.get_instance()
+        if profiler:
+            profiler.step_denoising_step()
+
+    def _manage_dit_use_site(
+        self,
+        current_model: nn.Module,
+        current_phase: str,
+        batch: Req,
+    ) -> None:
+        """
+        manage dit's residency by reporting the active sequential use
+
+        only applicable for dual-dit architecture like Wan
+
+        Args:
+            current_model: the next active dit, transformer_1 or transformer_2
+        """
+        manager = self._component_residency_manager
+
+        component_name = manager.component_name_for_module(current_model, current_phase)
+        phase = str(batch.extra.get("ltx2_phase", current_phase))
+        use = ComponentUse(
+            stage_name=self._active_component_stage_name(),
+            component_name=component_name,
+            phase=phase,
+            preferred_ready_after_request=component_name == "transformer",
+            memory_intensive=True,
+        )
+        manager.begin_use(use, module=current_model)
+
+    def _select_and_manage_model(
+        self,
+        t_int: int,
+        boundary_timestep: float | None,
+        server_args: ServerArgs,
+        batch: Req,
+    ):
+        if boundary_timestep is None or t_int >= boundary_timestep:
+            # High-noise stage
+            current_model = self.transformer
+            current_guidance_scale = batch.guidance_scale
+            current_phase = "transformer"
+        else:
+            # Low-noise stage
+            current_model = self.transformer_2
+            current_guidance_scale = batch.guidance_scale_2
+            current_phase = "transformer_2"
+
+        self._manage_dit_use_site(current_model, current_phase, batch)
+
+        assert current_model is not None, "The model for the current step is not set."
+        return current_model, current_guidance_scale
+
+    def expand_timestep_before_forward(
+        self,
+        batch: Req,
+        server_args: ServerArgs,
+        t_device,
+        target_dtype,
+        seq_len: int | None,
+        reserved_frames_mask,
+    ):
+        bsz = batch.raw_latent_shape[0]
+        should_preprocess_for_wan_ti2v = should_apply_wan_ti2v(batch, server_args)
+
+        # expand timestep
+        if should_preprocess_for_wan_ti2v:
+            assert seq_len is not None, "Wan TI2V requires a token sequence length."
+            timestep = expand_wan_ti2v_timestep(
+                batch,
+                t_device,
+                target_dtype,
+                seq_len,
+                reserved_frames_mask,
+                server_args.pipeline_config.dit_config.arch_config.patch_size,
+            )
+        else:
+            timestep = t_device.repeat(bsz)
+        return timestep
+
+    def post_forward_for_ti2v_task(
+        self, batch: Req, server_args: ServerArgs, reserved_frames_mask, latents, z
+    ):
+        """Re-apply Wan TI2V first-frame conditioning after each denoising step."""
+        should_preprocess_for_wan_ti2v = should_apply_wan_ti2v(batch, server_args)
+        if should_preprocess_for_wan_ti2v:
+            latents = blend_wan_ti2v_latents(latents, reserved_frames_mask, z)
+
+        return latents
+
+    @contextmanager
+    def _offload_for_torch_compile_warmup(self, batch: Req):
+        """wrap a denoise so the torch.compile warmup has spare VRAM.
+
+        No-op unless the DiT was layerwise-offloaded for compile.
+        Warmup: move resident non-DiT components off-device for the autotune window, restore
+        after.
+        """
+        if not self._offloaded_dit_modules_for_compile:
+            yield
+            return
+        # if the dits have been layerwise-offloaded in preparation stage
+        if batch.is_warmup:
+            # if warmup is enabled, for warmup request, offload components to ensure sufficient VRAM headroom for torch compile
+            moved = self._move_resident_components_for_warmup()
+            try:
+                yield
+            finally:
+                device = get_local_torch_device()
+                for module in moved:
+                    module.to(device)
+            return
+        # prepare for first real request: restore the user-configured residency
+        for module in self._offloaded_dit_modules_for_compile:
+            module.disable_offload()
+        # clear the list for avoid overhead during real request
+        self._offloaded_dit_modules_for_compile.clear()
+        yield
+
+    def forward(
+        self,
+        batch: Req,
+        server_args: ServerArgs,
+    ) -> Req:
+        with self._offload_for_torch_compile_warmup(batch):
+            return self._denoise(batch, server_args)
+
+    @torch.no_grad()
+    def _denoise(
+        self,
+        batch: Req,
+        server_args: ServerArgs,
+    ) -> Req:
+        """
+        Run the denoising loop.
+        """
+        ctx = self._prepare_denoising_loop(batch, server_args)
+        if batch.rollout:
+            self._maybe_init_denoising_env_collection(
+                batch=batch,
+                pipeline_config=server_args.pipeline_config,
+                image_kwargs=ctx.image_kwargs,
+                pos_cond_kwargs=ctx.pos_cond_kwargs,
+                neg_cond_kwargs=ctx.neg_cond_kwargs,
+                guidance=ctx.guidance,
+            )
+        denoising_start_time = time.time()
+        self._before_denoising_loop(ctx, batch, server_args)
+        # to avoid device-sync caused by timestep comparison
+        timesteps_cpu = ctx.timesteps.cpu()
+        num_timesteps = timesteps_cpu.shape[0]
+        # Re-resolve the explicit-range gate so the per-step markers
+        # below honor this request's is_warmup state. Layer hooks are
+        # registered by the residency manager at the use-site.
+        use_nvtx = self._apply_nvtx_gate(ctx.is_warmup)
+
+        with (
+            precision_autocast_context(
+                ctx.target_dtype,
+                server_args.disable_autocast,
+                enabled=ctx.autocast_enabled,
+            ),
+            maybe_nvtx_range("denoising_loop", use_nvtx),
+        ):
+            with self.progress_bar(
+                total=ctx.num_inference_steps, batch=batch
+            ) as progress_bar:
+                for step_index, t_host in enumerate(timesteps_cpu):
+                    # Use ``:.4g`` so flow-matching schedulers (e.g. FLUX) that
+                    # use non-integer timesteps keep their precision in markers.
+                    step_marker = f"denoising_step_{step_index}_t{t_host.item():.4g}"
+                    with (
+                        maybe_nvtx_range(step_marker, use_nvtx),
+                        StageProfiler(
+                            f"denoising_step_{step_index}",
+                            logger=logger,
+                            metrics=batch.metrics,
+                            perf_dump_path_provided=batch.perf_dump_path is not None,
+                            record_as_step=True,
+                        ),
+                    ):
+                        step = self._prepare_step_state(
+                            ctx,
+                            batch,
+                            server_args,
+                            step_index,
+                            t_host,
+                            timesteps_cpu,
+                        )
+                        # Capture the raw (pre-scale, pre-I2V-concat) noisy latent
+                        # x_{t_i} for rollout trajectory collection. Must run
+                        # BEFORE _run_denoising_step so ctx.latents is still the
+                        # pre-step value. Gated on batch.rollout to keep the
+                        # non-rollout path strictly untouched.
+                        if batch.rollout:
+                            batch._rollout_loop_step_index = step_index
+                            self._maybe_append_dit_trajectory_step(
+                                batch=batch,
+                                latents=ctx.latents,
+                                timestep_value=step.t_host,
+                                step_index=step_index,
+                            )
+                        self._run_denoising_step(ctx, step, batch, server_args)
+                        self._record_trajectory(ctx, step, batch, server_args)
+
+                        if step_index == num_timesteps - 1 or (
+                            (step_index + 1) > ctx.num_warmup_steps
+                            and (step_index + 1) % ctx.scheduler.order == 0
+                            and progress_bar is not None
+                        ):
+                            progress_bar.update()
+
+                        if not ctx.is_warmup:
+                            self.step_profile()
+
+        denoising_end_time = time.time()
+
+        if num_timesteps > 0 and not ctx.is_warmup:
+            self.log_info(
+                "average time per step: %.4f seconds",
+                (denoising_end_time - denoising_start_time) / len(ctx.timesteps),
+            )
+
+        if "step" in locals():
+            del step
+        self._finish_active_component_use()
+
+        # Rollout postprocessing must run BEFORE _finalize_denoising_loop so
+        # the final scheduler.step output (ctx.latents) is still SP-sharded and
+        # can be gathered uniformly alongside the per-step dit_trajectory via
+        # gather_stacked_latents_for_sp.
+        if batch.rollout:
+            self._postprocess_rollout_outputs(
+                batch=batch,
+                latents=ctx.latents,
+                num_inference_steps=num_timesteps,
+                final_timestep=timesteps_cpu.new_zeros(()),
+                server_args=server_args,
+            )
+        self._finalize_denoising_loop(ctx, batch, server_args)
+        return batch
+
+    def _get_extra_func_kwarg_names(self, func) -> tuple[bool, frozenset[str]]:
+        import functools
+
+        # Handle cache-dit's partial wrapping logic.
+        # Cache-dit wraps the forward method with functools.partial where args[0] is the instance.
+        # We access `_original_forward` if available to inspect the underlying signature.
+        # See: https://github.com/vipshop/cache-dit
+        if isinstance(func, functools.partial) and func.args:
+            func = getattr(func.args[0], "_original_forward", func)
+
+        # Unwrap any decorators (e.g. functools.wraps)
+        target_func = inspect.unwrap(func)
+        cache_target = (
+            target_func.__func__ if inspect.ismethod(target_func) else target_func
+        )
+        cache_key = id(cache_target)
+        cached = self._extra_func_kwarg_names_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        params = inspect.signature(target_func).parameters
+        result = (
+            any(
+                param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()
+            ),
+            frozenset(params),
+        )
+        self._extra_func_kwarg_names_cache[cache_key] = result
+        return result
+
+    # TODO: this will extends the preparation stage, should let subclass/passed-in variables decide which to prepare
+    def prepare_extra_func_kwargs(self, func, kwargs) -> dict[str, Any]:
+        """
+        Prepare extra kwargs for the scheduler step / denoise step.
+
+        Args:
+            func: The function to prepare kwargs for.
+            kwargs: The kwargs to prepare.
+        """
+        accepts_var_kwargs, param_names = self._get_extra_func_kwarg_names(func)
+        if accepts_var_kwargs:
+            return kwargs
+        return {k: v for k, v in kwargs.items() if k in param_names}
+
+    def _predict_noise_with_cfg(
+        self,
+        current_model: nn.Module,
+        latent_model_input: torch.Tensor,
+        timestep,
+        batch: Req,
+        timestep_index: int,
+        attn_metadata,
+        target_dtype,
+        current_guidance_scale,
+        cfg_policy: CFGPolicy,
+        cfg_gate_state: dict[str, Any] | None,
+        server_args: ServerArgs,
+        guidance: torch.Tensor,
+        latents: torch.Tensor,
+    ) -> "torch.Tensor | tuple[torch.Tensor, ...]":
+        """Run all CFG branch forward passes and combine into the final noise estimate."""
+        cfg_scale = server_args.pipeline_config.get_classifier_free_guidance_scale(
+            batch, current_guidance_scale
+        )
+
+        def predict_fn(branch):
+            branch.configure_batch(batch)
+            with set_forward_context(
+                current_timestep=timestep_index,
+                attn_metadata=attn_metadata,
+                forward_batch=batch,
+            ):
+                raw = self._predict_noise(
+                    current_model=current_model,
+                    latent_model_input=latent_model_input,
+                    timestep=timestep,
+                    target_dtype=target_dtype,
+                    guidance=guidance,
+                    **branch.kwargs,
+                )
+            pred_t = _wrap(raw)
+            if len(pred_t) == 1:
+                pred_t = (
+                    server_args.pipeline_config.slice_noise_pred(pred_t[0], latents),
+                )
+            return _unwrap(pred_t)
+
+        if (
+            cfg_gate_state
+            and cfg_gate_state["active"]
+            and not server_args.enable_cfg_parallel
+            and type(cfg_policy) is CFGPolicy
+            and len(cfg_policy.branches) == 2
+            and cfg_policy.branches[0].is_conditional
+            and not cfg_policy.branches[1].is_conditional
+        ):
+            model_id = id(current_model)
+            if cfg_gate_state["model_id"] not in (None, model_id):
+                cfg_gate_state["delta"] = None
+                cfg_gate_state["invalidations"] += 1
+
+            pos_pred = predict_fn(cfg_policy.branches[0])
+            pos_t = _wrap(pos_pred)
+            delta_t = cfg_gate_state["delta"]
+            can_reuse = (
+                timestep_index >= cfg_gate_state["gate_step"]
+                and delta_t is not None
+                and len(pos_t) == len(delta_t)
+            )
+
+            if can_reuse:
+                neg_pred = _unwrap(tuple(p - d for p, d in zip(pos_t, delta_t)))
+                cfg_gate_state["reused"] += 1
+            else:
+                neg_pred = predict_fn(cfg_policy.branches[1])
+                neg_t = _wrap(neg_pred)
+                cfg_gate_state["delta"] = tuple(
+                    p.detach() - n.detach() for p, n in zip(pos_t, neg_t)
+                )
+                cfg_gate_state["model_id"] = model_id
+                cfg_gate_state["fresh_uncond"] += 1
+
+            return cfg_policy.combine(
+                [pos_pred, neg_pred],
+                batch,
+                cfg_scale,
+                server_args.pipeline_config,
+            )
+
+        if server_args.enable_cfg_parallel:
+            if (
+                len(cfg_policy.branches) == 2
+                and get_classifier_free_guidance_world_size() == 2
+            ):
+                return run_two_branch_cfg_parallel(
+                    cfg_policy,
+                    predict_fn,
+                    cfg_scale,
+                    batch,
+                    server_args.pipeline_config,
+                )
+            # perform cfg branches in parallel, following the cfg policy
+            predictions = run_cfg_parallel(cfg_policy, predict_fn)
+        else:
+            # perform cfg branches one-by-one locally
+            predictions = [predict_fn(branch) for branch in cfg_policy.branches]
+
+        return cfg_policy.combine(
+            predictions,
+            batch,
+            cfg_scale,
+            server_args.pipeline_config,
+            cfg_parallel=server_args.enable_cfg_parallel,
+        )
+
+    def _build_attn_metadata(
+        self,
+        i: int,
+        batch: Req,
+        server_args: ServerArgs,
+        *,
+        timestep_value: int | None = None,
+        timesteps: torch.Tensor | None = None,
+    ) -> Any | None:
+        """
+        Build attention metadata for custom attention backends.
+
+        Args:
+            i: The current timestep index.
+        """
+        attn_metadata = None
+        self.attn_metadata_builder = None
+        try:
+            self.attn_metadata_builder_cls = self.attn_backend.get_builder_cls()
+        except NotImplementedError:
+            self.attn_metadata_builder_cls = None
+        if self.attn_metadata_builder_cls:
+            self.attn_metadata_builder = self.attn_metadata_builder_cls()
+        if (
+            self.attn_backend.get_enum() == AttentionBackendEnum.SLIDING_TILE_ATTN
+            or self.attn_backend.get_enum() == AttentionBackendEnum.VIDEO_SPARSE_ATTN
+        ):
+            attention_backend_config = server_args.attention_backend_config or {}
+            vsa_sparsity = attention_backend_config.get(
+                "VSA_sparsity", attention_backend_config.get("sparsity", 0.0)
+            )
+            attn_metadata = self.attn_metadata_builder.build(
+                current_timestep=i,
+                raw_latent_shape=batch.raw_latent_shape[2:5],
+                patch_size=server_args.pipeline_config.dit_config.patch_size,
+                STA_param=batch.STA_param,
+                VSA_sparsity=vsa_sparsity,
+                device=get_local_torch_device(),
+            )
+        elif (
+            self.attn_backend.get_enum() == AttentionBackendEnum.SPARSE_VIDEO_GEN_2_ATTN
+        ):
+            if timestep_value is None or timesteps is None:
+                raise ValueError(
+                    "timestep_value and timesteps must be provided for SVG2 attention metadata"
+                )
+
+            svg2_cfg = server_args.attention_backend_config or {}
+            num_layers = server_args.pipeline_config.dit_config.num_layers
+            if (
+                server_args.pipeline_config.dit_config.prefix.lower() == "hunyuan"
+                and hasattr(server_args.pipeline_config.dit_config, "num_single_layers")
+            ):
+                num_layers += server_args.pipeline_config.dit_config.num_single_layers
+            first_layers_fp = svg2_cfg.get("svg2_first_layers_fp", 0.03)
+            if first_layers_fp <= 1.0:
+                first_layers_fp = math.floor(first_layers_fp * num_layers)
+            first_layers_fp = max(0, min(int(first_layers_fp), num_layers))
+
+            first_times_fp = svg2_cfg.get("svg2_first_times_fp", 0.2)
+            if first_times_fp <= 1.0:
+                num_fp_steps = math.floor(first_times_fp * len(timesteps))
+                if num_fp_steps > 0:
+                    first_times_fp = float(timesteps[num_fp_steps - 1].item() - 1)
+                else:
+                    first_times_fp = float(timesteps.max().item() + 1)
+
+            current_timestep = int(timestep_value)
+
+            cache = batch.extra.get("svg2_cache")
+            if cache is None:
+                from sglang.multimodal_gen.runtime.layers.attention.backends.sparse_video_gen_2_attn import (
+                    Svg2Cache,
+                )
+
+                cache = Svg2Cache()
+                batch.extra["svg2_cache"] = cache
+
+            patch_size = server_args.pipeline_config.dit_config.patch_size
+            if isinstance(patch_size, list):
+                patch_size = tuple(patch_size)
+            if isinstance(patch_size, int):
+                patch_size_t = getattr(
+                    server_args.pipeline_config.dit_config, "patch_size_t", None
+                )
+                if patch_size_t is not None:
+                    patch_size = (patch_size_t, patch_size, patch_size)
+
+            context_length = 0
+            prompt_length = None
+            if server_args.pipeline_config.dit_config.prefix.lower() == "hunyuan":
+                prompt_embeds = server_args.pipeline_config.get_pos_prompt_embeds(batch)
+                if isinstance(prompt_embeds, list):
+                    text_embeds = prompt_embeds[0] if prompt_embeds else None
+                else:
+                    text_embeds = prompt_embeds
+                if isinstance(text_embeds, torch.Tensor) and text_embeds.ndim >= 2:
+                    context_length = int(text_embeds.shape[1])
+                if context_length > 0 and batch.prompt_attention_mask:
+                    mask = batch.prompt_attention_mask[0]
+                    if isinstance(mask, torch.Tensor):
+                        if mask.shape[-1] > context_length:
+                            mask = mask[:, -context_length:]
+                        prompt_length = int(mask[0].sum().item())
+                if prompt_length is None:
+                    prompt_length = context_length
+
+            attn_metadata = self.attn_metadata_builder.build(
+                current_timestep=current_timestep,
+                raw_latent_shape=batch.raw_latent_shape,
+                patch_size=patch_size,
+                num_q_centroids=svg2_cfg.get("svg2_num_q_centroids", 300),
+                num_k_centroids=svg2_cfg.get("svg2_num_k_centroids", 1000),
+                top_p_kmeans=svg2_cfg.get("svg2_top_p_kmeans", 0.9),
+                min_kc_ratio=svg2_cfg.get("svg2_min_kc_ratio", 0.1),
+                kmeans_iter_init=svg2_cfg.get("svg2_kmeans_iter_init", 50),
+                kmeans_iter_step=svg2_cfg.get("svg2_kmeans_iter_step", 2),
+                zero_step_kmeans_init=svg2_cfg.get("svg2_zero_step_kmeans_init", False),
+                first_layers_fp=first_layers_fp,
+                first_times_fp=first_times_fp,
+                context_length=context_length,
+                prompt_length=prompt_length,
+                cache=cache,
+                calculate_density=False,  # only need density when doing head load balancing
+            )
+        elif self.attn_backend.get_enum() == AttentionBackendEnum.VMOBA_ATTN:
+            moba_params = server_args.attention_backend_config.moba_config.copy()
+            moba_params.update(
+                {
+                    "current_timestep": i,
+                    "raw_latent_shape": batch.raw_latent_shape[2:5],
+                    "patch_size": server_args.pipeline_config.dit_config.patch_size,
+                    "device": get_local_torch_device(),
+                }
+            )
+        elif self.attn_backend.get_enum() == AttentionBackendEnum.FA:
+            attn_metadata = self.attn_metadata_builder.build(
+                raw_latent_shape=batch.raw_latent_shape
+            )
+        elif self.attn_backend.get_enum() in [
+            AttentionBackendEnum.BLOCK_SPARSE_ATTN,
+            AttentionBackendEnum.RAIN_FUSION_ATTN,
+        ]:
+            sparse_config = server_args.attention_backend_config
+
+            current_timestep = i
+            skip_first_steps = sparse_config.get("skip_first_steps", 10)
+            sparsity = sparse_config.get("sparsity", 0.2)
+
+            raw_latent_shape = batch.raw_latent_shape
+            patch_size = server_args.pipeline_config.dit_config.patch_size
+
+            if isinstance(patch_size, int):
+                patch_size_t = getattr(
+                    server_args.pipeline_config.dit_config, "patch_size_t", None
+                )
+                if patch_size_t is not None:
+                    patch_size = (patch_size_t, patch_size, patch_size)
+                else:
+                    patch_size = (patch_size, patch_size, patch_size)
+
+            attn_metadata = self.attn_metadata_builder.build(
+                current_timestep=current_timestep,
+                skip_first_steps=skip_first_steps,
+                sparsity=sparsity,
+                raw_latent_shape=raw_latent_shape,
+                patch_size=patch_size,
+            )
+        else:
+            # attn_metadata can be None for SDPA attention backend
+            return None
+
+        return attn_metadata
+
+    def _predict_noise(
+        self,
+        current_model,
+        latent_model_input,
+        timestep,
+        target_dtype,
+        guidance: torch.Tensor,
+        **kwargs,
+    ):
+        guidance_kwargs = self.prepare_extra_func_kwargs(
+            getattr(current_model, "forward", current_model),
+            {"guidance": guidance},
+        )
+        call_kwargs = dict(
+            hidden_states=latent_model_input,
+            timestep=timestep,
+            **guidance_kwargs,
+            **kwargs,
+        )
+        runner = self._maybe_get_bcg_runner(current_model)
+        if runner is not None:
+            model_output = self._bcg_run(runner, call_kwargs, current_model)
+        else:
+            model_output = current_model(**call_kwargs)
+        return _ensure_tensor_model_output(model_output)
+
+    @staticmethod
+    def _bcg_is_warmup() -> bool:
+        """True when the current forward is a warmup request."""
+        from sglang.multimodal_gen.runtime.managers.forward_context import (
+            get_forward_context,
+        )
+
+        try:
+            forward_batch = get_forward_context().forward_batch
+        except Exception:
+            return False
+        return bool(getattr(forward_batch, "is_warmup", False))
+
+    def _bcg_run(self, runner, call_kwargs: dict, current_model):
+        """Run the DiT through the BCG runner.
+
+        During warmup we proactively capture one graph per text bucket (in
+        addition to the request's own bucket) so that serving never records a
+        fresh graph for a different prompt length — every bucket is already
+        captured. Serving just replays (or runs eager for an uncaptured
+        signature, never capturing).
+        """
+        if self._bcg_is_warmup():
+            for bucket in self._bcg_text_buckets():
+                runner.capture(
+                    **self._bcg_pad_prompt_kwargs(
+                        call_kwargs, current_model=current_model, force_bucket=bucket
+                    )
+                )
+        return runner(
+            **self._bcg_pad_prompt_kwargs(call_kwargs, current_model=current_model)
+        )
+
+    @staticmethod
+    def _bcg_text_buckets() -> tuple[int, ...]:
+        """Prompt sequence-length buckets, from --bcg-text-buckets."""
+        from sglang.multimodal_gen.runtime.server_args import (
+            DEFAULT_BCG_TEXT_BUCKETS,
+            get_global_server_args,
+        )
+
+        try:
+            resolver = get_global_server_args().resolved_bcg_text_buckets
+            return resolver()
+        except Exception:
+            return DEFAULT_BCG_TEXT_BUCKETS
+
+    def _bcg_pad_prompt_kwargs(
+        self, call_kwargs: dict, current_model=None, force_bucket: int | None = None
+    ):
+        """Bucket prompt-conditioning inputs so BCG signatures ignore prompt length.
+
+        Generic padding lives in ``breakable_cuda_graph.prompt_padding``;
+        model-specific padders register from ``breakable_cuda_graph.model_padders``.
+
+        ``force_bucket`` pads to exactly that bucket (used by warmup to capture
+        every bucket); a prompt already longer than ``force_bucket`` is left
+        unchanged, exactly as the normal bucket selection would do.
+        """
+        buckets = (
+            (force_bucket,) if force_bucket is not None else self._bcg_text_buckets()
+        )
+        padder = bcg_utils.select_prompt_padder(current_model, call_kwargs)
+        if padder is not None:
+            return padder(call_kwargs, current_model, buckets)
+        return bcg_utils.pad_masked_prompt_kwargs(call_kwargs, buckets)
+
+    def _maybe_get_bcg_runner(self, current_model):
+        """Return (lazily creating) the breakable CUDA graph runner for
+        ``current_model``, or ``None`` if BCG is disabled / inapplicable.
+        """
+        if not self.server_args.enable_breakable_cuda_graph:
+            return None
+        if not isinstance(current_model, nn.Module):
+            return None
+        key = id(current_model)
+        runner = self._bcg_runners.get(key)
+        if runner is None:
+            from sglang.multimodal_gen.runtime.breakable_cuda_graph.runner import (
+                DiffusionBreakableCudaGraphRunner,
+            )
+
+            # DenoisingStage can switch between transformer and transformer_2;
+            # each module owns separate graph state and static input buffers.
+            runner = DiffusionBreakableCudaGraphRunner(
+                current_model, get_local_torch_device()
+            )
+            self._bcg_runners[key] = runner
+        return runner
+
+    def prepare_sta_param(self, batch: Req, server_args: ServerArgs):
+        """
+        Prepare Sliding Tile Attention (STA) parameters and settings.
+        """
+        # TODO(kevin): STA mask search, currently only support Wan2.1 with 69x768x1280
+        try:
+            STA_mode = STA_Mode[server_args.attention_backend_config.STA_mode]
+        except Exception as e:
+            logger.error(f"Passed STA_mode: {STA_mode} doesn't exist")
+            raise e
+        skip_time_steps = server_args.attention_backend_config.skip_time_steps
+        if batch.timesteps is None:
+            raise ValueError("Timesteps must be provided")
+        timesteps_num = batch.timesteps.shape[0]
+
+        logger.info("STA_mode: %s", STA_mode)
+        if (batch.num_frames, batch.height, batch.width) != (
+            69,
+            768,
+            1280,
+        ) and STA_mode != "STA_inference":
+            raise NotImplementedError(
+                "STA mask search/tuning is not supported for this resolution"
+            )
+
+        if (
+            STA_mode == STA_Mode.STA_SEARCHING
+            or STA_mode == STA_Mode.STA_TUNING
+            or STA_mode == STA_Mode.STA_TUNING_CFG
+        ):
+            size = (batch.width, batch.height)
+            if size == (1280, 768):
+                # TODO: make it configurable
+                sparse_mask_candidates_searching = [
+                    "3, 1, 10",
+                    "1, 5, 7",
+                    "3, 3, 3",
+                    "1, 6, 5",
+                    "1, 3, 10",
+                    "3, 6, 1",
+                ]
+                sparse_mask_candidates_tuning = [
+                    "3, 1, 10",
+                    "1, 5, 7",
+                    "3, 3, 3",
+                    "1, 6, 5",
+                    "1, 3, 10",
+                    "3, 6, 1",
+                ]
+                full_mask = ["3,6,10"]
+            else:
+                raise NotImplementedError(
+                    "STA mask search is not supported for this resolution"
+                )
+        layer_num = self.transformer.config.num_layers
+        # specific for HunyuanVideo
+        if hasattr(self.transformer.config, "num_single_layers"):
+            layer_num += self.transformer.config.num_single_layers
+        head_num = self.transformer.config.num_attention_heads
+
+        if STA_mode == STA_Mode.STA_SEARCHING:
+            STA_param = configure_sta(
+                mode=STA_Mode.STA_SEARCHING,
+                layer_num=layer_num,
+                head_num=head_num,
+                time_step_num=timesteps_num,
+                mask_candidates=sparse_mask_candidates_searching + full_mask,
+                # last is full mask; Can add more sparse masks while keep last one as full mask
+            )
+        elif STA_mode == STA_Mode.STA_TUNING:
+            STA_param = configure_sta(
+                mode=STA_Mode.STA_TUNING,
+                layer_num=layer_num,
+                head_num=head_num,
+                time_step_num=timesteps_num,
+                mask_search_files_path=f"output/mask_search_result_pos_{size[0]}x{size[1]}/",
+                mask_candidates=sparse_mask_candidates_tuning,
+                full_attention_mask=[int(x) for x in full_mask[0].split(",")],
+                skip_time_steps=skip_time_steps,  # Use full attention for first 12 steps
+                save_dir=f"output/mask_search_strategy_{size[0]}x{size[1]}/",  # Custom save directory
+                timesteps=timesteps_num,
+            )
+        elif STA_mode == STA_Mode.STA_TUNING_CFG:
+            STA_param = configure_sta(
+                mode=STA_Mode.STA_TUNING_CFG,
+                layer_num=layer_num,
+                head_num=head_num,
+                time_step_num=timesteps_num,
+                mask_search_files_path_pos=f"output/mask_search_result_pos_{size[0]}x{size[1]}/",
+                mask_search_files_path_neg=f"output/mask_search_result_neg_{size[0]}x{size[1]}/",
+                mask_candidates=sparse_mask_candidates_tuning,
+                full_attention_mask=[int(x) for x in full_mask[0].split(",")],
+                skip_time_steps=skip_time_steps,
+                save_dir=f"output/mask_search_strategy_{size[0]}x{size[1]}/",
+                timesteps=timesteps_num,
+            )
+        elif STA_mode == STA_Mode.STA_INFERENCE:
+            import sglang.multimodal_gen.envs as envs
+
+            config_file = envs.SGLANG_DIFFUSION_ATTENTION_CONFIG
+            if config_file is None:
+                raise ValueError("SGLANG_DIFFUSION_ATTENTION_CONFIG is not set")
+            STA_param = configure_sta(
+                mode=STA_Mode.STA_INFERENCE,
+                layer_num=layer_num,
+                head_num=head_num,
+                time_step_num=timesteps_num,
+                load_path=config_file,
+            )
+
+        batch.STA_param = STA_param
+        batch.mask_search_final_result_pos = [[] for _ in range(timesteps_num)]
+        batch.mask_search_final_result_neg = [[] for _ in range(timesteps_num)]
+
+    def save_sta_search_results(self, batch: Req):
+        """
+        Save the STA mask search results.
+
+        Args:
+            batch: The current batch information.
+        """
+        size = (batch.width, batch.height)
+        if size == (1280, 768):
+            # TODO: make it configurable
+            sparse_mask_candidates_searching = [
+                "3, 1, 10",
+                "1, 5, 7",
+                "3, 3, 3",
+                "1, 6, 5",
+                "1, 3, 10",
+                "3, 6, 1",
+            ]
+        else:
+            raise NotImplementedError(
+                "STA mask search is not supported for this resolution"
+            )
+
+        if batch.mask_search_final_result_pos is not None and batch.prompt is not None:
+            save_mask_search_results(
+                [dict(layer_data) for layer_data in batch.mask_search_final_result_pos],
+                prompt=str(batch.prompt),
+                mask_strategies=sparse_mask_candidates_searching,
+                output_dir=f"output/mask_search_result_pos_{size[0]}x{size[1]}/",
+            )
+        if batch.mask_search_final_result_neg is not None and batch.prompt is not None:
+            save_mask_search_results(
+                [dict(layer_data) for layer_data in batch.mask_search_final_result_neg],
+                prompt=str(batch.prompt),
+                mask_strategies=sparse_mask_candidates_searching,
+                output_dir=f"output/mask_search_result_neg_{size[0]}x{size[1]}/",
+            )
+
+    def verify_input(self, batch: Req, server_args: ServerArgs) -> VerificationResult:
+        """Verify denoising stage inputs."""
+        result = VerificationResult()
+        result.add_check("timesteps", batch.timesteps, [V.is_tensor, V.min_dims(1)])
+        # disable temporarily for image-generation models
+        # result.add_check("latents", batch.latents, [V.is_tensor, V.with_dims(5)])
+        result.add_check(
+            "prompt_embeds",
+            batch.prompt_embeds,
+            self._get_prompt_embeds_validator(batch),
+        )
+        result.add_check("image_embeds", batch.image_embeds, V.is_list)
+        # result.add_check(
+        #     "image_latent", batch.image_latent, V.none_or_tensor_with_dims(5)
+        # )
+        result.add_check(
+            "num_inference_steps", batch.num_inference_steps, V.positive_int
+        )
+        result.add_check("guidance_scale", batch.guidance_scale, V.non_negative_float)
+        result.add_check("eta", batch.eta, V.non_negative_float)
+        result.add_check("generator", batch.generator, V.generator_or_list_generators)
+        result.add_check(
+            "do_classifier_free_guidance",
+            batch.do_classifier_free_guidance,
+            V.bool_value,
+        )
+        result.add_check(
+            "negative_prompt_embeds",
+            batch.negative_prompt_embeds,
+            self._get_negative_prompt_embeds_validator(batch),
+        )
+        return result
+
+    def verify_output(self, batch: Req, server_args: ServerArgs) -> VerificationResult:
+        """Verify denoising stage outputs."""
+        result = VerificationResult()
+        # result.add_check("latents", batch.latents, [V.is_tensor, V.with_dims(5)])
+        return result

--- a/models/minimax_h3/rtx5090/patches/minimax_h3.py
+++ b/models/minimax_h3/rtx5090/patches/minimax_h3.py
@@ -1,0 +1,1718 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MiniMax H3 packed-token DiT.
+
+Native SGLang implementation of the MiniMax H3 audio-video DiT. The forward
+contract accepts packed inference keyword arguments and returns packed logits.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from adapter import (
+    begin_model_forward as _sol_attn_begin_model_forward,
+    forward_attention as _sol_attn_forward_attention,
+    parse_layer_index as _sol_attn_parse_layer_index,
+)
+from teacache import (
+    after_blocks as _sol_engine_teacache_after_blocks,
+    before_blocks as _sol_engine_teacache_before_blocks,
+    enabled as _sol_engine_teacache_enabled,
+)
+from sglang.kernels.ops.activation.activation import (
+    silu_and_mul_with_activation_rounding_,
+)
+from sglang.kernels.ops.diffusion.qknorm_rope import (
+    can_use_fused_inplace_qknorm_rope,
+    fused_inplace_qknorm_rope,
+)
+from sglang.kernels.ops.diffusion.triton.indexed_modulation import (
+    indexed_gate_bf16_,
+    indexed_scale_shift_bf16_,
+)
+from sglang.kernels.ops.layernorm.norm import fused_inplace_qknorm
+from sglang.multimodal_gen import envs
+from sglang.multimodal_gen.configs.models.dits.minimax_h3 import (
+    MINIMAX_H3_ADALN_MODALITY_NUM,
+    MINIMAX_H3_PACKED_SEQUENCE_ALIGNMENT,
+    MiniMaxH3DiTArchConfig,
+    MiniMaxH3DiTConfig,
+)
+from sglang.multimodal_gen.runtime.distributed import (
+    get_tp_world_size,
+    tensor_model_parallel_all_gather,
+)
+from sglang.multimodal_gen.runtime.layers.attention.selector import get_attn_backend
+from sglang.multimodal_gen.runtime.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    RowParallelLinear,
+)
+from sglang.multimodal_gen.runtime.layers.quantization.configs.base_config import (
+    QuantizationConfig,
+)
+from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload import (
+    LayerwiseOffloadableModuleMixin,
+    is_layerwise_offloaded_module,
+)
+from sglang.multimodal_gen.runtime.models.dits.base import BaseDiT
+from sglang.multimodal_gen.runtime.platforms import (
+    AttentionBackendEnum,
+    current_platform,
+)
+from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
+    eager_on_graph,
+)
+
+_ARCH_DEFAULTS = MiniMaxH3DiTArchConfig()
+_BF16_DTYPE = torch.bfloat16
+_FP32_DTYPE = torch.float32
+
+_MINIMAX_H3_FP32_PARAM_NAMES_IN_MODEL_ORDER = (
+    "video_patch_proj.weight",
+    "video_patch_proj.bias",
+    "audio_patch_proj.weight",
+    "audio_patch_proj.bias",
+    "time_embedder.proj_in.weight",
+    "time_embedder.proj_in.bias",
+    "time_embedder.proj_out.weight",
+    "time_embedder.proj_out.bias",
+    "final_layer.video_out.weight",
+    "final_layer.video_out.bias",
+    "final_layer.audio_out.weight",
+    "final_layer.audio_out.bias",
+)
+MINIMAX_H3_FP32_PARAM_NAMES = frozenset(_MINIMAX_H3_FP32_PARAM_NAMES_IN_MODEL_ORDER)
+MINIMAX_H3_FP32_BUFFER_NAMES = frozenset({"rope.inv_freq"})
+
+
+def _required_kwarg(kwargs: dict[str, Any], key: str) -> Any:
+    if key not in kwargs or kwargs[key] is None:
+        raise ValueError(f"MiniMaxH3DiTModel.forward requires kwarg {key!r}")
+    return kwargs[key]
+
+
+# The exhaustive keyword contract of MiniMaxH3DiTModel.forward. Anything not
+# listed here is rejected with a TypeError before any tensor work starts.
+_FORWARD_SUPPORTED_KWARGS = frozenset(
+    {
+        "x",
+        "audio_x",
+        "img_position_ids",
+        "rope_cache",
+        "unique_timesteps",
+        "inverse_indices",
+        "update_mask",
+        "update_audio_mask",
+        "token_tags",
+        "block_token_tags",
+        "block_combined_indices",
+        "skip_mask_out_condition",
+        "prompt_embeds",
+        "refined_prompt_embeds_length",
+        "img_pos_info",
+        "audio_pos_info",
+        "text_pos_info",
+        "img_pos_for_infer_output_info",
+        "local_embedding_layout",
+        "packed_seq_params",
+        "refiner_packed_seq_params",
+    }
+)
+
+
+def _ulysses_ctx() -> tuple[int, int]:
+    """(world_size, rank) of the Ulysses sequence-parallel group.
+
+    Returns (1, 0) when model parallelism is not initialized (unit tests /
+    single-process debug paths init tp=1 sp=1 which also yields ws=1).
+    """
+    from sglang.multimodal_gen.runtime.distributed.parallel_state import (
+        get_ulysses_parallel_rank,
+        get_ulysses_parallel_world_size,
+        model_parallel_is_initialized,
+    )
+
+    if not model_parallel_is_initialized():
+        return 1, 0
+    return get_ulysses_parallel_world_size(), get_ulysses_parallel_rank()
+
+
+def _ring_world_size() -> int:
+    from sglang.multimodal_gen.runtime.distributed.parallel_state import (
+        get_ring_parallel_world_size,
+        model_parallel_is_initialized,
+    )
+
+    if not model_parallel_is_initialized():
+        return 1
+    return get_ring_parallel_world_size()
+
+
+def _reorder_grouped_qkv_to_qkv(
+    weight: torch.Tensor,
+    *,
+    num_query_groups: int,
+    heads_per_group: int,
+    head_dim: int,
+) -> torch.Tensor:
+    per_group = (heads_per_group + 2) * head_dim
+    expected_out = num_query_groups * per_group
+    if weight.shape[0] != expected_out:
+        raise ValueError(
+            "qkv weight has incompatible output dim for grouped checkpoint layout: "
+            f"got {tuple(weight.shape)}, expected first dim {expected_out}."
+        )
+
+    rest_shape = weight.shape[1:]
+    grouped = weight.reshape(num_query_groups, per_group, *rest_shape)
+    q, k, v = torch.split(
+        grouped,
+        [heads_per_group * head_dim, head_dim, head_dim],
+        dim=1,
+    )
+    return torch.cat(
+        [
+            q.reshape(num_query_groups * heads_per_group * head_dim, *rest_shape),
+            k.reshape(num_query_groups * head_dim, *rest_shape),
+            v.reshape(num_query_groups * head_dim, *rest_shape),
+        ],
+        dim=0,
+    )
+
+
+def _copy_grouped_qkv_tp_shard(
+    param: torch.Tensor,
+    loaded_weight: torch.Tensor,
+    *,
+    num_query_groups: int,
+    head_dim: int,
+    tp_rank: int,
+    tp_size: int,
+) -> bool:
+    """Copy a dense MHA checkpoint directly into its TP-local Q/K/V rows."""
+    if (
+        tp_size <= 0
+        or not 0 <= tp_rank < tp_size
+        or num_query_groups % tp_size
+        or getattr(param, "output_dim", None) != 0
+        or getattr(param, "is_sharded_weight", False)
+        or getattr(param, "packed_dim", None) is not None
+        or param.dtype != _BF16_DTYPE
+        or loaded_weight.dtype != _BF16_DTYPE
+        or not param.is_contiguous()
+        or not loaded_weight.is_contiguous()
+    ):
+        return False
+
+    expected_rows = num_query_groups * 3 * head_dim
+    local_groups = num_query_groups // tp_size
+    rest_shape = loaded_weight.shape[1:]
+    if loaded_weight.shape[0] != expected_rows or tuple(param.shape) != (
+        3 * local_groups * head_dim,
+        *rest_shape,
+    ):
+        return False
+
+    grouped = loaded_weight.view(num_query_groups, 3, head_dim, *rest_shape)
+    grouped = grouped.narrow(0, tp_rank * local_groups, local_groups)
+    target = param.data.view(3, local_groups, head_dim, *rest_shape)
+    for index in range(3):
+        target[index].copy_(grouped[:, index])
+    return True
+
+
+def _norm(size: int, *, eps: float, dtype: torch.dtype = _BF16_DTYPE) -> nn.RMSNorm:
+    # RMSNorm uses fp32 accumulation with bf16 inputs and outputs.
+    # torch.nn.RMSNorm upcasts reduced-precision inputs for the variance
+    # reduction, matching that accumulation semantic.
+    return nn.RMSNorm(size, eps=eps, dtype=dtype)
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1, x2 = torch.chunk(x, 2, dim=-1)
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _modulate_scale_shift(
+    x: torch.Tensor,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+    indices: torch.Tensor,
+    *,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Apply indexed affine modulation, reusing disposable CUDA BF16 input."""
+    # Apply per-index affine modulation: x * (1 + scale[idx]) + shift[idx].
+    if (
+        x.is_cuda
+        and x.dtype == _BF16_DTYPE
+        and dtype == _BF16_DTYPE
+        and shift.dtype == _BF16_DTYPE
+        and scale.dtype == _BF16_DTYPE
+        and x.is_contiguous()
+    ):
+        return indexed_scale_shift_bf16_(x, shift, scale, indices)
+    return (
+        x * (1.0 + scale.index_select(0, indices)) + shift.index_select(0, indices)
+    ).to(dtype)
+
+
+def _modulate_gate(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    other: torch.Tensor,
+    indices: torch.Tensor,
+    *,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Apply indexed gated residual, reusing disposable CUDA BF16 input."""
+    # Apply the per-index gated residual: x + gate[idx] * other.
+    if (
+        x.is_cuda
+        and x.dtype == _BF16_DTYPE
+        and dtype == _BF16_DTYPE
+        and gate.dtype == _BF16_DTYPE
+        and other.dtype == _BF16_DTYPE
+        and x.is_contiguous()
+        and other.is_contiguous()
+    ):
+        return indexed_gate_bf16_(x, gate, other, indices)
+    return (x + gate.index_select(0, indices) * other).to(dtype)
+
+
+def _silu_mul(hidden: torch.Tensor, *, reuse_input: bool) -> torch.Tensor:
+    if (
+        reuse_input
+        and hidden.is_cuda
+        and hidden.dtype == _BF16_DTYPE
+        and hidden.is_contiguous()
+        and hidden.shape[-1] % 16 == 0
+    ):
+        return silu_and_mul_with_activation_rounding_(hidden)
+    gate, up = hidden.chunk(2, dim=-1)
+    return nn.functional.silu(gate) * up
+
+
+def _apply_qk_norm(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_norm: nn.RMSNorm,
+    k_norm: nn.RMSNorm,
+    head_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if (
+        q.is_cuda
+        and q.dtype == _BF16_DTYPE
+        and q.dtype == k.dtype == q_norm.weight.dtype == k_norm.weight.dtype
+        and q.stride(-1) == k.stride(-1) == 1
+        and q.stride(-2) == k.stride(-2) == head_dim
+        and q_norm.eps == k_norm.eps
+        and not torch.compiler.is_compiling()
+    ):
+        fused_inplace_qknorm(
+            q,
+            k,
+            q_norm.weight,
+            k_norm.weight,
+            eps=q_norm.eps,
+            head_dim=head_dim,
+        )
+        return q, k
+    return q_norm(q), k_norm(k)
+
+
+class MiniMaxH3Rope(nn.Module):
+    """3D rope over (t, h, w); rotates 96 of 128 head dims (rotary_percent 0.75).
+
+    Frequency layout concatenates temporal, height, and width embeddings twice,
+    with 16 frequencies per axis (inv_freq = base^-(arange(0,32,2)/32)).
+    """
+
+    def __init__(self, inv_freq_len: int) -> None:
+        super().__init__()
+        self.register_buffer(
+            "inv_freq",
+            torch.empty(inv_freq_len, dtype=_FP32_DTYPE),
+            persistent=True,
+        )
+
+    def forward(self, img_position_ids: torch.Tensor) -> torch.Tensor:
+        """img_position_ids: [1, S, 3] (t, h, w) -> freqs [S, rot_dim=96]."""
+        if img_position_ids.dim() != 3 or img_position_ids.shape[0] != 1:
+            raise ValueError(
+                "img_position_ids must be [1, S, 3], got "
+                f"{list(img_position_ids.shape)}"
+            )
+        pos = img_position_ids[0].to(_FP32_DTYPE)  # [S, 3]
+        per_axis = pos.unsqueeze(-1) * self.inv_freq.view(1, 1, -1)  # [S, 3, 16]
+        t_f, h_f, w_f = per_axis.unbind(dim=1)  # each [S, 16]
+        half = torch.cat((t_f, h_f, w_f), dim=-1)  # [S, 48]
+        return torch.cat((half, half), dim=-1)  # [S, 96]
+
+
+def _rope_cos_sin_cache(freqs: torch.Tensor, *, dtype: torch.dtype) -> torch.Tensor:
+    """Build the activation-dtype cos|sin cache for fused Q/K RoPE."""
+    half = freqs.shape[-1] // 2
+    return (
+        torch.cat(
+            (torch.cos(freqs[:, :half]), torch.sin(freqs[:, :half])),
+            dim=-1,
+        )
+        .to(dtype=dtype, copy=False)
+        .contiguous()
+    )
+
+
+def _apply_rope_cos_sin(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> torch.Tensor:
+    """Rotate the first cached RoPE dims; pass the remaining head dims through."""
+    rot_dim = cos.shape[-1]
+    x_rot, x_pass = x[..., :rot_dim], x[..., rot_dim:]
+    x_rot = (x_rot * cos) + (_rotate_half(x_rot) * sin)
+    return torch.cat((x_rot, x_pass), dim=-1)
+
+
+def _apply_rope_qk(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if not q.is_cuda:
+        half = cos_sin_cache.shape[-1] // 2
+        cos_half, sin_half = cos_sin_cache.split(half, dim=-1)
+        cos = torch.cat((cos_half, cos_half), dim=-1).unsqueeze(1)
+        sin = torch.cat((sin_half, sin_half), dim=-1).unsqueeze(1)
+        return (
+            _apply_rope_cos_sin(q, cos, sin),
+            _apply_rope_cos_sin(k, cos, sin),
+        )
+
+    from sgl_kernel import rotary_embedding as apply_sgl_kernel_rotary_embedding
+
+    apply_sgl_kernel_rotary_embedding(
+        positions,
+        q.view(q.shape[0], -1),
+        k.view(k.shape[0], -1),
+        q.shape[-1],
+        cos_sin_cache,
+        True,
+    )
+    return q, k
+
+
+class MiniMaxH3TimeEmbedder(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.frequency_embedding_size = arch.timestep_input_dim
+        self.proj_in = ColumnParallelLinear(
+            arch.timestep_input_dim,
+            arch.time_embed_hidden_size,
+            bias=True,
+            gather_output=False,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix=f"{prefix}.proj_in",
+        )
+        self.proj_out = RowParallelLinear(
+            arch.time_embed_hidden_size,
+            arch.time_embed_dim,
+            bias=True,
+            input_is_parallel=True,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix=f"{prefix}.proj_out",
+        )
+        self.register_buffer("_frequency_cache", None, persistent=False)
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        """t: [M] -> [M, time_embed_dim] fp32.
+
+        The sinusoidal embedding stays fp32 throughout and concatenates cosine
+        values before sine values.
+        """
+        half = self.frequency_embedding_size // 2
+        freqs = self._frequency_cache
+        if freqs is None or freqs.device != t.device:
+            # Construct this on the execution device once so the values keep
+            # the established CUDA numerics without repeating arange/exp on
+            # every denoise step.
+            freqs = torch.exp(
+                -math.log(10000.0)
+                * torch.arange(half, dtype=_FP32_DTYPE, device=t.device)
+                / half
+            )
+            self._frequency_cache = freqs
+        args = t.to(_FP32_DTYPE)[:, None] * freqs[None]
+        t_freq = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        hidden, _ = self.proj_in(t_freq)
+        hidden = nn.functional.silu(hidden)
+        out, _ = self.proj_out(hidden)
+        return out
+
+
+def _minimax_h3_attention_core_impl(
+    attention: MiniMaxH3Attention,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor,
+    cu_seqlens_host: tuple[int, ...] | None,
+    max_seqlen: int,
+    ulysses_active: bool,
+) -> torch.Tensor:
+    """Dynamic varlen attention and Ulysses collectives.
+
+    This is the narrow BCG break point: projections, normalization, RoPE,
+    residuals, and MLPs remain captured while the dynamic packed attention
+    kernel and sequence-parallel collectives execute eagerly.
+    """
+
+    return _sol_attn_forward_attention(
+        attention,
+        q,
+        k,
+        v,
+        cu_seqlens=cu_seqlens,
+        cu_seqlens_host=cu_seqlens_host,
+        max_seqlen=max_seqlen,
+        ulysses_active=ulysses_active,
+    )
+
+
+_minimax_h3_attention_core_bcg = eager_on_graph(True)(_minimax_h3_attention_core_impl)
+
+
+class MiniMaxH3Attention(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+        bcg_breakpoint: bool = True,
+    ) -> None:
+        super().__init__()
+        self.bcg_breakpoint = bcg_breakpoint
+        self.tp_size = get_tp_world_size()
+        if arch.num_attention_heads % self.tp_size:
+            raise ValueError(
+                "MiniMax H3 attention heads must be divisible by TP size: "
+                f"{arch.num_attention_heads} % {self.tp_size} != 0"
+            )
+        self.total_num_heads = arch.num_attention_heads
+        self.num_heads = self.total_num_heads // self.tp_size
+        self.head_dim = arch.attention_head_dim
+        self.inner_dim = self.total_num_heads * self.head_dim
+        self.local_inner_dim = self.num_heads * self.head_dim
+        self.softmax_scale = self.head_dim**-0.5
+        self._supported_attention_backends = arch._supported_attention_backends
+        self._attention_impl = None
+        self._sol_attn_layer_index = _sol_attn_parse_layer_index(prefix)
+        # The checkpoint stores one fused qkv tensor. Each logical Q/K/V
+        # matrix must be sharded independently; a plain ColumnParallelLinear
+        # would instead slice across the concatenated tensor and is incorrect
+        # for TP > 1.
+        self.qkv_proj = MergedColumnParallelLinear(
+            arch.hidden_size,
+            [self.inner_dim] * 3,
+            bias=False,
+            gather_output=False,
+            params_dtype=_BF16_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj",
+        )
+        self._install_qkv_weight_loader(arch)
+        self.q_norm = _norm(arch.attention_head_dim, eps=arch.qk_norm_eps)
+        self.k_norm = _norm(arch.attention_head_dim, eps=arch.qk_norm_eps)
+        # cache width covers cos/sin for temporal, height, and width frequencies
+        rope_dim = 6 * arch.rope_inv_freq_len
+        self._use_fused_qknorm_rope = (
+            current_platform.is_cuda()
+            and can_use_fused_inplace_qknorm_rope(
+                arch.attention_head_dim,
+                rope_dim,
+                True,
+                _BF16_DTYPE,
+                cache_dtype=_BF16_DTYPE,
+                round_norm_before_rope=True,
+            )
+        )
+        self.out_proj = RowParallelLinear(
+            self.inner_dim,
+            arch.hidden_size,
+            bias=False,
+            input_is_parallel=True,
+            params_dtype=_BF16_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.out_proj",
+        )
+
+    def _set_attention_backend(self, backend) -> None:
+        impl_cls = backend.get_impl_cls()
+        self._attention_impl = impl_cls(
+            num_heads=self.num_heads,
+            head_size=self.head_dim,
+            causal=False,
+            softmax_scale=self.softmax_scale,
+            num_kv_heads=self.num_heads,
+        )
+
+    def _install_qkv_weight_loader(self, arch: MiniMaxH3DiTArchConfig) -> None:
+        weight = self.qkv_proj.weight
+        base_loader = weight.weight_loader
+
+        def _weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
+            # The grouped checkpoint layout is
+            # [num_query_groups, q_per_group + k + v] before splitting.
+            # MiniMax H3 uses MHA, so checkpoint rows are per-head [q, k, v],
+            # while SGLang stores [q_all, k_all, v_all].
+            if _copy_grouped_qkv_tp_shard(
+                param,
+                loaded_weight,
+                num_query_groups=arch.num_attention_heads,
+                head_dim=arch.attention_head_dim,
+                tp_rank=self.qkv_proj.tp_rank,
+                tp_size=self.tp_size,
+            ):
+                return
+            reordered = _reorder_grouped_qkv_to_qkv(
+                loaded_weight,
+                num_query_groups=arch.num_attention_heads,
+                heads_per_group=1,
+                head_dim=arch.attention_head_dim,
+            )
+            base_loader(param, reordered)
+
+        if hasattr(weight, "_weight_loader"):
+            weight._weight_loader = _weight_loader
+        else:
+            weight.weight_loader = _weight_loader
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        rope_cache: tuple[torch.Tensor, torch.Tensor] | None,
+        cu_seqlens: torch.Tensor,
+        cu_seqlens_host: tuple[int, ...] | None = None,
+        max_seqlen: int,
+        ulysses_active: bool = False,
+    ) -> torch.Tensor:
+        """x: [T, hidden] packed thd rows -> [T, hidden].
+
+        Operation order: fused qkv projection -> per-head q/k RMSNorm -> RoPE
+        on q/k -> variable-length non-causal flash attention -> output projection.
+
+        With Ulysses sequence parallelism, x holds this rank's row shard;
+        qkv/norm/RoPE run locally, an all-to-all trades sequence for heads.
+        Each rank attends the full sequence with heads/world_size local heads,
+        so cu_seqlens retains global packed-document semantics. The inverse
+        all-to-all restores the row shard before the output projection.
+        """
+        total = x.shape[0]
+        qkv, _ = self.qkv_proj(x)
+        q, k, v = qkv.split(self.local_inner_dim, dim=-1)
+        q = q.view(total, self.num_heads, self.head_dim)
+        k = k.view(total, self.num_heads, self.head_dim)
+        v = v.view(total, self.num_heads, self.head_dim)
+        if rope_cache is None:
+            q, k = _apply_qk_norm(
+                q,
+                k,
+                self.q_norm,
+                self.k_norm,
+                self.head_dim,
+            )
+        else:
+            cos_sin_cache, positions = rope_cache
+            if self._use_fused_qknorm_rope and not torch.compiler.is_compiling():
+                fused_inplace_qknorm_rope(
+                    q,
+                    k,
+                    self.q_norm.weight,
+                    self.k_norm.weight,
+                    cos_sin_cache,
+                    positions,
+                    is_neox=True,
+                    eps=self.q_norm.eps,
+                    head_dim=self.head_dim,
+                    rope_dim=cos_sin_cache.shape[-1],
+                    round_norm_before_rope=True,
+                )
+            else:
+                q, k = _apply_qk_norm(
+                    q,
+                    k,
+                    self.q_norm,
+                    self.k_norm,
+                    self.head_dim,
+                )
+                q, k = _apply_rope_qk(q, k, cos_sin_cache, positions)
+
+        attention_core = (
+            _minimax_h3_attention_core_bcg
+            if self.bcg_breakpoint
+            else _minimax_h3_attention_core_impl
+        )
+        out = attention_core(
+            self,
+            q,
+            k,
+            v,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_host=cu_seqlens_host,
+            max_seqlen=max_seqlen,
+            ulysses_active=ulysses_active,
+        )
+        out = out.reshape(total, self.num_heads * self.head_dim)
+        out, _ = self.out_proj(out)
+        return out
+
+
+class MiniMaxH3MLP(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        # As with qkv, gate and up are two independently sharded logical
+        # matrices even though the checkpoint stores them fused.
+        self.fc1 = MergedColumnParallelLinear(
+            arch.hidden_size,
+            [arch.ffn_hidden_size] * 2,
+            bias=False,
+            gather_output=False,
+            params_dtype=_BF16_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.fc1",
+        )
+        # Chunk the fused fc1 output as [gate, up], then compute
+        # silu(gate) * up.
+        self.fc2 = RowParallelLinear(
+            arch.ffn_hidden_size,
+            arch.hidden_size,
+            bias=False,
+            input_is_parallel=True,
+            params_dtype=_BF16_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.fc2",
+        )
+        self.reuse_fc1_activation = quant_config is None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        hidden, _ = self.fc1(x)
+        hidden = _silu_mul(hidden, reuse_input=self.reuse_fc1_activation)
+        out, _ = self.fc2(hidden)
+        return out
+
+
+class MiniMaxH3AdalnProj(nn.Module):
+    """SiLU + zero-init linear over unique condition embeddings.
+
+    Per block, three modalities each produce six H-wide vectors:
+    [M, t_dim] -> [M, 3*6H] -> view(M*3, 6H) -> chunk(6).
+    The final layer uses one modality and produces two H-wide vectors:
+    [M, t_dim] -> [M, 2H] -> chunk(2).
+    """
+
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        out_features: int,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+        expand_ratio: int,
+        modality_num: int,
+    ) -> None:
+        super().__init__()
+        if out_features != expand_ratio * arch.hidden_size * modality_num:
+            raise ValueError(
+                "adaln out_features mismatch: "
+                f"{out_features} != {expand_ratio}*{arch.hidden_size}*{modality_num}"
+            )
+        self.expand_ratio = expand_ratio
+        self.modality_num = modality_num
+        self.hidden_size = arch.hidden_size
+        self.linear = ColumnParallelLinear(
+            arch.time_embed_dim,
+            out_features,
+            bias=True,
+            gather_output=False,
+            params_dtype=_BF16_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.linear",
+        )
+
+    def project_local(self, adaln_input: torch.Tensor) -> torch.Tensor:
+        x, _ = self.linear(adaln_input)
+        return x
+
+    def split_output(self, x: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        m = x.shape[0]
+        x = x.view(m * self.modality_num, self.expand_ratio * self.hidden_size)
+        return tuple(x.chunk(self.expand_ratio, dim=-1))
+
+    def forward(self, adaln_input: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        """adaln_input: SiLU(t_emb) BF16 -> expand_ratio tensors of [M*modality_num, H]."""
+        x = self.project_local(adaln_input)
+        if get_tp_world_size() > 1:
+            x = tensor_model_parallel_all_gather(x)
+        return self.split_output(x)
+
+
+class MiniMaxH3TokenRefinerBlock(nn.Module):
+    """Standard pre-norm transformer block without AdaLN or RoPE."""
+
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.norm1 = _norm(arch.hidden_size, eps=arch.norm_eps)
+        self.norm2 = _norm(arch.hidden_size, eps=arch.norm_eps)
+        # The whole dynamic text-refiner/scatter phase is one BCG break point;
+        # do not nest per-attention graph breaks inside it.
+        self.attn = MiniMaxH3Attention(
+            arch,
+            quant_config,
+            prefix=f"{prefix}.attn",
+            bcg_breakpoint=False,
+        )
+        self.mlp = MiniMaxH3MLP(arch, quant_config, prefix=f"{prefix}.mlp")
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor,
+        cu_seqlens_host: tuple[int, ...] | None = None,
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        x = x + self.attn(
+            self.norm1(x),
+            rope_cache=None,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_host=cu_seqlens_host,
+            max_seqlen=max_seqlen,
+        )
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class MiniMaxH3TokenRefiner(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.blocks = nn.ModuleList(
+            [
+                MiniMaxH3TokenRefinerBlock(
+                    arch,
+                    quant_config,
+                    prefix=f"{prefix}.blocks.{index}",
+                )
+                for index in range(arch.token_refiner_num_layers)
+            ]
+        )
+        self.final_norm = _norm(arch.hidden_size, eps=arch.final_norm_eps)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor,
+        cu_seqlens_host: tuple[int, ...] | None = None,
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        for block in self.blocks:
+            x = block(
+                x,
+                cu_seqlens=cu_seqlens,
+                cu_seqlens_host=cu_seqlens_host,
+                max_seqlen=max_seqlen,
+            )
+        return self.final_norm(x)
+
+
+class MiniMaxH3DiTBlock(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.norm1 = _norm(arch.hidden_size, eps=arch.norm_eps)
+        self.norm2 = _norm(arch.hidden_size, eps=arch.norm_eps)
+        self.attn = MiniMaxH3Attention(
+            arch,
+            quant_config,
+            prefix=f"{prefix}.attn",
+        )
+        self.mlp = MiniMaxH3MLP(arch, quant_config, prefix=f"{prefix}.mlp")
+        self.adaln_proj = MiniMaxH3AdalnProj(
+            arch,
+            arch.adaln_out_features,
+            quant_config,
+            prefix=f"{prefix}.adaln_proj",
+            expand_ratio=6,
+            modality_num=MINIMAX_H3_ADALN_MODALITY_NUM,
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        adaln_input: torch.Tensor,
+        combined_indices: torch.Tensor,
+        rope_cache: tuple[torch.Tensor, torch.Tensor],
+        cu_seqlens: torch.Tensor,
+        cu_seqlens_host: tuple[int, ...] | None = None,
+        max_seqlen: int,
+        ulysses_active: bool = False,
+        adaln_params: tuple[torch.Tensor, ...] | None = None,
+    ) -> torch.Tensor:
+        """x: [T, H]; adaln_input: [M, t_dim]; combined_indices: [T]
+        (= inverse_indices * modality_num + token_tags.clamp(min=0)).
+
+        Each block computes AdaLN parameters once, then applies
+        norm1 -> scale/shift -> attention -> gated residual, followed by
+        norm2 -> scale/shift -> MLP -> gated residual.
+        """
+        if adaln_params is None:
+            adaln_params = self.adaln_proj(adaln_input)
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = adaln_params
+
+        residual = x
+        h = self.norm1(x)
+        h = _modulate_scale_shift(
+            h, shift_msa, scale_msa, combined_indices, dtype=_BF16_DTYPE
+        )
+        h = self.attn(
+            h,
+            rope_cache=rope_cache,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_host=cu_seqlens_host,
+            max_seqlen=max_seqlen,
+            ulysses_active=ulysses_active,
+        )
+        x = _modulate_gate(residual, gate_msa, h, combined_indices, dtype=_BF16_DTYPE)
+
+        residual = x
+        h = self.norm2(x)
+        h = _modulate_scale_shift(
+            h, shift_mlp, scale_mlp, combined_indices, dtype=_BF16_DTYPE
+        )
+        h = self.mlp(h)
+        return _modulate_gate(
+            residual, gate_mlp, h, combined_indices, dtype=_BF16_DTYPE
+        )
+
+
+class MiniMaxH3FinalLayer(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        video_patch_dim = (
+            arch.latents_dim
+            * arch.patch_size[0]
+            * arch.patch_size[1]
+            * arch.patch_size[2]
+        )
+        self.norm = _norm(arch.hidden_size, eps=arch.final_norm_eps)
+        self.adaln_proj = MiniMaxH3AdalnProj(
+            arch,
+            arch.final_adaln_out_features,
+            quant_config,
+            prefix=f"{prefix}.adaln_proj",
+            expand_ratio=2,
+            modality_num=1,
+        )
+        self.video_out = ColumnParallelLinear(
+            arch.hidden_size,
+            video_patch_dim,
+            bias=True,
+            gather_output=False,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix=f"{prefix}.video_out",
+        )
+        self.audio_out = ColumnParallelLinear(
+            arch.hidden_size,
+            arch.audio_latents_dim,
+            bias=True,
+            gather_output=False,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix=f"{prefix}.audio_out",
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        adaln_input: torch.Tensor,
+        inverse_indices: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Project all rows into TP-local video/audio output shards.
+
+        Apply single-modality shift/scale AdaLN to the final normalized
+        activations, cast to fp32, then apply both output heads to all rows.
+        The model gathers output columns only after selecting live media rows,
+        preserving the GEMM shape while reducing collective payload.
+        """
+        shift, scale = self.adaln_proj(adaln_input)
+        h = self.norm(x)
+        h = _modulate_scale_shift(h, shift, scale, inverse_indices, dtype=_BF16_DTYPE)
+        # Preserve full precision through both final output projections.
+        h = h.to(_FP32_DTYPE)
+        video, _ = self.video_out(h)
+        audio, _ = self.audio_out(h)
+        return video, audio
+
+
+class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
+    _fsdp_shard_conditions = _ARCH_DEFAULTS._fsdp_shard_conditions
+    # parameters mix fp32 (patch projections, timestep embedder, and output
+    # heads) with bf16 blocks; FSDP must gather in each parameter's own dtype
+    _fsdp_mixed_dtype_params = True
+    _compile_conditions = _ARCH_DEFAULTS._compile_conditions
+    _supported_attention_backends = _ARCH_DEFAULTS._supported_attention_backends
+    param_names_mapping = _ARCH_DEFAULTS.param_names_mapping
+    reverse_param_names_mapping = _ARCH_DEFAULTS.reverse_param_names_mapping
+    lora_param_names_mapping = _ARCH_DEFAULTS.lora_param_names_mapping
+
+    def _can_batch_block_adaln(self) -> bool:
+        return (
+            get_tp_world_size() > 1
+            and not torch.compiler.is_compiling()
+            and not envs.SGLANG_CACHE_DIT_ENABLED
+            and not hasattr(self, "_sglang_cache_dit_adapter")
+            and not is_layerwise_offloaded_module(self)
+            and all(type(block) is MiniMaxH3DiTBlock for block in self.blocks)
+        )
+
+    def _validate_tp_config(
+        self, *, arch: MiniMaxH3DiTArchConfig, tp_size: int
+    ) -> None:
+        if tp_size <= 0:
+            raise ValueError("TP size must be positive.")
+        if arch.num_attention_heads <= 0:
+            raise ValueError("num_attention_heads must be positive.")
+        if arch.hidden_size <= 0:
+            raise ValueError("hidden_size must be positive.")
+        if arch.attention_head_dim <= 0:
+            raise ValueError("attention_head_dim must be positive.")
+        if arch.ffn_hidden_size <= 0:
+            raise ValueError("ffn_hidden_size must be positive.")
+        for name, value in (
+            ("num_attention_heads", arch.num_attention_heads),
+            ("hidden_size", arch.hidden_size),
+            ("ffn_hidden_size", arch.ffn_hidden_size),
+            ("time_embed_hidden_size", arch.time_embed_hidden_size),
+            ("adaln_out_features", arch.adaln_out_features),
+            ("final_adaln_out_features", arch.final_adaln_out_features),
+            ("video_patch_output_dim", arch.latents_dim * math.prod(arch.patch_size)),
+            ("audio_patch_output_dim", arch.audio_latents_dim),
+        ):
+            if value % tp_size:
+                raise ValueError(
+                    f"MiniMax H3 {name}={value} must be divisible by "
+                    f"TP size {tp_size}."
+                )
+
+    @staticmethod
+    def _validate_sequence_parallel_config(
+        *,
+        arch: MiniMaxH3DiTArchConfig,
+        tp_size: int,
+        ulysses_size: int,
+        ring_size: int,
+    ) -> None:
+        if ulysses_size <= 0:
+            raise ValueError("MiniMax H3 Ulysses size must be positive.")
+        if ring_size != 1:
+            raise NotImplementedError(
+                "MiniMax H3 packed multi-segment attention does not support "
+                "Ring or mixed USP. Set --ring-degree 1 and use Ulysses "
+                "sequence parallelism."
+            )
+        local_heads = arch.num_attention_heads // tp_size
+        if local_heads % ulysses_size:
+            raise ValueError(
+                f"MiniMax H3 TP-local heads {local_heads} must be divisible by "
+                f"Ulysses size {ulysses_size} (total heads="
+                f"{arch.num_attention_heads}, TP={tp_size})."
+            )
+        if MINIMAX_H3_PACKED_SEQUENCE_ALIGNMENT % ulysses_size:
+            raise ValueError(
+                "MiniMax H3 packed sequence alignment "
+                f"{MINIMAX_H3_PACKED_SEQUENCE_ALIGNMENT} must be divisible by "
+                f"Ulysses size {ulysses_size}. Choose a Ulysses size that "
+                "divides both the TP-local attention heads and the packed "
+                "sequence alignment."
+            )
+
+    def __init__(
+        self,
+        config: MiniMaxH3DiTConfig,
+        hf_config: dict[str, Any],
+        quant_config: QuantizationConfig | None = None,
+    ) -> None:
+        super().__init__(config=config, hf_config=hf_config)
+        arch = config.arch_config
+        self.arch = arch
+        self.hidden_size = arch.hidden_size
+        self.num_attention_heads = arch.num_attention_heads
+        self.num_channels_latents = arch.latents_dim
+        tp_size = get_tp_world_size()
+        ulysses_size, _ = _ulysses_ctx()
+        self._validate_tp_config(arch=arch, tp_size=tp_size)
+        self._validate_sequence_parallel_config(
+            arch=arch,
+            tp_size=tp_size,
+            ulysses_size=ulysses_size,
+            ring_size=_ring_world_size(),
+        )
+
+        self.video_patch_proj = ColumnParallelLinear(
+            arch.latents_dim
+            * arch.patch_size[0]
+            * arch.patch_size[1]
+            * arch.patch_size[2],
+            arch.hidden_size,
+            bias=True,
+            gather_output=True,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix="video_patch_proj",
+        )
+        self.audio_patch_proj = ColumnParallelLinear(
+            arch.audio_latents_dim,
+            arch.hidden_size,
+            bias=True,
+            gather_output=True,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix="audio_patch_proj",
+        )
+        self.condition_proj = ColumnParallelLinear(
+            arch.text_dim,
+            arch.hidden_size,
+            bias=True,
+            gather_output=True,
+            params_dtype=_BF16_DTYPE,
+            quant_config=quant_config,
+            prefix="condition_proj",
+        )
+        self.time_embedder = MiniMaxH3TimeEmbedder(
+            arch,
+            prefix="time_embedder",
+        )
+        self.rope = MiniMaxH3Rope(arch.rope_inv_freq_len)
+        self.token_refiner = MiniMaxH3TokenRefiner(
+            arch,
+            quant_config,
+            prefix="token_refiner",
+        )
+        self.blocks = nn.ModuleList(
+            [
+                MiniMaxH3DiTBlock(
+                    arch,
+                    quant_config,
+                    prefix=f"blocks.{index}",
+                )
+                for index in range(arch.num_layers)
+            ]
+        )
+        self.layer_names = ["blocks"]
+        self.final_layer = MiniMaxH3FinalLayer(
+            arch,
+            quant_config,
+            prefix="final_layer",
+        )
+        self._resolved_attention_backend: AttentionBackendEnum | None = None
+        self._mark_missing_params_required()
+
+    def _resolve_attention_backend_once(self) -> None:
+        if self._resolved_attention_backend is not None:
+            return
+        backend = get_attn_backend(
+            self.arch.attention_head_dim,
+            _BF16_DTYPE,
+            supported_attention_backends=self._supported_attention_backends,
+        )
+        for module in self.modules():
+            if isinstance(module, MiniMaxH3Attention):
+                module._set_attention_backend(backend)
+        self._resolved_attention_backend = backend.get_enum()
+
+    def _mark_missing_params_required(self) -> None:
+        for _, param in self.named_parameters():
+            param.missing_param_init = "error"
+
+    def post_load_weights(self) -> None:
+        for name in _MINIMAX_H3_FP32_PARAM_NAMES_IN_MODEL_ORDER:
+            param = self.get_parameter(name)
+            if param.dtype != _FP32_DTYPE:
+                raise ValueError(
+                    f"{name} must stay fp32 after load, got {param.dtype}."
+                )
+        # assign=True loading may re-register this persistent buffer as a parameter
+        rope_inv_freq = self.rope.inv_freq
+        if rope_inv_freq.dtype != _FP32_DTYPE:
+            raise ValueError(
+                f"rope.inv_freq must stay fp32 after load, got {rope_inv_freq.dtype}."
+            )
+
+    @staticmethod
+    def _pos_ids(pos_info: Any, key: str) -> torch.Tensor:
+        if isinstance(pos_info, dict):
+            ids = pos_info.get("position_ids")
+        else:
+            ids = getattr(pos_info, "position_ids", None)
+        if ids is None:
+            raise ValueError(f"{key}.position_ids is required")
+        return ids.view(-1).to(torch.long)
+
+    @staticmethod
+    def _psp_field(psp: Any, key: str, field: str) -> Any:
+        if isinstance(psp, dict):
+            value = psp.get(field)
+        else:
+            value = getattr(psp, field, None)
+        if value is None:
+            raise ValueError(f"{key}.{field} is required")
+        return value
+
+    @staticmethod
+    def _psp_optional_field(psp: Any, field: str) -> Any:
+        if isinstance(psp, dict):
+            return psp.get(field)
+        return getattr(psp, field, None)
+
+    def refine_prompt_embeds(
+        self,
+        prompt_embeds: torch.Tensor,
+        refiner_cu_seqlens: torch.Tensor,
+        *,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Project and refine request-static text conditioning once."""
+        text_len = int(refiner_cu_seqlens[1].item())
+        if text_len <= 0 or text_len > int(prompt_embeds.shape[0]):
+            raise ValueError(
+                "refiner cu_seqlens live text length must be in "
+                f"[1, {int(prompt_embeds.shape[0])}], got {text_len}"
+            )
+        text_rows = prompt_embeds[:text_len].to(device=device, dtype=_BF16_DTYPE)
+        true_refiner_cu = torch.stack(
+            (
+                refiner_cu_seqlens[0],
+                refiner_cu_seqlens[1],
+                refiner_cu_seqlens[1],
+            )
+        )
+        text_embed, _ = self.condition_proj(text_rows)
+        return self.token_refiner(
+            text_embed,
+            cu_seqlens=true_refiner_cu,
+            cu_seqlens_host=(0, text_len, text_len),
+            max_seqlen=text_len,
+        )
+
+    def build_rope_cache(
+        self,
+        img_position_ids: torch.Tensor,
+        *,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build request-static RoPE inputs for this Ulysses rank."""
+        if img_position_ids.dim() != 3 or img_position_ids.shape[0] != 1:
+            raise ValueError(
+                "img_position_ids must be [1, S, 3], got "
+                f"{list(img_position_ids.shape)}"
+            )
+        seq_len = int(img_position_ids.shape[1])
+        sp_ws, sp_rank = _ulysses_ctx()
+        if seq_len % sp_ws:
+            raise ValueError(
+                f"packed seq_len {seq_len} not divisible by ulysses world size {sp_ws}"
+            )
+        local_seq_len = seq_len // sp_ws
+        row_start = sp_rank * local_seq_len
+        rope_freqs = self.rope(
+            img_position_ids[:, row_start : row_start + local_seq_len]
+        ).to(device)
+        return (
+            _rope_cos_sin_cache(rope_freqs, dtype=_BF16_DTYPE),
+            torch.arange(
+                local_seq_len,
+                device=device,
+                dtype=torch.long,
+            ),
+        )
+
+    @eager_on_graph(True)
+    def _embed(
+        self,
+        *,
+        x: torch.Tensor,
+        audio_x: torch.Tensor,
+        text_embeddings_selected: torch.Tensor,
+        unique_timesteps: torch.Tensor,
+        img_pos: torch.Tensor,
+        audio_pos: torch.Tensor,
+        text_pos: torch.Tensor,
+        refiner_cu_seqlens: torch.Tensor,
+        refiner_max_seqlen: int,
+        row_start: int,
+        row_stop: int,
+        device: torch.device,
+        refined_prompt_embeds_length: int | torch.Tensor | None = None,
+        local_embedding_layout: dict[str, torch.Tensor | int] | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build embeddings for one contiguous block-stack row shard.
+
+        Returns (decoder_input [S_local, H] bf16, t_emb [M, t_dim] fp32).
+        """
+        # BCG pads the prompt tensor only to stabilize its input signature.
+        # Raw-input callers recover the live length from refiner metadata;
+        # request-static refined inputs carry it as a host integer and avoid a
+        # per-step device scalar read. Running the refiner at the bucketed M
+        # dimension changes GEMM selection and is not bitwise equivalent.
+        if refined_prompt_embeds_length is None:
+            text_len = int(refiner_cu_seqlens[1].item())
+        elif torch.is_tensor(refined_prompt_embeds_length):
+            # BCG turns this request-varying host constant into a scalar input
+            # so different live lengths can replay one padded-text signature.
+            # _embed is an eager graph break, so this value is read outside
+            # captured CUDA graphs.
+            text_len = int(refined_prompt_embeds_length.item())
+        else:
+            text_len = int(refined_prompt_embeds_length)
+        if text_len <= 0 or text_len > int(text_embeddings_selected.shape[0]):
+            raise ValueError(
+                "refiner cu_seqlens live text length must be in "
+                f"[1, {int(text_embeddings_selected.shape[0])}], got {text_len}"
+            )
+        text_pos = text_pos[:text_len]
+        if refined_prompt_embeds_length is not None:
+            text_embed = text_embeddings_selected[:text_len].to(
+                device=device, dtype=_BF16_DTYPE
+            )
+            if int(text_embed.shape[-1]) != self.hidden_size:
+                raise ValueError(
+                    "refined prompt embeddings must have hidden width "
+                    f"{self.hidden_size}, got {int(text_embed.shape[-1])}"
+                )
+        else:
+            text_embed = self.refine_prompt_embeds(
+                text_embeddings_selected,
+                refiner_cu_seqlens,
+                device=device,
+            )
+
+        local_seq_len = row_stop - row_start
+        trusted_layout = local_embedding_layout is not None
+        if trusted_layout:
+            used_len = text_len + int(img_pos.numel()) + int(audio_pos.numel())
+            local_live_rows = min(max(used_len - row_start, 0), local_seq_len)
+            embeddings = torch.empty(
+                (local_seq_len, self.hidden_size), device=device, dtype=_BF16_DTYPE
+            )
+            if local_live_rows < local_seq_len:
+                embeddings[local_live_rows:].zero_()
+        else:
+            # Direct model callers do not provide the serving-time partition
+            # contract. Preserve their historical zero-fill/add semantics for
+            # sparse or overlapping row maps.
+            embeddings = torch.zeros(
+                (local_seq_len, self.hidden_size), device=device, dtype=_BF16_DTYPE
+            )
+
+        if local_embedding_layout is None:
+            text_source_ids = torch.nonzero(
+                (text_pos >= row_start) & (text_pos < row_stop),
+                as_tuple=False,
+            ).view(-1)
+            text_row_ids = text_pos.index_select(0, text_source_ids) - row_start
+            img_global_ids = img_pos.index_select(
+                0,
+                torch.nonzero(
+                    (img_pos >= row_start) & (img_pos < row_stop),
+                    as_tuple=False,
+                ).view(-1),
+            )
+            img_row_ids = img_global_ids - row_start
+            audio_global_ids = audio_pos.index_select(
+                0,
+                torch.nonzero(
+                    (audio_pos >= row_start) & (audio_pos < row_stop),
+                    as_tuple=False,
+                ).view(-1),
+            )
+            audio_row_ids = audio_global_ids - row_start
+        else:
+            text_source_start = int(local_embedding_layout["text_source_start"])
+            text_source_stop = int(local_embedding_layout["text_source_stop"])
+            img_global_ids = local_embedding_layout["img_global_ids"]
+            img_row_ids = local_embedding_layout["img_row_ids"]
+            audio_global_ids = local_embedding_layout["audio_global_ids"]
+            audio_row_ids = local_embedding_layout["audio_row_ids"]
+
+        write_rows = embeddings.index_copy_ if trusted_layout else embeddings.index_add_
+        if trusted_layout:
+            text_rows = text_source_stop - text_source_start
+            if text_rows:
+                embeddings[:text_rows].copy_(
+                    text_embed[text_source_start:text_source_stop]
+                )
+        elif text_row_ids.numel():
+            write_rows(
+                0,
+                text_row_ids,
+                text_embed.index_select(0, text_source_ids).to(_BF16_DTYPE),
+            )
+
+        # latent embedders stay fp32; only rows owned by this SP rank are
+        # projected, then cast during scattering into the bf16 sequence
+        if img_row_ids.numel():
+            x_rows = (
+                x.view(-1, x.shape[-1]).index_select(0, img_global_ids).to(_FP32_DTYPE)
+            )
+            video_embed, _ = self.video_patch_proj(x_rows)
+            write_rows(
+                0,
+                img_row_ids,
+                video_embed.to(_BF16_DTYPE),
+            )
+
+        if audio_row_ids.numel():
+            audio_rows = (
+                audio_x.view(-1, audio_x.shape[-1])
+                .index_select(0, audio_global_ids)
+                .to(_FP32_DTYPE)
+            )
+            audio_embed, _ = self.audio_patch_proj(audio_rows)
+            write_rows(
+                0,
+                audio_row_ids,
+                audio_embed.to(_BF16_DTYPE),
+            )
+
+        t_emb = self.time_embedder(unique_timesteps)
+        return embeddings, t_emb
+
+    def forward(self, **kwargs: Any) -> tuple[torch.Tensor, torch.Tensor]:
+        """Packed inference forward.
+
+        Keyword names follow the checkpoint's serving contract.
+        Returns `(video_logits, audio_logits)` from rows selected by
+        `img_pos_for_infer_output_info` and `audio_pos_info`, with condition
+        rows zeroed by update masks.
+        """
+        # Strict keyword contract: refuse any kwarg forward does not consume.
+        unexpected = sorted(set(kwargs) - _FORWARD_SUPPORTED_KWARGS)
+        if unexpected:
+            raise TypeError(
+                "MiniMaxH3DiTModel.forward received unexpected kwargs: "
+                f"{unexpected}; supported kwargs: "
+                f"{sorted(_FORWARD_SUPPORTED_KWARGS)}"
+            )
+
+        x = _required_kwarg(kwargs, "x")
+        audio_x = _required_kwarg(kwargs, "audio_x")
+        img_position_ids = _required_kwarg(kwargs, "img_position_ids")
+        unique_timesteps = _required_kwarg(kwargs, "unique_timesteps")
+        inverse_indices = (
+            _required_kwarg(kwargs, "inverse_indices").view(-1).to(torch.long)
+        )
+        update_mask = _required_kwarg(kwargs, "update_mask")
+        block_token_tags = kwargs.get("block_token_tags")
+        token_tags = kwargs.get("token_tags")
+        if block_token_tags is None:
+            token_tags = _required_kwarg(kwargs, "token_tags").view(-1).to(torch.long)
+        else:
+            block_token_tags = block_token_tags.view(-1).to(torch.long)
+            token_tags = None
+        skip_mask_out_condition = bool(kwargs.get("skip_mask_out_condition", False))
+
+        text_selected = _required_kwarg(kwargs, "prompt_embeds")
+
+        img_pos = self._pos_ids(_required_kwarg(kwargs, "img_pos_info"), "img_pos_info")
+        audio_pos = self._pos_ids(
+            _required_kwarg(kwargs, "audio_pos_info"), "audio_pos_info"
+        )
+        text_pos = self._pos_ids(
+            _required_kwarg(kwargs, "text_pos_info"),
+            "text_pos_info",
+        )
+        infer_out_pos = self._pos_ids(
+            _required_kwarg(kwargs, "img_pos_for_infer_output_info"),
+            "img_pos_for_infer_output_info",
+        )
+
+        psp = _required_kwarg(kwargs, "packed_seq_params")
+        cu_seqlens = self._psp_field(psp, "packed_seq_params", "cu_seqlens_q").to(
+            torch.int32
+        )
+        raw_cu_seqlens_host = self._psp_optional_field(psp, "cu_seqlens_q_host")
+        cu_seqlens_host = tuple(
+            int(value)
+            for value in (
+                cu_seqlens.tolist()
+                if raw_cu_seqlens_host is None
+                else raw_cu_seqlens_host
+            )
+        )
+        max_seqlen = int(self._psp_field(psp, "packed_seq_params", "max_seqlen_q"))
+        refiner_psp = _required_kwarg(kwargs, "refiner_packed_seq_params")
+        refiner_cu = self._psp_field(
+            refiner_psp, "refiner_packed_seq_params", "cu_seqlens_q"
+        ).to(torch.int32)
+        refiner_max = int(
+            self._psp_field(refiner_psp, "refiner_packed_seq_params", "max_seqlen_q")
+        )
+
+        if x.dim() != 3 or x.shape[0] != 1:
+            raise ValueError(f"x must be [1, S, C], got {list(x.shape)}")
+        seq_len = int(x.shape[1])
+        if token_tags is not None and token_tags.shape[0] != seq_len:
+            raise ValueError(
+                "token_tags must cover the full packed sequence "
+                f"({seq_len}), got {token_tags.shape[0]}."
+            )
+        if inverse_indices.shape[0] != seq_len:
+            raise ValueError(
+                f"inverse_indices must be [{seq_len}], got {list(inverse_indices.shape)}"
+            )
+        sol_attn_context = _sol_attn_begin_model_forward(
+            unique_timesteps=unique_timesteps,
+            text_positions=text_pos,
+            image_positions=img_pos,
+            audio_positions=audio_pos,
+            cu_seqlens_host=cu_seqlens_host,
+            total_tokens=seq_len,
+            num_layers=len(self.blocks),
+        )
+        device = x.device
+        self._resolve_attention_backend_once()
+        if _ring_world_size() != 1:
+            raise NotImplementedError(
+                "MiniMax H3 packed multi-segment attention requires "
+                "--ring-degree 1; Ring and mixed USP are unsupported."
+            )
+
+        sp_ws, sp_rank = _ulysses_ctx()
+        local_seq_len = seq_len
+        if sp_ws > 1:
+            if seq_len % sp_ws:
+                raise ValueError(
+                    f"packed seq_len {seq_len} not divisible by ulysses "
+                    f"world size {sp_ws}"
+                )
+            local_heads = self.num_attention_heads // get_tp_world_size()
+            if local_heads % sp_ws:
+                raise ValueError(
+                    f"TP-local heads {local_heads} not divisible by Ulysses "
+                    f"world size {sp_ws} (total heads={self.num_attention_heads}, "
+                    f"TP={get_tp_world_size()})"
+                )
+            local_seq_len = seq_len // sp_ws
+        row_start = sp_rank * local_seq_len
+        row_stop = row_start + local_seq_len
+
+        # RoPE and latent projections are row-local before Ulysses exchanges
+        # sequence for heads inside attention. Serving normally prepares the
+        # request-static cache once; direct model callers use this fallback.
+        rope_cache = kwargs.get("rope_cache")
+        if rope_cache is None:
+            rope_freqs = self.rope(img_position_ids[:, row_start:row_stop]).to(device)
+            rope_cache = (
+                _rope_cos_sin_cache(rope_freqs, dtype=_BF16_DTYPE),
+                torch.arange(
+                    local_seq_len,
+                    device=device,
+                    dtype=torch.long,
+                ),
+            )
+        img_pos = img_pos.to(device)
+        audio_pos = audio_pos.to(device)
+        text_pos = text_pos.to(device)
+
+        decoder_input, t_emb = self._embed(
+            x=x,
+            audio_x=audio_x,
+            text_embeddings_selected=text_selected,
+            unique_timesteps=unique_timesteps.view(-1).to(device),
+            img_pos=img_pos,
+            audio_pos=audio_pos,
+            text_pos=text_pos,
+            refiner_cu_seqlens=refiner_cu.to(device),
+            refiner_max_seqlen=refiner_max,
+            row_start=row_start,
+            row_stop=row_stop,
+            device=device,
+            refined_prompt_embeds_length=kwargs.get("refined_prompt_embeds_length"),
+            local_embedding_layout=kwargs.get("local_embedding_layout"),
+        )
+        # request-step AdaLN input shared by all blocks
+        adaln_input = nn.functional.silu(t_emb).to(_BF16_DTYPE)
+        inverse_indices = inverse_indices.to(device)
+        block_inverse = inverse_indices[row_start:row_stop]
+        if block_token_tags is None:
+            assert token_tags is not None
+            token_tags = token_tags.to(device)
+            block_token_tags = token_tags[row_start:row_stop].clamp(min=0)
+        else:
+            block_token_tags = block_token_tags.to(device)
+            if block_token_tags.shape[0] != local_seq_len:
+                raise ValueError(
+                    "block_token_tags must cover the rank-local packed sequence "
+                    f"({local_seq_len}), got {block_token_tags.shape[0]}."
+                )
+        block_combined = kwargs.get("block_combined_indices")
+        if block_combined is None:
+            block_combined = torch.add(
+                block_token_tags,
+                block_inverse,
+                alpha=MINIMAX_H3_ADALN_MODALITY_NUM,
+            )
+
+        teacache_enabled = _sol_engine_teacache_enabled()
+        if teacache_enabled:
+            teacache_adaln = self.blocks[0].adaln_proj(adaln_input)
+            teacache_probe = _modulate_scale_shift(
+                self.blocks[0].norm1(decoder_input),
+                teacache_adaln[0],
+                teacache_adaln[1],
+                block_combined,
+                dtype=_BF16_DTYPE,
+            )
+            hidden, cache_action = _sol_engine_teacache_before_blocks(
+                decoder_input,
+                teacache_probe,
+                context=sol_attn_context,
+            )
+        else:
+            hidden, cache_action = decoder_input, None
+        cu_seqlens = cu_seqlens.to(device)
+        if cache_action != "reuse":
+            block_adaln_params = None
+            if self._can_batch_block_adaln():
+                local_adaln = torch.stack(
+                    [
+                        block.adaln_proj.project_local(adaln_input)
+                        for block in self.blocks
+                    ]
+                )
+                gathered_adaln = tensor_model_parallel_all_gather(local_adaln)
+                block_adaln_params = tuple(
+                    block.adaln_proj.split_output(output)
+                    for block, output in zip(self.blocks, gathered_adaln)
+                )
+            # With Ulysses sequence parallelism, shard rows across the group for
+            # the block stack. Attention trades sequence for heads internally.
+            for index, block in enumerate(self.blocks):
+                hidden = block(
+                    hidden,
+                    adaln_input=adaln_input,
+                    combined_indices=block_combined,
+                    rope_cache=rope_cache,
+                    cu_seqlens=cu_seqlens,
+                    cu_seqlens_host=cu_seqlens_host,
+                    max_seqlen=max_seqlen,
+                    ulysses_active=sp_ws > 1,
+                    adaln_params=(
+                        None
+                        if block_adaln_params is None
+                        else block_adaln_params[index]
+                    ),
+                )
+            if cache_action == "compute":
+                hidden = _sol_engine_teacache_after_blocks(hidden)
+        video_logits, audio_logits = self.final_layer(
+            hidden,
+            adaln_input=adaln_input,
+            inverse_indices=block_inverse,
+        )
+        if sp_ws > 1:
+            from sglang.multimodal_gen.runtime.distributed.parallel_state import (
+                get_sp_group,
+            )
+
+            video_width = video_logits.shape[-1]
+            logits = get_sp_group().all_gather(
+                torch.cat((video_logits, audio_logits), dim=-1), dim=0
+            )
+            video_logits, audio_logits = logits.split(
+                (video_width, logits.shape[-1] - video_width), dim=-1
+            )
+
+        # Preserve the full-row output GEMM (and therefore its numerical
+        # contract), but defer TP column gathers until after dead text/padding
+        # rows have been removed. For hybrid TP+Ulysses, the preceding SP row
+        # gather also carries only the TP-local output width.
+        video_logits = video_logits.index_select(0, infer_out_pos.to(device))
+        audio_logits = audio_logits.index_select(0, audio_pos.to(device))
+        if get_tp_world_size() > 1:
+            video_logits = tensor_model_parallel_all_gather(video_logits)
+            audio_logits = tensor_model_parallel_all_gather(audio_logits)
+        if not skip_mask_out_condition:
+            update_mask = update_mask.view(-1).to(device)
+            if update_mask.shape[0] != video_logits.shape[0]:
+                raise ValueError(
+                    "update_mask length mismatch: "
+                    f"{update_mask.shape[0]} != {video_logits.shape[0]}"
+                )
+            video_logits = video_logits * update_mask.unsqueeze(-1)
+            # Audio has no condition rows in the supported tasks, so its
+            # derived update mask is all ones. Honor an explicit mask when
+            # provided.
+            update_audio_mask = kwargs.get("update_audio_mask")
+            if update_audio_mask is not None:
+                audio_logits = audio_logits * update_audio_mask.view(-1).unsqueeze(-1)
+        return video_logits, audio_logits
+
+
+EntryClass = MiniMaxH3DiTModel
+
+__all__ = [
+    "MINIMAX_H3_FP32_BUFFER_NAMES",
+    "MINIMAX_H3_FP32_PARAM_NAMES",
+    "MiniMaxH3DiTModel",
+    "_reorder_grouped_qkv_to_qkv",
+]

--- a/models/minimax_h3/rtx5090/patches/minimax_h3_decoding.py
+++ b/models/minimax_h3/rtx5090/patches/minimax_h3_decoding.py
@@ -1,0 +1,585 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import contextlib
+import functools
+import os
+import time
+from collections.abc import Mapping
+
+import torch
+
+from sglang.multimodal_gen.runtime.disaggregation.roles import RoleType
+from sglang.multimodal_gen.runtime.distributed import (
+    get_world_group,
+    model_parallel_is_initialized,
+)
+from sglang.multimodal_gen.runtime.managers.memory_managers.component_manager import (
+    ComponentUse,
+)
+from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload import (
+    is_layerwise_offloaded_module,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch, Req
+from sglang.multimodal_gen.runtime.pipelines_core.stages.base import (
+    StageParallelismType,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.decoding import DecodingStage
+from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
+    StageValidators as V,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
+    VerificationResult,
+)
+from sglang.multimodal_gen.runtime.server_args import ServerArgs
+from sglang.multimodal_gen.runtime.utils.precision import (
+    autocast_enabled,
+    resolve_decode_precision,
+    resolve_precision,
+)
+from sglang.multimodal_gen.runtime.utils.torch_compile import (
+    ActiveTargetCompiledCallable,
+)
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+
+logger = init_logger(__name__)
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _resident_vae_dtype() -> torch.dtype | None:
+    raw_dtype = os.environ.get("H3_FULL_VAE_DTYPE", "").strip().lower()
+    if not raw_dtype:
+        return None
+    aliases = {
+        "bf16": torch.bfloat16,
+        "bfloat16": torch.bfloat16,
+        "fp16": torch.float16,
+        "float16": torch.float16,
+        "fp32": torch.float32,
+        "float32": torch.float32,
+    }
+    try:
+        return aliases[raw_dtype]
+    except KeyError as exc:
+        raise ValueError(
+            "H3_FULL_VAE_DTYPE must be one of bf16, fp16, or fp32; "
+            f"got {raw_dtype!r}"
+        ) from exc
+
+
+def _parameter_megabytes_by_dtype(module) -> dict[str, float]:
+    totals: dict[str, int] = {}
+    for parameter in module.parameters():
+        key = str(parameter.dtype).removeprefix("torch.")
+        totals[key] = totals.get(key, 0) + parameter.numel() * parameter.element_size()
+    return {key: value / (1024**2) for key, value in sorted(totals.items())}
+
+
+@contextlib.contextmanager
+def _full_video_vae_residency(video_vae):
+    """Temporarily replace per-layer streaming with one full VAE H2D load."""
+
+    enabled = _env_flag("H3_FULL_VAE_AFTER_DENOISE")
+    was_layerwise = enabled and is_layerwise_offloaded_module(video_vae)
+    if not was_layerwise:
+        yield
+        return
+
+    device = torch.get_device_module()
+    resident_dtype = _resident_vae_dtype()
+    device.synchronize()
+    device.empty_cache()
+    if resident_dtype is not None:
+        # Convert the already-resident non-layer parameters first. Offloaded
+        # transformer blocks are materialized below and converted in-place.
+        video_vae.to(dtype=resident_dtype)
+    load_started = time.perf_counter()
+    video_vae.disable_offload()
+    if resident_dtype is not None:
+        video_vae.to(dtype=resident_dtype)
+    device.synchronize()
+    logger.info(
+        "[H3FullVAE] video VAE resident after denoise in %.4f seconds; "
+        "dtype=%s parameter_mb=%s allocated=%.2f MB reserved=%.2f MB",
+        time.perf_counter() - load_started,
+        resident_dtype,
+        _parameter_megabytes_by_dtype(video_vae),
+        device.memory_allocated() / (1024**2),
+        device.memory_reserved() / (1024**2),
+    )
+    try:
+        yield
+    finally:
+        restore_started = time.perf_counter()
+        video_vae.enable_offload()
+        device.synchronize()
+        device.empty_cache()
+        logger.info(
+            "[H3FullVAE] video VAE restored to layerwise offload in %.4f "
+            "seconds; allocated=%.2f MB reserved=%.2f MB",
+            time.perf_counter() - restore_started,
+            device.memory_allocated() / (1024**2),
+            device.memory_reserved() / (1024**2),
+        )
+
+
+@contextlib.contextmanager
+def _bounded_video_vae_tile_batch(video_vae):
+    """Bound stacked spatial-tile batches without changing tile geometry."""
+
+    raw_batch_size = os.environ.get("H3_FULL_VAE_TILE_BATCH_SIZE", "0")
+    try:
+        tile_batch_size = int(raw_batch_size)
+    except ValueError as exc:
+        raise ValueError(
+            "H3_FULL_VAE_TILE_BATCH_SIZE must be an integer, got "
+            f"{raw_batch_size!r}"
+        ) from exc
+    original_run_tile_tasks = getattr(video_vae, "_run_tile_tasks", None)
+    if tile_batch_size <= 0 or not callable(original_run_tile_tasks):
+        yield
+        return
+
+    def run_tile_tasks(tiles, tile_indices, forward_fn, stack_tiling, cls_agg=None):
+        if not stack_tiling or len(tile_indices) <= tile_batch_size:
+            return original_run_tile_tasks(
+                tiles, tile_indices, forward_fn, stack_tiling, cls_agg
+            )
+
+        outputs = []
+        for start in range(0, len(tile_indices), tile_batch_size):
+            chunk_indices = tile_indices[start : start + tile_batch_size]
+            outputs.extend(
+                original_run_tile_tasks(
+                    tiles, chunk_indices, forward_fn, True, cls_agg
+                )
+            )
+        return outputs
+
+    video_vae._run_tile_tasks = run_tile_tasks
+    logger.info(
+        "[H3FullVAE] limiting stacked spatial tiles to %d per decode batch",
+        tile_batch_size,
+    )
+    try:
+        yield
+    finally:
+        video_vae._run_tile_tasks = original_run_tile_tasks
+
+
+def _required_tensor(value, path: str) -> torch.Tensor:
+    if not isinstance(value, torch.Tensor):
+        raise ValueError(f"{path} must be a torch.Tensor")
+    return value
+
+
+@functools.lru_cache(maxsize=None)
+def _cached_decode_mean_std(
+    mean_values: tuple[float, ...],
+    std_values: tuple[float, ...],
+    device: torch.device,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Device/dtype-keyed mean/std tensors, built once per distinct combination.
+
+    mean_values/std_values come from the loaded arch_config and are fixed
+    for the process lifetime, so the same (values, device, dtype) always
+    reconstructs an identical tensor; cache it instead of rebuilding it on
+    every decode call.
+    """
+    mean = torch.as_tensor(mean_values, device=device, dtype=dtype)
+    std = torch.as_tensor(std_values, device=device, dtype=dtype)
+    return mean, std
+
+
+def _reverse_normalize_latents_(
+    latents: torch.Tensor,
+    *,
+    mean_values,
+    std_values,
+    name: str,
+) -> torch.Tensor:
+    mean, std = _cached_decode_mean_std(
+        tuple(mean_values), tuple(std_values), latents.device, latents.dtype
+    )
+    if mean.ndim != 1:
+        raise ValueError(f"{name}.latents_mean must be 1-D, got {tuple(mean.shape)}")
+    if std.ndim != 1:
+        raise ValueError(f"{name}.latents_std must be 1-D, got {tuple(std.shape)}")
+    if mean.shape != std.shape:
+        raise ValueError(
+            f"{name} latent normalization shape mismatch: "
+            f"mean={tuple(mean.shape)} std={tuple(std.shape)}"
+        )
+    if latents.ndim < 2:
+        raise ValueError(f"{name} latents must have a channel dimension")
+    if int(latents.shape[1]) != int(mean.shape[0]):
+        raise ValueError(
+            f"{name} latent normalization channel mismatch: "
+            f"latents.shape[1]={int(latents.shape[1])} mean_len={int(mean.shape[0])}"
+        )
+    view_shape = [1] * latents.ndim
+    view_shape[1] = int(mean.shape[0])
+    return latents.mul_(std.view(*view_shape)).add_(mean.view(*view_shape))
+
+
+def _crop_to_target_canvas(batch: Req, frames: torch.Tensor) -> torch.Tensor:
+    """Crop decoded frames [B,C,T,H,W] back to the target canvas.
+
+    The visual VAE pads the latent grid to its tile multiples (padding lands
+    at the bottom/right), so a non-tile-aligned geometry decodes larger than the
+    requested canvas (e.g. 1344x768 for a 1280x704 target). Target dims come
+    from the direct-mode denoise state (latent_h/w * 16); requests without
+    that state keep the raw decode.
+    """
+    from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.minimax_h3.constants import (
+        MINIMAX_H3_DENOISE_STATE_EXTRA_KEY,
+    )
+
+    state = batch.extra.get(MINIMAX_H3_DENOISE_STATE_EXTRA_KEY)
+    if state is None:
+        return frames
+    target_h = int(state["latent_h"]) * 16
+    target_w = int(state["latent_w"]) * 16
+    h, w = int(frames.shape[-2]), int(frames.shape[-1])
+    if h < target_h or w < target_w:
+        raise ValueError(
+            f"decoded frames {h}x{w} smaller than target canvas {target_h}x{target_w}"
+        )
+    if h == target_h and w == target_w:
+        return frames
+    return frames[..., :target_h, :target_w]
+
+
+def _canonical_visual_video_frames(
+    frames: torch.Tensor, *, batch_size: int
+) -> torch.Tensor:
+    if frames.ndim == 4:
+        if int(frames.shape[0]) % batch_size != 0:
+            raise ValueError(
+                f"Decoded visual video shape {tuple(frames.shape)} is incompatible "
+                f"with batch_size={batch_size}"
+            )
+        frames = frames.reshape(
+            batch_size, int(frames.shape[0]) // batch_size, *frames.shape[1:]
+        )
+        frames = frames.transpose(1, 2)
+    elif frames.ndim == 5:
+        if int(frames.shape[0]) != batch_size:
+            raise ValueError(
+                f"Decoded visual video batch mismatch: frames.shape[0]={int(frames.shape[0])} "
+                f"batch_size={batch_size}"
+            )
+    else:
+        raise ValueError(
+            f"Decoded visual video shape {tuple(frames.shape)} is not supported"
+        )
+    return frames
+
+
+def _canonical_output_audio_waveform(
+    audio_waveform: torch.Tensor, *, batch_size: int
+) -> torch.Tensor:
+    """Project audio-VAE-native ``[C, 1, L]`` audio to output ``[1, C, L]``.
+
+    The audio VAE treats stereo channels as its decoder batch and returns
+    ``[2, 1, samples]`` for MiniMax H3's one generated sample.  The generic output
+    path instead selects generated samples along dimension zero.  Keep the audio VAE
+    tensor unchanged for decoder artifacts, then make the singleton generated-
+    sample dimension explicit only at the ``OutputBatch`` boundary.
+    """
+    if audio_waveform.ndim != 3:
+        raise ValueError(
+            "Decoded audio VAE waveform must be [C, 1, L], got "
+            f"{tuple(audio_waveform.shape)}"
+        )
+    if batch_size != 1:
+        raise ValueError(
+            "MiniMax H3 audio VAE output only supports one generated sample, "
+            f"got visual batch_size={batch_size}"
+        )
+    if int(audio_waveform.shape[1]) != 1:
+        raise ValueError(
+            "Decoded audio VAE waveform must have shape [C, 1, L], got "
+            f"{tuple(audio_waveform.shape)}"
+        )
+    return audio_waveform.permute(1, 0, 2).contiguous()
+
+
+_MINIMAX_H3_DECODER_TASKS = frozenset({"t2va", "fl2va", "ref2va"})
+_MINIMAX_H3_CANONICAL_REQUEST_EXTRA_KEY = "minimax_h3_canonical_request"
+_MINIMAX_H3_RESOLVED_PLAN_EXTRA_KEY = "minimax_h3_resolved_plan"
+
+
+def _minimax_h3_decoder_task(batch: Req) -> str | None:
+    """Return the validated request task used for output-decoder routing.
+
+    Debug requests have no canonical task and retain the
+    generic decoder.
+    """
+
+    extra = getattr(batch, "extra", None)
+    if not isinstance(extra, Mapping):
+        return None
+    canonical = extra.get(_MINIMAX_H3_CANONICAL_REQUEST_EXTRA_KEY)
+    if canonical is not None and not isinstance(canonical, Mapping):
+        raise ValueError("minimax_h3_canonical_request must be a mapping")
+    canonical_task = canonical.get("task") if isinstance(canonical, Mapping) else None
+    resolved = extra.get(_MINIMAX_H3_RESOLVED_PLAN_EXTRA_KEY)
+    resolved_task = getattr(resolved, "task", None) if resolved is not None else None
+    if canonical_task is not None and resolved_task is not None:
+        if str(canonical_task) != str(resolved_task):
+            raise ValueError(
+                "MiniMax H3 decoder task mismatch between canonical request and "
+                "resolved plan"
+            )
+    task_value = resolved_task if resolved_task is not None else canonical_task
+    if task_value is None:
+        return None
+    if not isinstance(task_value, str) or task_value not in _MINIMAX_H3_DECODER_TASKS:
+        raise ValueError(f"unsupported MiniMax H3 decoder task {task_value!r}")
+    return task_value
+
+
+class MiniMaxH3DecodingStage(DecodingStage):
+    def __init__(self, video_vae, audio_vae) -> None:
+        super().__init__(vae=video_vae, component_name="video_vae")
+        self.video_vae = video_vae
+        self.audio_vae = audio_vae
+        self._compiled_audio_vae_decode = ActiveTargetCompiledCallable()
+
+    @property
+    def role_affinity(self) -> RoleType:
+        return RoleType.DECODER
+
+    @property
+    def parallelism_type(self) -> StageParallelismType:
+        # Every decode-group rank owns a subset of visual VAE tiles. The GPU
+        # worker only materializes/saves the final OutputBatch on world rank 0.
+        return StageParallelismType.REPLICATED
+
+    def component_uses(
+        self, server_args: ServerArgs, stage_name: str | None = None
+    ) -> list[ComponentUse]:
+        stage_name = self._component_stage_name(stage_name)
+        video_vae_dtype = resolve_precision(
+            server_args, "video_vae", precision_attr="vae_precision"
+        )
+        audio_vae_dtype = resolve_precision(
+            server_args, "audio_vae", precision_attr="audio_vae_precision"
+        )
+        uses = [
+            ComponentUse(stage_name, "video_vae", target_dtype=video_vae_dtype),
+        ]
+        uses.append(ComponentUse(stage_name, "audio_vae", target_dtype=audio_vae_dtype))
+        return uses
+
+    def verify_input(self, batch: Req, server_args: ServerArgs) -> VerificationResult:
+        result = VerificationResult()
+        result.add_check("latents", batch.latents, [V.is_tensor, V.with_dims(5)])
+        result.add_check(
+            "audio_latents",
+            batch.audio_latents,
+            [V.is_tensor, V.with_dims(3)],
+        )
+        return result
+
+    def verify_output(
+        self, batch: OutputBatch, server_args: ServerArgs
+    ) -> VerificationResult:
+        result = VerificationResult()
+        result.add_check("output", batch.output, [V.is_tensor, V.with_dims(5)])
+        result.add_check("audio", batch.audio, [V.is_tensor, V.with_dims(3)])
+        result.add_check("audio_sample_rate", batch.audio_sample_rate, V.positive_int)
+        return result
+
+    def _decode_audio(
+        self,
+        audio_latent: torch.Tensor,
+        server_args: ServerArgs,
+    ) -> dict:
+        with self.use_declared_component(
+            component_name="audio_vae",
+            module=self.audio_vae,
+        ) as audio_vae:
+            assert audio_vae is not None
+            self.audio_vae = audio_vae
+            if audio_vae.training:
+                audio_vae.eval()
+            audio_arch_config = server_args.pipeline_config.audio_vae_config.arch_config
+            audio_decode_latent = _reverse_normalize_latents_(
+                audio_latent,
+                mean_values=audio_arch_config.latents_mean,
+                std_values=audio_arch_config.latents_std,
+                name="audio_vae",
+            )
+            audio_vae_dtype = resolve_precision(
+                server_args, "audio_vae", precision_attr="audio_vae_precision"
+            )
+            audio_autocast_enabled = (
+                audio_latent.device.type == "cuda"
+                and autocast_enabled(audio_vae_dtype, server_args.disable_autocast)
+            )
+            with torch.autocast(
+                device_type=audio_latent.device.type,
+                dtype=audio_vae_dtype,
+                enabled=audio_autocast_enabled,
+            ):
+                audio_decode = self._get_vae_decode_fn(
+                    audio_vae,
+                    server_args,
+                    decode_fn=audio_vae.decode,
+                    compiled_callable=self._compiled_audio_vae_decode,
+                )
+                waveform = _required_tensor(
+                    audio_decode(audio_decode_latent), "audio_vae.decode"
+                )
+            return {
+                "waveform": waveform,
+                "sample_rate": int(audio_vae.sample_rate),
+            }
+
+    @torch.no_grad()
+    def forward(self, batch: Req, server_args: ServerArgs) -> OutputBatch:
+        _minimax_h3_decoder_task(batch)
+        visual_latent = _required_tensor(batch.latents, "batch.latents")
+        audio_latent = _required_tensor(batch.audio_latents, "batch.audio_latents")
+        if visual_latent.ndim != 5:
+            raise ValueError("batch.latents must be [B, C, T, H, W]")
+        if audio_latent.ndim != 3:
+            raise ValueError(
+                "batch.audio_latents must be [audio_channel, latent_dim, T]"
+            )
+
+        if self.video_vae is None:
+            raise RuntimeError("MiniMax H3 tasks require the video_vae output decoder")
+        with self.use_declared_component(
+            component_name="video_vae",
+            module=self.video_vae,
+        ) as selected_video_vae:
+            if selected_video_vae is None:
+                raise RuntimeError("video_vae became unavailable during decode")
+            self.video_vae = selected_video_vae
+            if selected_video_vae.training:
+                selected_video_vae.eval()
+            visual_arch_config = server_args.pipeline_config.vae_config.arch_config
+            visual_decode_latent = _reverse_normalize_latents_(
+                visual_latent,
+                mean_values=visual_arch_config.latents_mean,
+                std_values=visual_arch_config.latents_std,
+                name="video_vae",
+            )
+            video_vae_dtype = resolve_decode_precision(server_args, "video_vae")
+            visual_autocast_enabled = (
+                visual_latent.device.type == "cuda"
+                and autocast_enabled(video_vae_dtype, server_args.disable_autocast)
+            )
+            with (
+                _full_video_vae_residency(selected_video_vae),
+                _bounded_video_vae_tile_batch(selected_video_vae),
+            ):
+                if visual_autocast_enabled:
+                    selected_video_vae.prepare_decoder_autocast_weights(
+                        video_vae_dtype
+                    )
+                with torch.autocast(
+                    device_type=visual_latent.device.type,
+                    dtype=video_vae_dtype,
+                    enabled=visual_autocast_enabled,
+                ):
+                    use_compiled_decode = not _env_flag(
+                        "H3_FULL_VAE_AFTER_DENOISE"
+                    ) or _env_flag("H3_FULL_VAE_TORCH_COMPILE")
+                    if use_compiled_decode:
+                        video_decode = self._get_vae_decode_fn(
+                            selected_video_vae,
+                            server_args,
+                            decode_fn=selected_video_vae.decode_base,
+                        )
+                    else:
+                        video_decode = selected_video_vae.decode_base
+                    visual_frames = video_decode(visual_decode_latent)
+                visual_frames = selected_video_vae.processor.revert_tensor(
+                    visual_frames
+                )
+                visual_frames = _required_tensor(
+                    visual_frames,
+                    "video_vae.processor.revert_tensor",
+                )
+                visual_frames = _canonical_visual_video_frames(
+                    visual_frames, batch_size=int(visual_latent.shape[0])
+                )
+                visual_frames = _crop_to_target_canvas(batch, visual_frames)
+                if (
+                    visual_frames.dtype != torch.float32
+                    or not visual_frames.is_contiguous()
+                ):
+                    canonical_frames = torch.empty_like(
+                        visual_frames,
+                        dtype=torch.float32,
+                        memory_format=torch.contiguous_format,
+                    )
+                    canonical_frames.copy_(visual_frames)
+                    visual_frames = canonical_frames
+
+        # DP is currently rejected by ServerArgs validation, so the world group
+        # is one request replica (TP/CFG/SP ranks), not a collection of
+        # independent requests. Decode the non-sharded audio VAE once per
+        # request and distribute its output to the ranks that decoded video.
+        world_group = get_world_group() if model_parallel_is_initialized() else None
+        is_audio_owner = world_group is None or world_group.rank_in_group == 0
+        owner_exception = None
+        owner_error = None
+        audio_payload = None
+        if is_audio_owner:
+            try:
+                audio_payload = self._decode_audio(audio_latent, server_args)
+            except Exception as exc:
+                owner_exception = exc
+                owner_error = f"{type(exc).__name__}: {exc}"
+        if world_group is not None:
+            owner_error = world_group.broadcast_object(owner_error, src=0)
+        if owner_error is not None:
+            if owner_exception is not None:
+                raise owner_exception
+            raise RuntimeError(
+                f"MiniMax H3 audio decode failed on rank 0: {owner_error}"
+            )
+        if world_group is not None:
+            audio_payload = world_group.broadcast_tensor_dict(audio_payload, src=0)
+        if not isinstance(audio_payload, dict):
+            raise RuntimeError("MiniMax H3 audio decode produced no output payload")
+        audio_waveform = _required_tensor(
+            audio_payload.get("waveform"), "audio_vae.decode"
+        )
+        audio_sample_rate = int(audio_payload["sample_rate"])
+
+        visual_frames = server_args.pipeline_config.post_decoding(
+            visual_frames, server_args
+        )
+        output_audio_waveform = _canonical_output_audio_waveform(
+            audio_waveform, batch_size=int(visual_frames.shape[0])
+        )
+        return OutputBatch(
+            output=visual_frames,
+            audio=output_audio_waveform,
+            audio_sample_rate=audio_sample_rate,
+            trajectory_timesteps=batch.trajectory_timesteps,
+            trajectory_latents=batch.trajectory_latents,
+            rollout_trajectory_data=batch.rollout_trajectory_data,
+            trajectory_decoded=None,
+            metrics=batch.metrics,
+            noise_pred=None,
+        )
+
+
+__all__ = [
+    "MiniMaxH3DecodingStage",
+]

--- a/models/minimax_h3/rtx5090/request.py
+++ b/models/minimax_h3/rtx5090/request.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Run one official-profile MiniMax-H3 T2VA request and download its MP4."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+RUNTIME_ROOT = Path(__file__).resolve().parent
+ROOT = Path(os.getenv("H3_ROOT", str(RUNTIME_ROOT)))
+BASE_URL = os.getenv("H3_SERVER_URL", "http://127.0.0.1:30010")
+STEPS = int(os.getenv("H3_NUM_STEPS", "5"))
+DURATION_SECONDS = int(os.getenv("H3_DURATION_SECONDS", "5"))
+SEED = int(os.getenv("H3_SEED", "1101"))
+OUTPUT_DIR = Path(
+    os.getenv("H3_OUTPUT_DIR", str(ROOT / "outputs" / f"t2va_{STEPS}step_seed{SEED}"))
+)
+PROMPT = os.getenv(
+    "H3_PROMPT",
+    (
+        "At night, while their owner sleeps in a bedroom, three cats march in "
+        "loudly playing tiny brass instruments, then abruptly file out."
+    ),
+)
+
+
+def request_json(method: str, path: str, body: dict[str, Any] | None = None) -> dict:
+    data = None if body is None else json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(
+        f"{BASE_URL}{path}",
+        data=data,
+        method=method,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(request, timeout=3600) as response:
+        return json.load(response)
+
+
+def wait_for_server(timeout_seconds: int = 7200) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    latest_error = "server has not answered"
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(f"{BASE_URL}/health", timeout=5) as response:
+                if response.status == 200:
+                    return
+        except (OSError, urllib.error.URLError) as exc:
+            latest_error = repr(exc)
+        time.sleep(10)
+    raise TimeoutError(f"server did not become healthy: {latest_error}")
+
+
+def poll_video(video_id: str, timeout_seconds: int = 7200) -> dict:
+    deadline = time.monotonic() + timeout_seconds
+    latest: dict = {}
+    while time.monotonic() < deadline:
+        latest = request_json("GET", f"/v1/videos/{video_id}")
+        status = str(latest.get("status", "")).lower()
+        print(f"video_id={video_id} status={status}", flush=True)
+        if status in {"completed", "succeeded"}:
+            return latest
+        if status in {"failed", "cancelled", "canceled"}:
+            raise RuntimeError(json.dumps(latest, ensure_ascii=False, indent=2))
+        time.sleep(5)
+    raise TimeoutError(f"video generation timed out; latest={latest!r}")
+
+
+def download_video(video_id: str, destination: Path) -> None:
+    request = urllib.request.Request(
+        f"{BASE_URL}/v1/videos/{video_id}/content", method="GET"
+    )
+    with urllib.request.urlopen(request, timeout=1200) as response:
+        destination.write_bytes(response.read())
+
+
+def main() -> None:
+    if STEPS <= 0:
+        raise ValueError("H3_NUM_STEPS must be positive")
+    if not 4 <= DURATION_SECONDS <= 15:
+        raise ValueError("H3_DURATION_SECONDS must be in [4, 15]")
+
+    payload = {
+        "model": "MiniMaxAI/MiniMax-H3",
+        "prompt": PROMPT,
+        "seconds": DURATION_SECONDS,
+        "task": "t2va",
+        "conditions": [],
+        "target": {
+            "short_edge": 768,
+            "aspect_ratio": "16:9",
+            "duration_seconds": float(DURATION_SECONDS),
+        },
+        "num_outputs_per_prompt": 1,
+        "num_inference_steps": STEPS,
+        "flow_shift": 12.0,
+        "audio_flow_shift": 3.0,
+        "seed": SEED,
+    }
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    (OUTPUT_DIR / "request.json").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+    )
+    wait_for_server()
+
+    started_at = time.time()
+    started_monotonic = time.monotonic()
+    create_response = request_json("POST", "/v1/videos", payload)
+    (OUTPUT_DIR / "create_response.json").write_text(
+        json.dumps(create_response, ensure_ascii=False, indent=2) + "\n"
+    )
+    video_id = str(create_response["id"])
+    final_status = poll_video(video_id)
+
+    output_path = OUTPUT_DIR / (
+        f"minimax_h3_t2va_1344x768_{DURATION_SECONDS}s_"
+        f"{STEPS}step_seed{SEED}.mp4"
+    )
+    download_video(video_id, output_path)
+    metadata = {
+        "base_url": BASE_URL,
+        "video_id": video_id,
+        "request_started_unix": started_at,
+        "request_finished_unix": time.time(),
+        "request_wall_seconds": time.monotonic() - started_monotonic,
+        "output_path": str(output_path),
+        "output_bytes": output_path.stat().st_size,
+        "final_status": final_status,
+    }
+    (OUTPUT_DIR / "run_metadata.json").write_text(
+        json.dumps(metadata, ensure_ascii=False, indent=2) + "\n"
+    )
+    print(json.dumps(metadata, ensure_ascii=False, indent=2), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/minimax_h3/rtx5090/request_suite.py
+++ b/models/minimax_h3/rtx5090/request_suite.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Run the aligned MiniMax-H3 RTX 5090 review prompt suite."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+RUNTIME_ROOT = Path(__file__).resolve().parent
+OUTPUT_ROOT = Path(os.environ["H3_SUITE_OUTPUT_ROOT"])
+SERVER_URL = os.environ["H3_SERVER_URL"]
+NUM_STEPS = int(os.getenv("H3_NUM_STEPS", "50"))
+DURATION_SECONDS = int(os.getenv("H3_DURATION_SECONDS", "5"))
+
+CASES = [
+    {
+        "slug": "flamenco_dancer",
+        "seed": 1301,
+        "prompt": (
+            "A flamenco dancer spins fast on a wooden stage under a single warm "
+            "spotlight, her red skirt flaring wide, heels striking the boards in "
+            "sharp rapid bursts, a guitar driving underneath and hands clapping on "
+            "the offbeat, camera circling with her."
+        ),
+    },
+    {
+        "slug": "garage_mechanics",
+        "seed": 1302,
+        "prompt": (
+            "Two mechanics in a garage at night lean over an open engine bay. The "
+            "older one wipes his hands and says \"It's not the pump.\" The younger "
+            "one answers \"Then what is it?\" A radio murmurs in the corner, a "
+            "wrench clatters onto the concrete, fluorescent tubes buzz overhead."
+        ),
+    },
+    {
+        "slug": "official_starship",
+        "seed": 0,
+        "prompt": """integrated_multimodal_description: [Shot 1] Cinematic, medium wide shot, pushing in slowly. In the cavernous, dimly lit bridge of a starship, sleek metallic consoles with glowing amber displays flank a massive, curved observation window. A female captain, in her late 40s with an athletic build and short silver-streaked black hair, stands in the center midground. She wears a structured, high-collared dark navy military tunic with silver chest insignias. Her back is to the camera, silhouetted against the cool, ambient starlight pouring through the thick glass. She stands perfectly still with her hands clasped tightly behind her back. Outside the window, a massive armada of jagged, dark grey dreadnoughts hovers in tight formation against a deep purple space nebula. The fleet's massive rear thrusters begin to glow with an intense, escalating bright blue light. [Shot 2] At 00:04.500, the camera cuts to a close-up of the captain's face and shakes strongly. The brilliant blue-white light from the fleet's gathering energy reflects vividly in her dark eyes. Suddenly, a blinding white flash floods through the window, completely washing out the background as the fleet jumps to hyperspace. The sheer spatial force violently jolts the bridge, causing the captain from Shot 1 to stagger slightly forward, her shoulders tensing as she visibly braces herself against the physical tremors. As the intense white light fades abruptly, leaving only the dim, empty expanse of the purple nebula reflected on her starkly lit skin, her jaw clenches, and she slowly closes her eyes in the newly emptied space.
+overall_soundscape: A low, resonant hum of the ship's ambient life support systems serves as the baseline, soon drowned out by an audible, escalating, high-pitched electronic whine as the fleet outside charges its hyperdrives. A massive, deafening, bass-heavy boom and sharp crackle erupts during the blinding flash, accompanied by the loud metallic creaking, rattling, and deep thuds of the bridge's bulkheads vibrating under immense physical stress. The intense roaring impact then cuts abruptly back to a hollow, echoing room tone, leaving only the faint, steady hum of the isolated bridge.
+non_diegetic_music: Cinematic space-opera orchestral score, slow tempo, featuring a solitary, mournful French horn melody over deep, sustained string dissonances that build rapidly in volume and intensity, swelling to a massive orchestral peak before snapping immediately into silence right after the jump.""",
+    },
+]
+
+
+def main() -> None:
+    OUTPUT_ROOT.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "server_url": SERVER_URL,
+        "num_steps": NUM_STEPS,
+        "duration_seconds": DURATION_SECONDS,
+        "cases": CASES,
+    }
+    (OUTPUT_ROOT / "suite_manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n"
+    )
+
+    for case in CASES:
+        case_dir = OUTPUT_ROOT / case["slug"]
+        env = os.environ.copy()
+        env.update(
+            {
+                "H3_SERVER_URL": SERVER_URL,
+                "H3_NUM_STEPS": str(NUM_STEPS),
+                "H3_DURATION_SECONDS": str(DURATION_SECONDS),
+                "H3_SEED": str(case["seed"]),
+                "H3_PROMPT": case["prompt"],
+                "H3_OUTPUT_DIR": str(case_dir),
+            }
+        )
+        with (OUTPUT_ROOT / f"{case['slug']}.log").open("w") as log:
+            subprocess.run(
+                [
+                    os.getenv("PYTHON_BIN", "python3"),
+                    str(RUNTIME_ROOT / "request.py"),
+                ],
+                env=env,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                check=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/models/minimax_h3/rtx5090/results/bf16_5090_20260805.json
+++ b/models/minimax_h3/rtx5090/results/bf16_5090_20260805.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "workload": {
+    "task": "t2va",
+    "width": 1344,
+    "height": 768,
+    "frames": 124,
+    "fps": 24,
+    "duration_seconds": 5,
+    "steps": 50,
+    "dtype": "bfloat16",
+    "gpu_count": 1
+  },
+  "single_case": {
+    "seed": 1101,
+    "dense": {
+      "inference_time_s": 1045.409,
+      "denoise_time_s": 951.472,
+      "decode_time_s": 91.423,
+      "client_wall_s": 1050.356,
+      "peak_memory_mb": 16558
+    },
+    "sol": {
+      "inference_time_s": 781.783,
+      "denoise_time_s": 688.167,
+      "decode_time_s": 91.281,
+      "client_wall_s": 785.280,
+      "peak_memory_mb": 16574
+    },
+    "sol_speedup_e2e": 1.3372
+  },
+  "aligned_three_prompt_suite": [
+    {
+      "case": "flamenco_dancer",
+      "seed": 1301,
+      "dense_inference_time_s": 1047.7912,
+      "dense_peak_memory_mb": 16584,
+      "fullopt_inference_time_s": 271.1285,
+      "fullopt_peak_memory_mb": 22388
+    },
+    {
+      "case": "garage_mechanics",
+      "seed": 1302,
+      "dense_inference_time_s": 1051.1344,
+      "dense_peak_memory_mb": 16568,
+      "fullopt_inference_time_s": 237.6223,
+      "fullopt_peak_memory_mb": 22380
+    },
+    {
+      "case": "official_starship",
+      "seed": 0,
+      "dense_inference_time_s": 1066.3769,
+      "dense_peak_memory_mb": 17132,
+      "fullopt_inference_time_s": 243.8952,
+      "fullopt_peak_memory_mb": 22390
+    }
+  ],
+  "suite_mean": {
+    "dense_inference_time_s": 1055.1008,
+    "dense_peak_memory_mb": 16761.3,
+    "fullopt_inference_time_s": 250.8820,
+    "fullopt_peak_memory_mb": 22386.0,
+    "fullopt_speedup_e2e": 4.2056
+  },
+  "timing_source": "SGLang video API final_status.inference_time_s",
+  "memory_source": "SGLang video API final_status.peak_memory_mb"
+}

--- a/models/minimax_h3/rtx5090/scripts/launch_server.sh
+++ b/models/minimax_h3/rtx5090/scripts/launch_server.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNTIME_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${RUNTIME_ROOT}/../../.." && pwd)"
+
+H3_ROOT="${H3_ROOT:-${HOME}/minimax_h3_5090}"
+SGLANG_ROOT="${H3_SGLANG_ROOT:-${H3_ROOT}/sglang}"
+MODEL_PATH="${H3_MODEL_PATH:-${H3_ROOT}/model/FL2VA}"
+PROFILE="${H3_RTX5090_PROFILE:-dense}"
+PORT="${H3_PORT:-30010}"
+MASTER_PORT="${H3_MASTER_PORT:-30005}"
+VENV_ROOT="${H3_VENV_ROOT:-${H3_ROOT}/.venv}"
+SGLANG_BIN="${H3_SGLANG_BIN:-${VENV_ROOT}/bin/sglang}"
+
+UPSTREAM_H3="${SGLANG_ROOT}/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py"
+UPSTREAM_DENOISING="${SGLANG_ROOT}/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py"
+UPSTREAM_DECODING="${SGLANG_ROOT}/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/decoding.py"
+EXPECTED_H3_SHA256="5f87319969c446685ee93d422fc34a7c040defb238eff2274d664f2f8310e997"
+EXPECTED_DENOISING_SHA256="2325b039c055d2db8c320a00f65e2880816888fd5fa107b72cfd6a85be104399"
+EXPECTED_DECODING_SHA256="5e2cf87da11e0c744d6c7703d8151abd7da7937e1ad67d576fdbf6c678380954"
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+verify_source() {
+  local path="$1"
+  local expected="$2"
+  local label="$3"
+  local actual
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing ${label}: ${path}" >&2
+    exit 2
+  fi
+  actual="$(sha256_file "${path}")"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "Refusing to patch unexpected ${label}: ${actual}" >&2
+    exit 2
+  fi
+}
+
+if [[ ! -x "${SGLANG_BIN}" ]]; then
+  echo "SGLang executable is not available: ${SGLANG_BIN}" >&2
+  exit 2
+fi
+if [[ ! -d "${MODEL_PATH}" ]]; then
+  echo "MiniMax-H3 FL2VA model directory is not available: ${MODEL_PATH}" >&2
+  exit 2
+fi
+
+verify_source "${UPSTREAM_H3}" "${EXPECTED_H3_SHA256}" "MiniMax-H3 DiT source"
+
+compile="false"
+regional_compile="false"
+server_warmup="false"
+patch_denoising=0
+patch_decoding=0
+case "${PROFILE}" in
+  dense)
+    export H3_TEACACHE_ENABLED=0
+    export H3_FULL_VAE_AFTER_DENOISE=0
+    ;;
+  sol)
+    export H3_TEACACHE_ENABLED=0
+    export H3_FULL_VAE_AFTER_DENOISE=0
+    ;;
+  fullopt)
+    verify_source \
+      "${UPSTREAM_DENOISING}" \
+      "${EXPECTED_DENOISING_SHA256}" \
+      "SGLang denoising source"
+    verify_source \
+      "${UPSTREAM_DECODING}" \
+      "${EXPECTED_DECODING_SHA256}" \
+      "MiniMax-H3 decoding source"
+    compile="${H3_FULL_OPT_COMPILE:-true}"
+    regional_compile="${H3_FULL_OPT_REGIONAL_COMPILE:-true}"
+    server_warmup="${H3_SERVER_WARMUP:-true}"
+    patch_denoising=1
+    patch_decoding=1
+    export H3_TEACACHE_ENABLED="${H3_TEACACHE_ENABLED:-1}"
+    export H3_FULL_VAE_AFTER_DENOISE="${H3_FULL_VAE_AFTER_DENOISE:-1}"
+    ;;
+  *)
+    echo "H3_RTX5090_PROFILE must be dense, sol, or fullopt" >&2
+    exit 2
+    ;;
+esac
+
+python_root="${SGLANG_ROOT}/python"
+if [[ "${PROFILE}" != "dense" ]]; then
+  patched_h3_sha="$(sha256_file "${RUNTIME_ROOT}/patches/minimax_h3.py")"
+  overlay_key="${patched_h3_sha:0:12}"
+  if [[ "${patch_denoising}" == "1" ]]; then
+    patched_denoising_sha="$(sha256_file "${RUNTIME_ROOT}/patches/denoising.py")"
+    overlay_key="${overlay_key}-${patched_denoising_sha:0:12}"
+  fi
+  if [[ "${patch_decoding}" == "1" ]]; then
+    patched_decoding_sha="$(sha256_file "${RUNTIME_ROOT}/patches/minimax_h3_decoding.py")"
+    overlay_key="${overlay_key}-${patched_decoding_sha:0:12}"
+  fi
+  overlay="${H3_OVERLAY_ROOT:-${H3_ROOT}/cache/overlays}/sglang-h3-${PROFILE}-${overlay_key}"
+  if [[ ! -s "${overlay}/.ready" ]]; then
+    if [[ -e "${overlay}" ]]; then
+      echo "Incomplete source overlay already exists: ${overlay}" >&2
+      exit 2
+    fi
+    mkdir -p "${overlay}"
+    cp -a "${SGLANG_ROOT}/python/sglang" "${overlay}/"
+    install -m 0644 \
+      "${RUNTIME_ROOT}/patches/minimax_h3.py" \
+      "${overlay}/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py"
+    if [[ "${patch_denoising}" == "1" ]]; then
+      install -m 0644 \
+        "${RUNTIME_ROOT}/patches/denoising.py" \
+        "${overlay}/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py"
+    fi
+    if [[ "${patch_decoding}" == "1" ]]; then
+      install -m 0644 \
+        "${RUNTIME_ROOT}/patches/minimax_h3_decoding.py" \
+        "${overlay}/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/decoding.py"
+    fi
+    printf '%s\n' "${overlay_key}" >"${overlay}/.ready"
+  fi
+  python_root="${overlay}"
+fi
+
+mkdir -p "${H3_ROOT}/cache/huggingface" "${H3_ROOT}/cache/xdg"
+mkdir -p "${H3_ROOT}/cache/triton" "${H3_ROOT}/cache/torchinductor-sm120"
+
+export OMP_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export NUMEXPR_NUM_THREADS=1
+export TOKENIZERS_PARALLELISM=false
+export PYTHONUNBUFFERED=1
+export PATH="${VENV_ROOT}/bin:${PATH}"
+export PYTHONPATH="${python_root}:${RUNTIME_ROOT}:${REPO_ROOT}/techniques/sparse_backends${PYTHONPATH:+:${PYTHONPATH}}"
+export HF_HOME="${HF_HOME:-${H3_ROOT}/cache/huggingface}"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-${H3_ROOT}/cache/xdg}"
+export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-${H3_ROOT}/cache/triton}"
+export TORCHINDUCTOR_CACHE_DIR="${TORCHINDUCTOR_CACHE_DIR:-${H3_ROOT}/cache/torchinductor-sm120}"
+export SGLANG_USE_RUNAI_MODEL_STREAMER=false
+
+export H3_TEACACHE_THRESHOLD="${H3_TEACACHE_THRESHOLD:-0.10}"
+export H3_TEACACHE_RETAIN_STEPS="${H3_TEACACHE_RETAIN_STEPS:-5}"
+export H3_TEACACHE_COOLDOWN_STEPS="${H3_TEACACHE_COOLDOWN_STEPS:-1}"
+export H3_TEACACHE_NUM_FORWARDS="${H3_TEACACHE_NUM_FORWARDS:-49}"
+export H3_TEACACHE_COEFFICIENTS="${H3_TEACACHE_COEFFICIENTS:-1.0,0.0}"
+export H3_FULL_VAE_TORCH_COMPILE="${H3_FULL_VAE_TORCH_COMPILE:-0}"
+export H3_FULL_VAE_DTYPE="${H3_FULL_VAE_DTYPE:-bfloat16}"
+export H3_FULL_VAE_TILE_BATCH_SIZE="${H3_FULL_VAE_TILE_BATCH_SIZE:-0}"
+
+export SOL_ATTN_STRICT=1
+export SOL_ATTN_TAU="${SOL_ATTN_TAU:-1.0}"
+export SOL_ATTN_THRESH_TYPE="${SOL_ATTN_THRESH_TYPE:-diag}"
+export SOL_ATTN_FIRST_DENSE_STEPS="${SOL_ATTN_FIRST_DENSE_STEPS:-10}"
+export SOL_ATTN_FIRST_DENSE_LAYER_RATIO="${SOL_ATTN_FIRST_DENSE_LAYER_RATIO:-0.03}"
+export SOL_ATTN_FIRST_DENSE_LAYERS="${SOL_ATTN_FIRST_DENSE_LAYERS:-2}"
+export SOL_ATTN_CORRECTNESS_GATE="${SOL_ATTN_CORRECTNESS_GATE:-1}"
+export SOL_ATTN_FORCE_DENSE=0
+
+exec "${SGLANG_BIN}" serve \
+  --model-path "${MODEL_PATH}" \
+  --model-subfolder . \
+  --num-gpus 1 \
+  --tp-size 1 \
+  --ulysses-degree 1 \
+  --performance-mode memory \
+  --layerwise-offload-components dit,text_encoder,vae \
+  --dit-offload-prefetch-size "${H3_DIT_OFFLOAD_PREFETCH_SIZE:-1}" \
+  --dit-layerwise-resident-layers "${H3_DIT_RESIDENT_LAYERS:-0}" \
+  --pin-cpu-memory false \
+  --enable-torch-compile "${compile}" \
+  --regional-compile "${regional_compile}" \
+  --server-warmup "${server_warmup}" \
+  --master-port "${MASTER_PORT}" \
+  --host 127.0.0.1 \
+  --port "${PORT}"

--- a/models/minimax_h3/rtx5090/scripts/run_minimax_h3_gpu.sh
+++ b/models/minimax_h3/rtx5090/scripts/run_minimax_h3_gpu.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNTIME_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PROFILE="${H3_RTX5090_PROFILE:-dense}"
+H3_ROOT="${H3_ROOT:-${HOME}/minimax_h3_5090}"
+VENV_ROOT="${H3_VENV_ROOT:-${H3_ROOT}/.venv}"
+PYTHON_BIN="${PYTHON_BIN:-${VENV_ROOT}/bin/python}"
+PORT="${H3_PORT:-30010}"
+GPU="${H3_CUDA_VISIBLE_DEVICES:-0}"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT_DIR="${OUT_DIR:-${RUNTIME_ROOT}/outputs/${PROFILE}-${STAMP}}"
+MEASURED_STEPS="${H3_MEASURED_NUM_STEPS:-50}"
+
+if [[ "${PROFILE}" == "dense" ]]; then
+  WARMUP_STEPS="${H3_WARMUP_NUM_STEPS:-5}"
+else
+  WARMUP_STEPS="${H3_WARMUP_NUM_STEPS:-50}"
+fi
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+  echo "Python executable is not available: ${PYTHON_BIN}" >&2
+  exit 2
+fi
+
+mkdir -p "${OUT_DIR}/warmup" "${OUT_DIR}/measured"
+server_pid=""
+monitor_pid=""
+
+stop_scoped_processes() {
+  if [[ -n "${monitor_pid}" ]] && kill -0 "${monitor_pid}" 2>/dev/null; then
+    kill -TERM "${monitor_pid}" 2>/dev/null || true
+    wait "${monitor_pid}" 2>/dev/null || true
+  fi
+  if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill -TERM -- "-${server_pid}" 2>/dev/null || true
+    for _ in $(seq 1 60); do
+      if ! kill -0 "${server_pid}" 2>/dev/null; then
+        break
+      fi
+      sleep 1
+    done
+    if kill -0 "${server_pid}" 2>/dev/null; then
+      kill -KILL -- "-${server_pid}" 2>/dev/null || true
+    fi
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+}
+trap stop_scoped_processes EXIT TERM INT
+
+export CUDA_VISIBLE_DEVICES="${GPU}"
+export H3_PORT="${PORT}"
+export SOL_ATTN_EVENT_LOG="${OUT_DIR}/sol_events_rank0.jsonl"
+export SOL_ATTN_REQUEST_EPOCH_FILE="${OUT_DIR}/request_epoch.txt"
+
+setsid bash "${SCRIPT_DIR}/launch_server.sh" >"${OUT_DIR}/server.log" 2>&1 &
+server_pid=$!
+printf '%s\n' "${server_pid}" >"${OUT_DIR}/server.pid"
+
+(
+  while kill -0 "${server_pid}" 2>/dev/null; do
+    printf '%s,' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    nvidia-smi -i "${GPU}" \
+      --query-gpu=memory.used,memory.total,utilization.gpu,power.draw \
+      --format=csv,noheader,nounits
+    sleep 1
+  done
+) >"${OUT_DIR}/resources.csv" 2>&1 &
+monitor_pid=$!
+
+healthy=0
+for _ in $(seq 1 1440); do
+  if curl -fsS "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+    healthy=1
+    break
+  fi
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    echo "${PROFILE} server exited during startup" >&2
+    tail -200 "${OUT_DIR}/server.log" >&2 || true
+    exit 1
+  fi
+  sleep 5
+done
+if [[ "${healthy}" != "1" ]]; then
+  echo "${PROFILE} server did not become healthy" >&2
+  exit 1
+fi
+
+printf 'warmup-%s\n' "${STAMP}" >"${SOL_ATTN_REQUEST_EPOCH_FILE}"
+H3_SERVER_URL="http://127.0.0.1:${PORT}" \
+H3_ROOT="${H3_ROOT}" \
+H3_NUM_STEPS="${WARMUP_STEPS}" \
+H3_DURATION_SECONDS="${H3_DURATION_SECONDS:-5}" \
+H3_SEED="${H3_WARMUP_SEED:-1100}" \
+H3_OUTPUT_DIR="${OUT_DIR}/warmup" \
+  "${PYTHON_BIN}" "${RUNTIME_ROOT}/request.py" \
+  >"${OUT_DIR}/warmup_request.log" 2>&1
+
+printf 'measured-%s\n' "${STAMP}" >"${SOL_ATTN_REQUEST_EPOCH_FILE}"
+H3_SERVER_URL="http://127.0.0.1:${PORT}" \
+H3_ROOT="${H3_ROOT}" \
+H3_NUM_STEPS="${MEASURED_STEPS}" \
+H3_DURATION_SECONDS="${H3_DURATION_SECONDS:-5}" \
+H3_SEED="${H3_SEED:-1101}" \
+H3_OUTPUT_DIR="${OUT_DIR}/measured" \
+  "${PYTHON_BIN}" "${RUNTIME_ROOT}/request.py" \
+  >"${OUT_DIR}/measured_request.log" 2>&1
+
+stop_scoped_processes
+trap - EXIT TERM INT
+"${PYTHON_BIN}" "${RUNTIME_ROOT}/summarize.py" "${OUT_DIR}" \
+  >"${OUT_DIR}/summary.json"
+printf '%s\n' "${OUT_DIR}"

--- a/models/minimax_h3/rtx5090/summarize.py
+++ b/models/minimax_h3/rtx5090/summarize.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Summarize one RTX 5090 MiniMax-H3 run from official API metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _request_summary(path: Path) -> dict[str, Any]:
+    metadata = _load_json(path / "run_metadata.json")
+    status = metadata.get("final_status", {})
+    return {
+        "inference_time_s": status.get("inference_time_s"),
+        "peak_memory_mb": status.get("peak_memory_mb"),
+        "request_wall_seconds": metadata.get("request_wall_seconds"),
+        "video": metadata.get("output_path"),
+    }
+
+
+def _event_summary(path: Path) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "dense_backends": [],
+        "route_density_samples": [],
+        "teacache_generation_summaries": [],
+    }
+    if not path.exists():
+        return result
+    for line in path.read_text(encoding="utf-8").splitlines():
+        event = json.loads(line)
+        kind = event.get("event")
+        if kind == "dense_backend":
+            result["dense_backends"].append(event.get("backend"))
+        elif kind == "route_density":
+            result["route_density_samples"].append(event)
+        elif kind == "teacache_generation_summary":
+            result["teacache_generation_summaries"].append(event)
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("run_root", type=Path)
+    args = parser.parse_args()
+    report = {
+        "run_root": str(args.run_root.resolve()),
+        "requests": {
+            name: _request_summary(args.run_root / name)
+            for name in ("warmup", "measured")
+        },
+        "events": _event_summary(args.run_root / "sol_events_rank0.jsonl"),
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/models/minimax_h3/rtx5090/teacache.py
+++ b/models/minimax_h3/rtx5090/teacache.py
@@ -1,0 +1,231 @@
+"""TeaCache residual reuse for the packed MiniMax-H3 main DiT."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+import torch
+import torch.distributed as dist
+
+from adapter import StepContext, emit_event
+
+
+def _env_int(name: str, default: int) -> int:
+    return int(os.getenv(name, str(default)))
+
+
+def _env_float(name: str, default: float) -> float:
+    return float(os.getenv(name, str(default)))
+
+
+def _coefficients() -> tuple[float, ...]:
+    raw = os.getenv("H3_TEACACHE_COEFFICIENTS", "1.0,0.0")
+    values = tuple(float(value.strip()) for value in raw.split(",") if value.strip())
+    if not values:
+        raise ValueError("H3_TEACACHE_COEFFICIENTS must not be empty")
+    return values
+
+
+def enabled() -> bool:
+    return os.getenv("H3_TEACACHE_ENABLED", "0") == "1"
+
+
+@dataclass(frozen=True)
+class TeaCacheConfig:
+    threshold: float
+    retain_steps: int
+    cooldown_steps: int
+    coefficients: tuple[float, ...]
+
+    @classmethod
+    def from_env(cls) -> "TeaCacheConfig":
+        config = cls(
+            threshold=_env_float("H3_TEACACHE_THRESHOLD", 0.10),
+            retain_steps=_env_int("H3_TEACACHE_RETAIN_STEPS", 5),
+            cooldown_steps=_env_int("H3_TEACACHE_COOLDOWN_STEPS", 1),
+            coefficients=_coefficients(),
+        )
+        if config.threshold <= 0:
+            raise ValueError("H3_TEACACHE_THRESHOLD must be positive")
+        if min(config.retain_steps, config.cooldown_steps) < 0:
+            raise ValueError("MiniMax-H3 TeaCache step counts must be non-negative")
+        return config
+
+
+def _polyval(coefficients: tuple[float, ...], value: float) -> float:
+    result = 0.0
+    for coefficient in coefficients:
+        result = result * value + coefficient
+    return result
+
+
+@torch.no_grad()
+def _relative_l1(current: torch.Tensor, previous: torch.Tensor) -> float:
+    if current.shape != previous.shape:
+        raise ValueError(
+            f"MiniMax-H3 TeaCache probe shape changed: {current.shape} != {previous.shape}"
+        )
+    totals = torch.stack(
+        (
+            (current - previous).abs().sum(dtype=torch.float32),
+            previous.abs().sum(dtype=torch.float32),
+        )
+    )
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(totals, op=dist.ReduceOp.SUM)
+    return float((totals[0] / totals[1].clamp_min(1.0e-8)).cpu().item())
+
+
+class _TeaCacheController:
+    def __init__(self, config: TeaCacheConfig) -> None:
+        self.config = config
+        self.request_epoch: str | None = None
+        self.previous_modulated_input: torch.Tensor | None = None
+        self.residual: torch.Tensor | None = None
+        self.pending_input: torch.Tensor | None = None
+        self.accumulator = 0.0
+        self.calls = 0
+        self.compute = 0
+        self.reuse = 0
+
+    def _emit_summary(self) -> None:
+        if self.request_epoch is None or self.calls == 0:
+            return
+        emit_event(
+            "teacache_generation_summary",
+            request_epoch=self.request_epoch,
+            calls=self.calls,
+            compute=self.compute,
+            reuse=self.reuse,
+            reuse_rate=self.reuse / self.calls,
+            threshold=self.config.threshold,
+            coefficients=self.config.coefficients,
+        )
+
+    def _begin_generation(self, request_epoch: str) -> None:
+        self._emit_summary()
+        self.request_epoch = request_epoch
+        self.previous_modulated_input = None
+        self.residual = None
+        self.pending_input = None
+        self.accumulator = 0.0
+        self.calls = 0
+        self.compute = 0
+        self.reuse = 0
+        emit_event(
+            "teacache_generation_start",
+            request_epoch=request_epoch,
+            threshold=self.config.threshold,
+            retain_steps=self.config.retain_steps,
+            cooldown_steps=self.config.cooldown_steps,
+            coefficients=self.config.coefficients,
+        )
+
+    @torch.no_grad()
+    def before_blocks(
+        self,
+        hidden: torch.Tensor,
+        modulated_input: torch.Tensor,
+        *,
+        context: StepContext,
+    ) -> tuple[torch.Tensor, str]:
+        if self.request_epoch != context.request_epoch:
+            self._begin_generation(context.request_epoch)
+
+        num_forwards = _env_int("H3_TEACACHE_NUM_FORWARDS", 49)
+        step = context.step_index
+        relative_l1: float | None = None
+        rescaled_l1: float | None = None
+        reason = "threshold"
+        must_compute = step < self.config.retain_steps
+        if must_compute:
+            reason = "warmup"
+            self.accumulator = 0.0
+        elif step >= num_forwards - self.config.cooldown_steps:
+            must_compute = True
+            reason = "cooldown"
+            self.accumulator = 0.0
+        elif self.previous_modulated_input is None or self.residual is None:
+            must_compute = True
+            reason = "initialize"
+        else:
+            relative_l1 = _relative_l1(modulated_input, self.previous_modulated_input)
+            rescaled_l1 = _polyval(self.config.coefficients, relative_l1)
+            self.accumulator += rescaled_l1
+            must_compute = self.accumulator >= self.config.threshold
+            if must_compute:
+                self.accumulator = 0.0
+            else:
+                reason = "below_threshold"
+
+        self.previous_modulated_input = modulated_input.detach().clone()
+        self.calls += 1
+        if must_compute:
+            self.compute += 1
+            self.pending_input = hidden.detach().clone()
+            action = "compute"
+        else:
+            self.reuse += 1
+            self.pending_input = None
+            hidden = hidden + self.residual
+            action = "reuse"
+
+        emit_event(
+            "teacache_decision",
+            request_epoch=context.request_epoch,
+            step_index=step,
+            action=action,
+            reason=reason,
+            relative_l1=relative_l1,
+            rescaled_l1=rescaled_l1,
+            accumulator=self.accumulator,
+        )
+        return hidden, action
+
+    @torch.no_grad()
+    def after_blocks(self, hidden: torch.Tensor) -> torch.Tensor:
+        if self.pending_input is None:
+            raise RuntimeError("MiniMax-H3 TeaCache is missing its block input")
+        self.residual = (hidden - self.pending_input).detach()
+        self.pending_input = None
+        return hidden
+
+
+_CONTROLLER: _TeaCacheController | None = None
+_CONFIG: TeaCacheConfig | None = None
+
+
+def _controller() -> _TeaCacheController | None:
+    global _CONFIG, _CONTROLLER
+    if not enabled():
+        return None
+    config = TeaCacheConfig.from_env()
+    if _CONTROLLER is None or config != _CONFIG:
+        _CONFIG = config
+        _CONTROLLER = _TeaCacheController(config)
+    return _CONTROLLER
+
+
+@torch.no_grad()
+def before_blocks(
+    hidden: torch.Tensor,
+    modulated_input: torch.Tensor,
+    *,
+    context: StepContext,
+) -> tuple[torch.Tensor, str | None]:
+    controller = _controller()
+    if controller is None:
+        return hidden, None
+    return controller.before_blocks(hidden, modulated_input, context=context)
+
+
+@torch.no_grad()
+def after_blocks(hidden: torch.Tensor) -> torch.Tensor:
+    controller = _controller()
+    if controller is None:
+        return hidden
+    return controller.after_blocks(hidden)
+
+
+__all__ = ["TeaCacheConfig", "after_blocks", "before_blocks", "enabled"]

--- a/models/minimax_h3/rtx5090/tests/test_full_vae.py
+++ b/models/minimax_h3/rtx5090/tests/test_full_vae.py
@@ -1,0 +1,126 @@
+import os
+from pathlib import Path
+import sys
+import unittest
+from unittest import mock
+
+RUNTIME_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(RUNTIME_ROOT))
+
+from patches import minimax_h3_decoding as decoding  # noqa: E402
+
+
+class _FakeDevice:
+    def synchronize(self):
+        pass
+
+    def empty_cache(self):
+        pass
+
+    def memory_allocated(self):
+        return 0
+
+    def memory_reserved(self):
+        return 0
+
+
+class _FakeVAE:
+    def __init__(self):
+        self.events = []
+        self.tile_calls = []
+
+    def parameters(self):
+        return []
+
+    def to(self, *, dtype):
+        self.events.append(("dtype", dtype))
+        return self
+
+    def disable_offload(self):
+        self.events.append("resident")
+
+    def enable_offload(self):
+        self.events.append("layerwise")
+
+    def _run_tile_tasks(
+        self, tiles, tile_indices, forward_fn, stack_tiling, cls_agg=None
+    ):
+        self.tile_calls.append(list(tile_indices))
+        return [forward_fn(tiles[index]) for index in tile_indices]
+
+
+class MiniMaxH3FullVAETests(unittest.TestCase):
+    def test_restores_layerwise_offload_after_failure(self):
+        vae = _FakeVAE()
+        with (
+            mock.patch.dict(os.environ, {"H3_FULL_VAE_AFTER_DENOISE": "1"}),
+            mock.patch.object(
+                decoding, "is_layerwise_offloaded_module", return_value=True
+            ),
+            mock.patch.object(decoding.torch, "get_device_module", _FakeDevice),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "decode failed"):
+                with decoding._full_video_vae_residency(vae):
+                    self.assertEqual(vae.events, ["resident"])
+                    raise RuntimeError("decode failed")
+
+        self.assertEqual(vae.events, ["resident", "layerwise"])
+
+    def test_disabled_path_is_noop(self):
+        vae = _FakeVAE()
+        with (
+            mock.patch.dict(os.environ, {"H3_FULL_VAE_AFTER_DENOISE": "0"}),
+            mock.patch.object(
+                decoding, "is_layerwise_offloaded_module", return_value=True
+            ),
+        ):
+            with decoding._full_video_vae_residency(vae):
+                pass
+
+        self.assertEqual(vae.events, [])
+
+    def test_resident_dtype_is_applied_before_and_after_materialization(self):
+        vae = _FakeVAE()
+        with (
+            mock.patch.dict(
+                os.environ,
+                {
+                    "H3_FULL_VAE_AFTER_DENOISE": "1",
+                    "H3_FULL_VAE_DTYPE": "bf16",
+                },
+            ),
+            mock.patch.object(
+                decoding, "is_layerwise_offloaded_module", return_value=True
+            ),
+            mock.patch.object(decoding.torch, "get_device_module", _FakeDevice),
+        ):
+            with decoding._full_video_vae_residency(vae):
+                pass
+
+        self.assertEqual(
+            vae.events,
+            [
+                ("dtype", decoding.torch.bfloat16),
+                "resident",
+                ("dtype", decoding.torch.bfloat16),
+                "layerwise",
+            ],
+        )
+
+    def test_tile_batching_preserves_order(self):
+        vae = _FakeVAE()
+        tiles = list(range(8))
+        with mock.patch.dict(
+            os.environ, {"H3_FULL_VAE_TILE_BATCH_SIZE": "3"}
+        ):
+            with decoding._bounded_video_vae_tile_batch(vae):
+                outputs = vae._run_tile_tasks(
+                    tiles, list(range(8)), lambda value: value * 2, True
+                )
+
+        self.assertEqual(outputs, [value * 2 for value in tiles])
+        self.assertEqual(vae.tile_calls, [[0, 1, 2], [3, 4, 5], [6, 7]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/models/minimax_h3/rtx5090/tests/test_teacache.py
+++ b/models/minimax_h3/rtx5090/tests/test_teacache.py
@@ -1,0 +1,87 @@
+import os
+from pathlib import Path
+import sys
+import unittest
+from unittest import mock
+
+import torch
+
+RUNTIME_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(RUNTIME_ROOT))
+
+import adapter  # noqa: E402
+import teacache  # noqa: E402
+
+
+def _context(step: int, epoch: str = "request-0") -> adapter.StepContext:
+    return adapter.StepContext(
+        request_epoch=epoch,
+        request_index=0,
+        step_index=step,
+        total_tokens=64,
+        live_tokens=64,
+        text_start=0,
+        text_tokens=8,
+        cu_seqlens_host=(0, 64),
+        num_layers=50,
+        timestep_max=float(50 - step),
+    )
+
+
+class MiniMaxH3TeaCacheTests(unittest.TestCase):
+    def test_accumulates_modulated_input_l1_and_reuses_residual(self) -> None:
+        controller = teacache._TeaCacheController(
+            teacache.TeaCacheConfig(
+                threshold=0.10,
+                retain_steps=1,
+                cooldown_steps=0,
+                coefficients=(1.0, 0.0),
+            )
+        )
+        with mock.patch.dict(
+            os.environ, {"H3_TEACACHE_NUM_FORWARDS": "6"}
+        ), mock.patch.object(teacache, "emit_event"):
+            hidden, action = controller.before_blocks(
+                torch.zeros(4), torch.ones(4), context=_context(0)
+            )
+            self.assertEqual(action, "compute")
+            controller.after_blocks(hidden + 2.0)
+
+            hidden, action = controller.before_blocks(
+                torch.full((4,), 0.1),
+                torch.full((4,), 1.01),
+                context=_context(1),
+            )
+            self.assertEqual(action, "reuse")
+            torch.testing.assert_close(hidden, torch.full((4,), 2.1))
+
+            _, action = controller.before_blocks(
+                torch.full((4,), 0.2),
+                torch.full((4,), 1.05),
+                context=_context(2),
+            )
+            self.assertEqual(action, "reuse")
+
+            hidden, action = controller.before_blocks(
+                torch.full((4,), 0.3),
+                torch.full((4,), 1.11),
+                context=_context(3),
+            )
+            self.assertEqual(action, "compute")
+            controller.after_blocks(hidden + 3.0)
+
+        self.assertEqual(controller.compute, 2)
+        self.assertEqual(controller.reuse, 2)
+
+    def test_disabled_path_is_identity(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            hidden = torch.randn(2, 3)
+            output, action = teacache.before_blocks(
+                hidden, torch.randn(2, 3), context=_context(0)
+            )
+        self.assertIs(output, hidden)
+        self.assertIsNone(action)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/launch_candidate.py
+++ b/scripts/launch_candidate.py
@@ -301,7 +301,13 @@ def vendored_snapshot_identity(path: Path) -> str | None:
     core_hashes = snapshot.get("core_sha256", {})
     if not isinstance(core_hashes, dict) or not core_hashes:
         raise SystemExit(f"Vendored source snapshot has no core_sha256 entries: {snapshot_path}")
-    source_root = path / "lingbot_src"
+    source_root = (path / str(snapshot.get("source_root", "lingbot_src"))).resolve()
+    try:
+        source_root.relative_to(path.resolve())
+    except ValueError as exc:
+        raise SystemExit(
+            f"Vendored source_root escapes runtime root: {source_root}"
+        ) from exc
     for relative, expected in core_hashes.items():
         source_path = source_root / str(relative)
         if not source_path.is_file():


### PR DESCRIPTION
## Summary

- add a first-class `models/minimax_h3/rtx5090/` hardware runtime beside `gb200/` and `gb10/`
- provide BF16 dense, SM120 Sol-Attn, and full-opt candidate profiles for one RTX 5090
- isolate the verified Sol-Attn text sink, TeaCache, compile/offload fix, and post-denoise BF16 VAE residency in SHA-guarded SGLang overlays
- document the exact environment, policies, measurements, and reproduction commands
- teach the candidate launcher to honor a snapshot-local `source_root`

## Runtime policy

- released MiniMax-H3 FL2VA BF16 weights
- one RTX 5090 with layerwise DiT/text-encoder/VAE offload
- Sol-Attn: tau 1.0, diagonal threshold, first 10 steps and first 2 layers dense, no reorder
- exact text K/V sink plus dense text-query rows
- full-opt: TeaCache 0.10, regional `torch.compile`, and full BF16 video VAE residency after denoising

## Validation

- `bash -n` passed for both launch scripts
- all Python sources passed `compileall`
- all candidate and model TOML files parsed successfully
- dense, Sol-Attn, and full-opt candidate dry-runs generated successfully
- snapshot hashes were verified
- the RTX 5090 runtime contains no alternate checkpoint or quantized-weight loader
- measured aligned three-prompt BF16 full-opt speedup: 4.206x E2E versus dense

## Notes

The runtime is pinned to SGLang commit `6fa3f9df11c8bdbc0e3b4ddc87a3d873343aca72` and fails closed if the patched upstream sources do not match their recorded SHA-256 values.
