### PR TITLE
Add MiniMax-H3 H100 and A100 Sol-Engine runtimes

### DIFF
--- a/candidates/minimax_h3_a100_aggressive.toml
+++ b/candidates/minimax_h3_a100_aggressive.toml
@@ -1,0 +1,47 @@
+id = "minimax_h3_a100_aggressive"
+kind = "optimized"
+purpose = "frontier"
+description = "Aggressive 4x A100 profile: FirstBlockCache plus Triton Sol-Attn."
+model_profile = "minimax_h3"
+inherit_profile_env = false
+submodule = "models/minimax_h3/h100_a100"
+run_script = "scripts/run_minimax_h3_gpu.sh"
+
+[runtime]
+root = "models/minimax_h3/h100_a100"
+python = "python3"
+
+[official_config]
+revision = "bfc8ed0353f5a9733be73e6b2c98ec0948195b86"
+num_gpus = 4
+context_parallel_degree = 4
+
+[env]
+H3_HARDWARE = "a100"
+H3_SOL_PROFILE = "aggressive"
+H3_CONTAINER_RUNTIME = "pyxis"
+H3_CONTAINER_IMAGE = "docker://lmsysorg/sglang:nightly-dev-cu13-20260803-12eadf86"
+H3_MODEL_PATH = "MiniMaxAI/MiniMax-H3"
+H3_PROMPT_FILE = "models/minimax_h3/prompts/t2va_example_1.json"
+H3_WARMUP_NUM_STEPS = "50"
+H3_MEASURED_NUM_STEPS = "50"
+H3_DURATION_SECONDS = "5.166667"
+H3_SEED = "0"
+HF_HUB_OFFLINE = "0"
+
+[slurm]
+account = ""
+partition = ""
+nodes = 1
+gpus_per_node = 4
+cpus_per_task = 48
+mem = "500G"
+time = "04:00:00"
+job_name = "h3-a100-aggressive"
+exclusive = false
+
+[artifacts]
+output_dir = "outputs"
+video = "out.mp4"
+log = "run.log"
+benchmark = "benchmark.json"

--- a/candidates/minimax_h3_a100_balanced.toml
+++ b/candidates/minimax_h3_a100_balanced.toml
@@ -1,0 +1,47 @@
+id = "minimax_h3_a100_balanced"
+kind = "optimized"
+purpose = "delivery"
+description = "Balanced 4x A100 profile: EasyCache plus Triton Sol-Attn."
+model_profile = "minimax_h3"
+inherit_profile_env = false
+submodule = "models/minimax_h3/h100_a100"
+run_script = "scripts/run_minimax_h3_gpu.sh"
+
+[runtime]
+root = "models/minimax_h3/h100_a100"
+python = "python3"
+
+[official_config]
+revision = "bfc8ed0353f5a9733be73e6b2c98ec0948195b86"
+num_gpus = 4
+context_parallel_degree = 4
+
+[env]
+H3_HARDWARE = "a100"
+H3_SOL_PROFILE = "balanced"
+H3_CONTAINER_RUNTIME = "pyxis"
+H3_CONTAINER_IMAGE = "docker://lmsysorg/sglang:nightly-dev-cu13-20260803-12eadf86"
+H3_MODEL_PATH = "MiniMaxAI/MiniMax-H3"
+H3_PROMPT_FILE = "models/minimax_h3/prompts/t2va_example_1.json"
+H3_WARMUP_NUM_STEPS = "50"
+H3_MEASURED_NUM_STEPS = "50"
+H3_DURATION_SECONDS = "5.166667"
+H3_SEED = "0"
+HF_HUB_OFFLINE = "0"
+
+[slurm]
+account = ""
+partition = ""
+nodes = 1
+gpus_per_node = 4
+cpus_per_task = 48
+mem = "500G"
+time = "04:00:00"
+job_name = "h3-a100-balanced"
+exclusive = false
+
+[artifacts]
+output_dir = "outputs"
+video = "out.mp4"
+log = "run.log"
+benchmark = "benchmark.json"

--- a/candidates/minimax_h3_a100_dense.toml
+++ b/candidates/minimax_h3_a100_dense.toml
@@ -1,0 +1,47 @@
+id = "minimax_h3_a100_dense"
+kind = "baseline"
+purpose = "control"
+description = "Official SGLang MiniMax-H3 BF16 dense control on 4x A100 with FSDP and Ulysses-4."
+model_profile = "minimax_h3"
+inherit_profile_env = false
+submodule = "models/minimax_h3/h100_a100"
+run_script = "scripts/run_minimax_h3_gpu.sh"
+
+[runtime]
+root = "models/minimax_h3/h100_a100"
+python = "python3"
+
+[official_config]
+revision = "bfc8ed0353f5a9733be73e6b2c98ec0948195b86"
+num_gpus = 4
+context_parallel_degree = 4
+
+[env]
+H3_HARDWARE = "a100"
+H3_SOL_PROFILE = "dense"
+H3_CONTAINER_RUNTIME = "pyxis"
+H3_CONTAINER_IMAGE = "docker://lmsysorg/sglang:nightly-dev-cu13-20260803-12eadf86"
+H3_MODEL_PATH = "MiniMaxAI/MiniMax-H3"
+H3_PROMPT_FILE = "models/minimax_h3/prompts/t2va_example_1.json"
+H3_WARMUP_NUM_STEPS = "50"
+H3_MEASURED_NUM_STEPS = "50"
+H3_DURATION_SECONDS = "5.166667"
+H3_SEED = "0"
+HF_HUB_OFFLINE = "0"
+
+[slurm]
+account = ""
+partition = ""
+nodes = 1
+gpus_per_node = 4
+cpus_per_task = 48
+mem = "500G"
+time = "04:00:00"
+job_name = "h3-a100-dense"
+exclusive = false
+
+[artifacts]
+output_dir = "outputs"
+video = "out.mp4"
+log = "run.log"
+benchmark = "benchmark.json"

--- a/candidates/minimax_h3_a100_fullopt_exact.toml
+++ b/candidates/minimax_h3_a100_fullopt_exact.toml
@@ -1,0 +1,47 @@
+id = "minimax_h3_a100_fullopt_exact"
+kind = "optimized"
+purpose = "delivery"
+description = "Exact-threshold 4x A100 profile: FirstBlockCache plus Triton Sol-Attn."
+model_profile = "minimax_h3"
+inherit_profile_env = false
+submodule = "models/minimax_h3/h100_a100"
+run_script = "scripts/run_minimax_h3_gpu.sh"
+
+[runtime]
+root = "models/minimax_h3/h100_a100"
+python = "python3"
+
+[official_config]
+revision = "bfc8ed0353f5a9733be73e6b2c98ec0948195b86"
+num_gpus = 4
+context_parallel_degree = 4
+
+[env]
+H3_HARDWARE = "a100"
+H3_SOL_PROFILE = "fullopt_exact"
+H3_CONTAINER_RUNTIME = "pyxis"
+H3_CONTAINER_IMAGE = "docker://lmsysorg/sglang:nightly-dev-cu13-20260803-12eadf86"
+H3_MODEL_PATH = "MiniMaxAI/MiniMax-H3"
+H3_PROMPT_FILE = "models/minimax_h3/prompts/t2va_example_1.json"
+H3_WARMUP_NUM_STEPS = "50"
+H3_MEASURED_NUM_STEPS = "50"
+H3_DURATION_SECONDS = "5.166667"
+H3_SEED = "0"
+HF_HUB_OFFLINE = "0"
+
+[slurm]
+account = ""
+partition = ""
+nodes = 1
+gpus_per_node = 4
+cpus_per_task = 48
+mem = "500G"
+time = "04:00:00"
+job_name = "h3-a100-exact"
+exclusive = false
+
+[artifacts]
+output_dir = "outputs"
+video = "out.mp4"
+log = "run.log"
+benchmark = "benchmark.json"

--- a/candidates/minimax_h3_a100_quality.toml
+++ b/candidates/minimax_h3_a100_quality.toml
@@ -1,0 +1,47 @@
+id = "minimax_h3_a100_quality"
+kind = "optimized"
+purpose = "delivery"
+description = "Quality-first 4x A100 profile: conservative EasyCache plus Triton Sol-Attn."
+model_profile = "minimax_h3"
+inherit_profile_env = false
+submodule = "models/minimax_h3/h100_a100"
+run_script = "scripts/run_minimax_h3_gpu.sh"
+
+[runtime]
+root = "models/minimax_h3/h100_a100"
+python = "python3"
+
+[official_config]
+revision = "bfc8ed0353f5a9733be73e6b2c98ec0948195b86"
+num_gpus = 4
+context_parallel_degree = 4
+
+[env]
+H3_HARDWARE = "a100"
+H3_SOL_PROFILE = "quality"
+H3_CONTAINER_RUNTIME = "pyxis"
+H3_CONTAINER_IMAGE = "docker://lmsysorg/sglang:nightly-dev-cu13-20260803-12eadf86"
+H3_MODEL_PATH = "MiniMaxAI/MiniMax-H3"
+H3_PROMPT_FILE = "models/minimax_h3/prompts/t2va_example_1.json"
+H3_WARMUP_NUM_STEPS = "50"
+H3_MEASURED_NUM_STEPS = "50"
+H3_DURATION_SECONDS = "5.166667"
+H3_SEED = "0"
+HF_HUB_OFFLINE = "0"
+
+[slurm]
+account = ""
+partition = ""
+nodes = 1
+gpus_per_node = 4
+cpus_per_task = 48
+mem = "500G"
+time = "04:00:00"
+job_name = "h3-a100-quality"
+exclusive = false
+
+[artifacts]
+output_dir = "outputs"
+video = "out.mp4"
+log = "run.log"
+benchmark = "benchmark.json"

--- a/candidates/minimax_h3_h100_aggressive.toml
+++ b/candidates/minimax_h3_h100_aggressive.toml
@@ -1,0 +1,47 @@
+id = "minimax_h3_h100_aggressive"
+kind = "optimized"
+purpose = "frontier"
+description = "Aggressive 4x H100 profile: FirstBlockCache plus CuTe-SM90 Sol-Attn."
+model_profile = "minimax_h3"
+inherit_profile_env = false
+submodule = "models/minimax_h3/h100_a100"
+run_script = "scripts/run_minimax_h3_gpu.sh"
+
+[runtime]
+root = "models/minimax_h3/h100_a100"
+python = "python3"
+
+[official_config]
+revision = "bfc8ed0353f5a9733be73e6b2c98ec0948195b86"
+num_gpus = 4
+context_parallel_degree = 4
+
+[env]
+H3_HARDWARE = "h100"
+H3_SOL_PROFILE = "aggressive"
+H3_CONTAINER_RUNTIME = "pyxis"
+H3_CONTAINER_IMAGE = "docker://lmsysorg/sglang:nightly-dev-cu13-20260803-12eadf86"
+H3_MODEL_PATH = "MiniMaxAI/MiniMax-H3"
+H3_PROMPT_FILE = "models/minimax_h3/prompts/t2va_example_1.json"
+H3_WARMUP_NUM_STEPS = "50"
+H3_MEASURED_NUM_STEPS = "50"
+H3_DURATION_SECONDS = "5.166667"
+H3_SEED = "0"
+HF_HUB_OFFLINE = "0"
+
+[slurm]
+account = ""
+partition = ""
+nodes = 1
+gpus_per_node = 4
+cpus_per_task = 64
+mem = "700G"
+time = "02:00:00"
+job_name = "h3-h100-aggressive"
+exclusive = false
+
+[artifacts]
+output_dir = "outputs"
+video = "out.mp4"
+log = "run.log"
+benchmark = "benchmark.json"

--- a/candidates/minimax_h3_h100_balanced.toml
+++ b/candidates/minimax_h3_h100_balanced.toml
@@ -1,0 +1,47 @@
+id = "minimax_h3_h100_balanced"
+kind = "optimized"
+purpose = "delivery"
+description = "Balanced 4x H100 profile: EasyCache plus CuTe-SM90 Sol-Attn."
+model_profile = "minimax_h3"
+inherit_profile_env = false
+submodule = "models/minimax_h3/h100_a100"
+run_script = "scripts/run_minimax_h3_gpu.sh"
+
+[runtime]
+root = "models/minimax_h3/h100_a100"
+python = "python3"
+
+[official_config]
+revision = "bfc8ed0353f5a9733be73e6b2c98ec0948195b86"
+num_gpus = 4
+context_parallel_degree = 4
+
+[env]
+H3_HARDWARE = "h100"
+H3_SOL_PROFILE = "balanced"
+H3_CONTAINER_RUNTIME = "pyxis"
+H3_CONTAINER_IMAGE = "docker://lmsysorg/sglang:nightly-dev-cu13-20260803-12eadf86"
+H3_MODEL_PATH = "MiniMaxAI/MiniMax-H3"
+H3_PROMPT_FILE = "models/minimax_h3/prompts/t2va_example_1.json"
+H3_WARMUP_NUM_STEPS = "50"
+H3_MEASURED_NUM_STEPS = "50"
+H3_DURATION_SECONDS = "5.166667"
+H3_SEED = "0"
+HF_HUB_OFFLINE = "0"
+
+[slurm]
+account = ""
+partition = ""
+nodes = 1
+gpus_per_node = 4
+cpus_per_task = 64
+mem = "700G"
+time = "02:00:00"
+job_name = "h3-h100-balanced"
+exclusive = false
+
+[artifacts]
+output_dir = "outputs"
+video = "out.mp4"
+log = "run.log"
+benchmark = "benchmark.json"

--- a/candidates/minimax_h3_h100_dense.toml
+++ b/candidates/minimax_h3_h100_dense.toml
@@ -1,0 +1,47 @@
+id = "minimax_h3_h100_dense"
+kind = "baseline"
+purpose = "control"
+description = "Official SGLang MiniMax-H3 BF16 dense control on 4x H100 with FSDP and Ulysses-4."
+model_profile = "minimax_h3"
+inherit_profile_env = false
+submodule = "models/minimax_h3/h100_a100"
+run_script = "scripts/run_minimax_h3_gpu.sh"
+
+[runtime]
+root = "models/minimax_h3/h100_a100"
+python = "python3"
+
+[official_config]
+revision = "bfc8ed0353f5a9733be73e6b2c98ec0948195b86"
+num_gpus = 4
+context_parallel_degree = 4
+
+[env]
+H3_HARDWARE = "h100"
+H3_SOL_PROFILE = "dense"
+H3_CONTAINER_RUNTIME = "pyxis"
+H3_CONTAINER_IMAGE = "docker://lmsysorg/sglang:nightly-dev-cu13-20260803-12eadf86"
+H3_MODEL_PATH = "MiniMaxAI/MiniMax-H3"
+H3_PROMPT_FILE = "models/minimax_h3/prompts/t2va_example_1.json"
+H3_WARMUP_NUM_STEPS = "50"
+H3_MEASURED_NUM_STEPS = "50"
+H3_DURATION_SECONDS = "5.166667"
+H3_SEED = "0"
+HF_HUB_OFFLINE = "0"
+
+[slurm]
+account = ""
+partition = ""
+nodes = 1
+gpus_per_node = 4
+cpus_per_task = 64
+mem = "700G"
+time = "02:00:00"
+job_name = "h3-h100-dense"
+exclusive = false
+
+[artifacts]
+output_dir = "outputs"
+video = "out.mp4"
+log = "run.log"
+benchmark = "benchmark.json"

--- a/candidates/minimax_h3_h100_fullopt_exact.toml
+++ b/candidates/minimax_h3_h100_fullopt_exact.toml
@@ -1,0 +1,47 @@
+id = "minimax_h3_h100_fullopt_exact"
+kind = "optimized"
+purpose = "delivery"
+description = "Exact-threshold 4x H100 profile: FirstBlockCache plus CuTe-SM90 Sol-Attn."
+model_profile = "minimax_h3"
+inherit_profile_env = false
+submodule = "models/minimax_h3/h100_a100"
+run_script = "scripts/run_minimax_h3_gpu.sh"
+
+[runtime]
+root = "models/minimax_h3/h100_a100"
+python = "python3"
+
+[official_config]
+revision = "bfc8ed0353f5a9733be73e6b2c98ec0948195b86"
+num_gpus = 4
+context_parallel_degree = 4
+
+[env]
+H3_HARDWARE = "h100"
+H3_SOL_PROFILE = "fullopt_exact"
+H3_CONTAINER_RUNTIME = "pyxis"
+H3_CONTAINER_IMAGE = "docker://lmsysorg/sglang:nightly-dev-cu13-20260803-12eadf86"
+H3_MODEL_PATH = "MiniMaxAI/MiniMax-H3"
+H3_PROMPT_FILE = "models/minimax_h3/prompts/t2va_example_1.json"
+H3_WARMUP_NUM_STEPS = "50"
+H3_MEASURED_NUM_STEPS = "50"
+H3_DURATION_SECONDS = "5.166667"
+H3_SEED = "0"
+HF_HUB_OFFLINE = "0"
+
+[slurm]
+account = ""
+partition = ""
+nodes = 1
+gpus_per_node = 4
+cpus_per_task = 64
+mem = "700G"
+time = "02:00:00"
+job_name = "h3-h100-exact"
+exclusive = false
+
+[artifacts]
+output_dir = "outputs"
+video = "out.mp4"
+log = "run.log"
+benchmark = "benchmark.json"

--- a/candidates/minimax_h3_h100_quality.toml
+++ b/candidates/minimax_h3_h100_quality.toml
@@ -1,0 +1,47 @@
+id = "minimax_h3_h100_quality"
+kind = "optimized"
+purpose = "delivery"
+description = "Quality-first 4x H100 profile: conservative EasyCache plus CuTe-SM90 Sol-Attn."
+model_profile = "minimax_h3"
+inherit_profile_env = false
+submodule = "models/minimax_h3/h100_a100"
+run_script = "scripts/run_minimax_h3_gpu.sh"
+
+[runtime]
+root = "models/minimax_h3/h100_a100"
+python = "python3"
+
+[official_config]
+revision = "bfc8ed0353f5a9733be73e6b2c98ec0948195b86"
+num_gpus = 4
+context_parallel_degree = 4
+
+[env]
+H3_HARDWARE = "h100"
+H3_SOL_PROFILE = "quality"
+H3_CONTAINER_RUNTIME = "pyxis"
+H3_CONTAINER_IMAGE = "docker://lmsysorg/sglang:nightly-dev-cu13-20260803-12eadf86"
+H3_MODEL_PATH = "MiniMaxAI/MiniMax-H3"
+H3_PROMPT_FILE = "models/minimax_h3/prompts/t2va_example_1.json"
+H3_WARMUP_NUM_STEPS = "50"
+H3_MEASURED_NUM_STEPS = "50"
+H3_DURATION_SECONDS = "5.166667"
+H3_SEED = "0"
+HF_HUB_OFFLINE = "0"
+
+[slurm]
+account = ""
+partition = ""
+nodes = 1
+gpus_per_node = 4
+cpus_per_task = 64
+mem = "700G"
+time = "02:00:00"
+job_name = "h3-h100-quality"
+exclusive = false
+
+[artifacts]
+output_dir = "outputs"
+video = "out.mp4"
+log = "run.log"
+benchmark = "benchmark.json"

--- a/candidates/schema.md
+++ b/candidates/schema.md
@@ -60,6 +60,12 @@ NEGATIVE_PROMPT = ""
 it in `metadata.json.runtime_python` and validates it before local or Slurm
 execution. Do not rely on ambient `python3` for GPU or model-runtime checks.
 
+Candidates normally inherit the model profile's environment. Set
+`inherit_profile_env = false` at the top level when a candidate uses an
+independent runtime and must not receive legacy conda, cache, or device paths.
+Candidate `[official_config]` values override individual profile values while
+retaining unspecified workload fields.
+
 ## `purpose`
 
 Supported purposes:

--- a/models/minimax_h3.toml
+++ b/models/minimax_h3.toml
@@ -161,6 +161,38 @@ teacache_threshold = 0.10
 teacache_retain_steps = 5
 teacache_cooldown_steps = 1
 
+[h100_a100]
+variant = "sglang_registered_bf16_4gpu"
+status = "measured_h100_a100"
+runtime_root = "models/minimax_h3/h100_a100"
+run_script = "models/minimax_h3/h100_a100/scripts/run_minimax_h3_gpu.sh"
+candidates = [
+  "candidates/minimax_h3_h100_dense.toml",
+  "candidates/minimax_h3_h100_quality.toml",
+  "candidates/minimax_h3_h100_balanced.toml",
+  "candidates/minimax_h3_h100_aggressive.toml",
+  "candidates/minimax_h3_h100_fullopt_exact.toml",
+  "candidates/minimax_h3_a100_dense.toml",
+  "candidates/minimax_h3_a100_quality.toml",
+  "candidates/minimax_h3_a100_balanced.toml",
+  "candidates/minimax_h3_a100_aggressive.toml",
+  "candidates/minimax_h3_a100_fullopt_exact.toml",
+]
+hardware = "4x H100-80GB (SM90) or 4x A100-80GB (SM80)"
+cell = "1344x768, 124 frames, 5.166667 seconds, 50 steps, BF16 FL2VA"
+timing_scope = "SGLang GenerationResult.metrics.total_duration_s after one full warmup"
+memory_scope = "SGLang GenerationResult.peak_memory_mb"
+source_snapshot = "models/minimax_h3/h100_a100/SOURCE_SNAPSHOT.json"
+note = "The two hardware targets share one registered model and locked algorithm profiles; only the Sol-Attn backend and capability contract differ."
+
+[h100_a100.policy]
+sink = "full multimodal prefix"
+prefix_query_rows = "dense"
+first_dense_layers = 2
+reorder = false
+offload = false
+torch_compile = false
+
 # ============================================================================================
 # Append to models/minimax_h3.toml. A second measured runtime, not a replacement for [baseline]:
 # different hardware, different checkpoint, and a tenth of the canvas, so the two tables are not

--- a/models/minimax_h3/README.md
+++ b/models/minimax_h3/README.md
@@ -21,6 +21,9 @@ measured on:
 - `rtx5090/`: the single-RTX-5090 BF16 runtime. It registers its local model
   and memory-stage extensions with pinned SGLang and runs through the offline
   generator; the SGLang installation remains untouched.
+- `h100_a100/`: the shared four-GPU BF16 SGLang runtime for H100-80GB and
+  A100-80GB. It provides dense plus four locked Sol-Attn/cache profiles through
+  process-local model registration, with hardware-specific Sol-Attn backends.
 
 Do not mix runtime files across these directories. Candidate manifests select
 the matching hardware directory explicitly.

--- a/models/minimax_h3/h100_a100/README.md
+++ b/models/minimax_h3/h100_a100/README.md
@@ -1,0 +1,68 @@
+# MiniMax-H3 on H100 and A100
+
+This runtime runs the released BF16 FL2VA checkpoint at 1344x768, 124 frames,
+50 steps on four H100-80GB or four A100-80GB GPUs. It uses SGLang FSDP
+inference plus Ulysses-4, with no offload and no `torch.compile`.
+
+The implementation follows the registered-runtime layout used by `rtx5090/`:
+`gpu_infer.py` calls SGLang's process-local `DiffGenerator`, `registration.py`
+verifies the pinned upstream source before registering `model.py`, and the
+installed SGLang checkout is never patched or modified.
+
+## Profiles
+
+| Profile | Attention | Cache |
+|---|---|---|
+| `dense` | Official SGLang dense backend | None |
+| `quality` | Sol-Attn, tau 0.5, diag, 15 dense steps | EasyCache 0.30, retain 10, max hit 1 |
+| `balanced` | Sol-Attn, tau 1.0, diag, 10 dense steps | EasyCache 0.30, retain 6, max hit 2 |
+| `aggressive` | Sol-Attn, tau 1.0, diag, 10 dense steps | FirstBlockCache 0.08 |
+| `fullopt_exact` | Sol-Attn, tau 1.0, exact, 10 dense steps | FirstBlockCache 0.08 |
+
+Every sparse profile leaves the first two transformer layers dense. The whole
+multimodal prefix is an exact KV sink, its query rows are recomputed densely,
+and token reordering is disabled. H100 selects `cute_sm90`; A100 selects the
+Triton backend. The profile definitions are locked in `profiles.py` so a
+conflicting environment override fails instead of silently changing a run.
+
+## Environment
+
+The candidate manifests pin:
+
+- `lmsysorg/sglang:nightly-dev-cu13-20260803-12eadf86`
+- PyTorch `2.11.0+cu130`
+- Triton `3.6.0`
+- MiniMax-H3 revision `bfc8ed0353f5a9733be73e6b2c98ec0948195b86`
+
+Set `H3_STORAGE_ROOT` to a shared path containing this checkout. Set
+`H3_MODEL_PATH` to a local MiniMax-H3 root or FL2VA directory for offline
+clusters; otherwise the Hugging Face repository in the manifest is used.
+The runner supports `pyxis`, `singularity`/`apptainer`, and `none`.
+
+## Run
+
+For example, submit the exact H100 profile:
+
+```bash
+python scripts/launch_candidate.py \
+  candidates/minimax_h3_h100_fullopt_exact.toml \
+  --mode sbatch --confirm-submit \
+  --env H3_STORAGE_ROOT=/shared/path/Sana
+```
+
+Replace `h100` with `a100`, and select `dense`, `quality`, `balanced`,
+`aggressive`, or `fullopt_exact`. Site-specific Slurm account and partition are
+intentionally omitted; the generated job uses the site's defaults. Each run
+writes only `out.mp4`, `benchmark.json`, and `run.log` under its output folder.
+`benchmark.json` uses SGLang's own inference time and peak-memory fields and
+also records the selected backend, warmup routing density, and measured cache
+reuse.
+
+## Files
+
+- `model.py`: pinned SGLang MiniMax-H3 model with attention/cache hook points.
+- `adapter.py`: packed-sequence Sol-Attn policy and full-prefix sink.
+- `easycache.py`, `first_block_cache.py`: collective cache controllers.
+- `registration.py`: source verification and process-local model registration.
+- `gpu_infer.py`: warmup plus measured offline generation.
+- `scripts/run_minimax_h3_gpu.sh`: native/container launcher.

--- a/models/minimax_h3/h100_a100/SOURCE_SNAPSHOT.json
+++ b/models/minimax_h3/h100_a100/SOURCE_SNAPSHOT.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "variant": "h100_a100",
+  "source_root": ".",
+  "core_sha256": {
+    "adapter.py": "b68e53f4f92073ba6b299671edfd740e2c7aa8f80c0cad1744df8b03a14d78af",
+    "easycache.py": "13d52e5c53d5000070849e902412295ebab122dceccde6d74fc06de9a674bdb6",
+    "first_block_cache.py": "7a5edc1b160b366f43a592cc62a259850a58ebb01cd7347e48b5a2f168f457e9",
+    "model.py": "4325d6d109e7a06ffc5f1aa01d54afa88bc3447b928b43692e0a1f22d5067cd1",
+    "profiles.py": "848eb1adbd5ea3bf75c3196dc9b7024e3d05235ac4357460fb408d81ccda5e7f",
+    "registration.py": "439ec3a4dbc2015191f762bee30c9954dc30a4e5676d5411ce26082169556f8c",
+    "gpu_infer.py": "15a44a33aff270471849d6eeb84da67552afd8d55b67148d3035e76908ca0bd7",
+    "scripts/run_minimax_h3_gpu.sh": "c3720ae9ca7a1606bc0dc2553adc494ee46a23cdc79ccd2dbfe2d626970b7d85"
+  },
+  "sglang": {
+    "repo": "https://github.com/sgl-project/sglang.git",
+    "commit": "12eadf86f12aec2e6f81a6e38b61b964a4c6b529",
+    "source_sha256": {
+      "runtime/models/dits/minimax_h3.py": "5f87319969c446685ee93d422fc34a7c040defb238eff2274d664f2f8310e997"
+    }
+  },
+  "weights": {
+    "repo": "MiniMaxAI/MiniMax-H3",
+    "revision": "bfc8ed0353f5a9733be73e6b2c98ec0948195b86",
+    "partition": "FL2VA",
+    "dtype": "bfloat16"
+  },
+  "environment": {
+    "container": "docker://lmsysorg/sglang:nightly-dev-cu13-20260803-12eadf86",
+    "torch": "2.11.0+cu130",
+    "triton": "3.6.0"
+  },
+  "hardware": {
+    "h100": {
+      "gpus": 4,
+      "sm": "90",
+      "sol_attn_backend": "cute_sm90"
+    },
+    "a100": {
+      "gpus": 4,
+      "sm": "80",
+      "sol_attn_backend": "triton"
+    }
+  }
+}

--- a/models/minimax_h3/h100_a100/__init__.py
+++ b/models/minimax_h3/h100_a100/__init__.py
@@ -1,0 +1,5 @@
+"""Registered MiniMax-H3 runtime for four H100 or A100 GPUs."""
+
+from .profiles import HARDWARE, PROFILES
+
+__all__ = ["HARDWARE", "PROFILES"]

--- a/models/minimax_h3/h100_a100/adapter.py
+++ b/models/minimax_h3/h100_a100/adapter.py
@@ -1,0 +1,712 @@
+"""Sol-Engine attention adapter for SGLang's packed MiniMax-H3 DiT.
+
+The adapter runs after the Ulysses all-to-all, where each rank owns all packed
+tokens for a disjoint set of heads. MiniMax-H3 packs one live document as
+``[text | references | target audio | target video]`` followed by padding.
+Everything before the target-video suffix is therefore one exact KV sink; its
+query rows are recomputed densely, as required for multimodal joint attention.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import math
+import os
+from pathlib import Path
+import re
+from typing import Any, Iterable
+
+import torch
+import torch.nn.functional as F
+
+
+_LAYER_PATTERN = re.compile(r"(?:^|\.)blocks\.(\d+)\.attn$")
+_LOG_PREFIX = "MINIMAX_H3_SOL_ENGINE "
+_SPARSE_POLICIES = {
+    "quality": (0.5, "diag", 15, 2),
+    "balanced": (1.0, "diag", 10, 2),
+    "aggressive": (1.0, "diag", 10, 2),
+    "fullopt_exact": (1.0, "exact", 10, 2),
+}
+
+
+@dataclass(frozen=True)
+class StepContext:
+    request_epoch: str
+    request_index: int
+    step_index: int
+    total_tokens: int
+    live_tokens: int
+    target_video_start: int
+    prefix_tokens: int
+    cu_seqlens_host: tuple[int, ...]
+    num_layers: int
+    timestep_max: float | None
+
+
+@dataclass
+class _RuntimeState:
+    context: StepContext | None = None
+    request_index: int = -1
+    previous_epoch: str | None = None
+    previous_timestep: float | None = None
+    timestep_direction: int = 0
+    dense_backend_logged: bool = False
+    backend_logged: bool = False
+    gated_shapes: set[tuple[int, int, int]] = field(default_factory=set)
+    density_logged: set[tuple[int, int, int, int]] = field(default_factory=set)
+    sparse_logged: set[tuple[int, int, int, int]] = field(default_factory=set)
+    layout_signature: tuple[Any, ...] | None = None
+    layout: tuple[
+        tuple[int, ...],
+        tuple[int, ...],
+        tuple[int, ...],
+        int,
+        int,
+    ] | None = None
+
+
+_STATE = _RuntimeState()
+
+
+def enabled() -> bool:
+    return (
+        os.getenv("H3_SOL_ATTN", "0") == "1"
+        or os.getenv("H3_FIRSTBLOCKCACHE", "0") == "1"
+        or os.getenv("H3_EASYCACHE", "0") == "1"
+    )
+
+
+def parse_layer_index(prefix: str) -> int | None:
+    if "token_refiner" in prefix:
+        return None
+    match = _LAYER_PATTERN.search(prefix)
+    return None if match is None else int(match.group(1))
+
+
+def _rank() -> int:
+    return int(os.getenv("RANK", os.getenv("LOCAL_RANK", "0")))
+
+
+def emit_event(event: str, **payload: Any) -> None:
+    record = {"event": event, "rank": _rank(), **payload}
+    line = json.dumps(record, sort_keys=True)
+    print(_LOG_PREFIX + line, flush=True)
+    path_template = os.getenv("H3_SOL_EVENT_LOG")
+    if path_template:
+        path = Path(path_template.format(rank=_rank()))
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+
+
+def _host_positions(values: torch.Tensor | Iterable[int]) -> tuple[int, ...]:
+    if torch.is_tensor(values):
+        values = values.detach().reshape(-1).to(device="cpu").tolist()
+    return tuple(int(value) for value in values if int(value) >= 0)
+
+
+def _position_identity(values: torch.Tensor | Iterable[int]) -> tuple[Any, ...]:
+    if torch.is_tensor(values):
+        return (
+            str(values.device),
+            int(values.data_ptr()),
+            int(values.numel()),
+        )
+    materialized = tuple(int(value) for value in values)
+    return ("host", materialized)
+
+
+def _last_contiguous_run_start(values: tuple[int, ...]) -> int:
+    ordered = tuple(sorted(set(values)))
+    if not ordered:
+        raise ValueError("MiniMax-H3 has no video token positions")
+    start_index = 0
+    for index, (left, right) in enumerate(zip(ordered, ordered[1:]), start=1):
+        if right != left + 1:
+            start_index = index
+    return ordered[start_index]
+
+
+def _normalize_boundaries(
+    boundaries: Iterable[int] | None,
+    total_tokens: int,
+) -> tuple[int, ...]:
+    if boundaries is None:
+        return (0, total_tokens)
+    result = tuple(int(value) for value in boundaries)
+    if not result or result[0] != 0:
+        raise ValueError(f"cu_seqlens_host must start at 0, got {result}")
+    if any(left > right for left, right in zip(result, result[1:])):
+        raise ValueError(f"cu_seqlens_host must be nondecreasing, got {result}")
+    if result[-1] > total_tokens:
+        raise ValueError(f"cu_seqlens_host ends beyond T={total_tokens}: {result}")
+    if result[-1] < total_tokens:
+        result = (*result, total_tokens)
+    return result
+
+
+def _request_epoch() -> str | None:
+    path = os.getenv("H3_REQUEST_EPOCH_FILE")
+    if not path:
+        return None
+    try:
+        return Path(path).read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+
+
+def _timestep_max(unique_timesteps: torch.Tensor) -> float | None:
+    if not torch.is_tensor(unique_timesteps) or not unique_timesteps.numel():
+        return None
+    return float(unique_timesteps.detach().float().max().cpu().item())
+
+
+def _timestep_reversed(current: float | None) -> bool:
+    previous = _STATE.previous_timestep
+    _STATE.previous_timestep = current
+    if current is None or previous is None:
+        return False
+    delta = current - previous
+    if abs(delta) <= 1.0e-6:
+        return False
+    direction = 1 if delta > 0 else -1
+    if _STATE.timestep_direction == 0:
+        _STATE.timestep_direction = direction
+        return False
+    return direction != _STATE.timestep_direction
+
+
+@torch.no_grad()
+def begin_model_forward(
+    *,
+    unique_timesteps: torch.Tensor,
+    text_positions: torch.Tensor | Iterable[int],
+    image_positions: torch.Tensor | Iterable[int],
+    audio_positions: torch.Tensor | Iterable[int],
+    cu_seqlens_host: Iterable[int] | None,
+    total_tokens: int,
+    num_layers: int,
+) -> StepContext | None:
+    if not enabled():
+        return None
+
+    boundaries = _normalize_boundaries(cu_seqlens_host, total_tokens)
+    layout_signature = (
+        total_tokens,
+        boundaries,
+        _position_identity(text_positions),
+        _position_identity(image_positions),
+        _position_identity(audio_positions),
+    )
+    if layout_signature == _STATE.layout_signature and _STATE.layout is not None:
+        text, image, audio, live_tokens, target_video_start = _STATE.layout
+    else:
+        text = _host_positions(text_positions)
+        image = _host_positions(image_positions)
+        audio = _host_positions(audio_positions)
+        live_positions = text + image + audio
+        live_tokens = max(live_positions, default=-1) + 1
+        if live_tokens <= 0 or live_tokens > total_tokens:
+            raise ValueError(
+                f"invalid live token count {live_tokens} for T={total_tokens}"
+            )
+        if len(set(live_positions)) != len(live_positions):
+            raise ValueError("MiniMax-H3 text/video/audio token positions overlap")
+        if tuple(sorted(live_positions)) != tuple(range(live_tokens)):
+            raise ValueError("MiniMax-H3 live packed rows must cover one contiguous prefix")
+
+        target_video_start = _last_contiguous_run_start(image)
+        image_set = set(image)
+        if any(
+            position not in image_set
+            for position in range(target_video_start, live_tokens)
+        ):
+            raise ValueError(
+                "MiniMax-H3 target video must be the final contiguous live suffix"
+            )
+        _STATE.layout_signature = layout_signature
+        _STATE.layout = (text, image, audio, live_tokens, target_video_start)
+
+    if len(boundaries) < 2 or boundaries[1] != live_tokens:
+        raise ValueError(
+            "MiniMax-H3 first packed document must end at the live-token boundary: "
+            f"{boundaries}, live={live_tokens}"
+        )
+
+    epoch = _request_epoch()
+    timestep = None if epoch is not None else _timestep_max(unique_timesteps)
+    previous = _STATE.context
+    layout_changed = previous is None or (
+        previous.total_tokens,
+        previous.live_tokens,
+        previous.target_video_start,
+        previous.cu_seqlens_host,
+    ) != (total_tokens, live_tokens, target_video_start, boundaries)
+    epoch_changed = epoch is not None and epoch != _STATE.previous_epoch
+    reversal = epoch is None and _timestep_reversed(timestep)
+    new_request = layout_changed or epoch_changed or reversal
+    if new_request:
+        _STATE.request_index += 1
+        step_index = 0
+        _STATE.timestep_direction = 0
+        _STATE.previous_timestep = timestep
+    else:
+        step_index = 0 if previous is None else previous.step_index + 1
+
+    request_epoch = epoch if epoch is not None else f"auto-{_STATE.request_index}"
+    context = StepContext(
+        request_epoch=request_epoch,
+        request_index=_STATE.request_index,
+        step_index=step_index,
+        total_tokens=total_tokens,
+        live_tokens=live_tokens,
+        target_video_start=target_video_start,
+        prefix_tokens=target_video_start,
+        cu_seqlens_host=boundaries,
+        num_layers=int(num_layers),
+        timestep_max=timestep,
+    )
+    _STATE.context = context
+    _STATE.previous_epoch = epoch
+    if new_request or step_index < 2:
+        emit_event(
+            "step_context",
+            request_epoch=request_epoch,
+            request_index=context.request_index,
+            step_index=step_index,
+            total_tokens=total_tokens,
+            live_tokens=live_tokens,
+            padding_tokens=total_tokens - live_tokens,
+            text_tokens=len(text),
+            image_tokens=len(image),
+            audio_tokens=len(audio),
+            target_video_start=target_video_start,
+            prefix_tokens=context.prefix_tokens,
+            cu_seqlens_host=list(boundaries),
+            num_layers=context.num_layers,
+        )
+    return context
+
+
+def _set_dense_backend(attention: Any, q: torch.Tensor) -> None:
+    if attention._attention_impl is not None:
+        return
+    from sglang.multimodal_gen.runtime.layers.attention.selector import get_attn_backend
+
+    attention._set_attention_backend(
+        get_attn_backend(
+            attention.head_dim,
+            q.dtype,
+            supported_attention_backends=attention._supported_attention_backends,
+        )
+    )
+
+
+def _dense_varlen(
+    attention: Any,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor,
+    cu_seqlens_host: tuple[int, ...] | None,
+    max_seqlen: int,
+) -> torch.Tensor:
+    _set_dense_backend(attention, q)
+    if not _STATE.dense_backend_logged:
+        emit_event(
+            "dense_backend",
+            backend=type(attention._attention_impl).__name__,
+            q_shape=list(q.shape),
+        )
+        _STATE.dense_backend_logged = True
+    return attention._attention_impl.forward_varlen(
+        q,
+        k,
+        v,
+        cu_seqlens=cu_seqlens,
+        max_seqlen=max_seqlen,
+        cu_seqlens_host=cu_seqlens_host,
+    )
+
+
+def _dense_queries(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    start: int,
+    tokens: int,
+    scale: float,
+) -> torch.Tensor:
+    return F.scaled_dot_product_attention(
+        q[:, start : start + tokens].transpose(1, 2),
+        k.transpose(1, 2),
+        v.transpose(1, 2),
+        dropout_p=0.0,
+        is_causal=False,
+        scale=scale,
+    ).transpose(1, 2)
+
+
+def _error_stats(actual: torch.Tensor, expected: torch.Tensor) -> dict[str, float]:
+    difference = actual.float() - expected.float()
+    return {
+        "max_abs": float(difference.abs().max().item()),
+        "mean_abs": float(difference.abs().mean().item()),
+        "rel_l2": float(
+            (
+                torch.linalg.vector_norm(difference)
+                / torch.linalg.vector_norm(expected.float()).clamp_min(1.0e-12)
+            ).item()
+        ),
+    }
+
+
+def _kernel_and_backend(device: torch.device) -> tuple[Any, str]:
+    from sol_attn import get_sol_attn_backend, sol_attn
+
+    backend = get_sol_attn_backend(device)
+    expected = os.getenv("H3_EXPECTED_SOL_BACKEND")
+    if expected and backend != expected:
+        raise RuntimeError(
+            f"MiniMax-H3 expected Sol-Attn backend {expected!r}, selected {backend!r}"
+        )
+    if not _STATE.backend_logged:
+        emit_event(
+            "sol_backend",
+            backend=backend,
+            expected_backend=expected,
+            capability=list(torch.cuda.get_device_capability(device)),
+        )
+        _STATE.backend_logged = True
+    return sol_attn, backend
+
+
+@torch.no_grad()
+def _run_correctness_gate(
+    kernel: Any,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    scale: float,
+    thresh_type: str,
+) -> None:
+    shape = (int(q.shape[1]), int(q.shape[2]), int(q.shape[3]))
+    if shape in _STATE.gated_shapes or os.getenv("H3_SOL_CORRECTNESS_GATE", "1") != "1":
+        return
+    candidate = kernel(
+        q,
+        k,
+        v,
+        scale=scale,
+        tau=-1000.0,
+        thresh_type=thresh_type,
+        kv_splits=1,
+    )
+    reference = F.scaled_dot_product_attention(
+        q.transpose(1, 2),
+        k.transpose(1, 2),
+        v.transpose(1, 2),
+        dropout_p=0.0,
+        is_causal=False,
+        scale=scale,
+    ).transpose(1, 2)
+    torch.cuda.synchronize(q.device)
+    stats = _error_stats(candidate, reference)
+    limits = {
+        "max_abs": float(os.getenv("H3_SOL_GATE_MAX_ABS", "0.15")),
+        "mean_abs": float(os.getenv("H3_SOL_GATE_MEAN_ABS", "0.002")),
+        "rel_l2": float(os.getenv("H3_SOL_GATE_REL_L2", "0.005")),
+    }
+    passed = all(stats[name] <= limit for name, limit in limits.items())
+    emit_event(
+        "real_qkv_correctness_gate",
+        passed=passed,
+        shape=list(q.shape),
+        stats=stats,
+        limits=limits,
+    )
+    if not passed:
+        raise RuntimeError(f"MiniMax-H3 Sol-Attn correctness gate failed: {stats}")
+    _STATE.gated_shapes.add(shape)
+
+
+@torch.no_grad()
+def _estimate_density(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    backend: str,
+    scale: float,
+    tau: float,
+    thresh_type: str,
+    sink_start: int,
+    sink_tokens: int,
+) -> dict[str, float | int]:
+    from sol_attn.preprocess import BLOCK_SIZE
+
+    tokens = int(q.shape[1])
+    blocks = math.ceil(tokens / BLOCK_SIZE)
+    if backend == "triton" and torch.cuda.get_device_capability(q.device)[0] < 9:
+        from sol_attn.triton_ref.preprocess import prepare
+
+        kc, _, threshold = prepare(
+            q, k, v, scale=scale, tau=tau, thresh_type=thresh_type, tokens=tokens
+        )
+        kc = kc[:, :blocks]
+    else:
+        from sol_attn.preprocess import prepare
+
+        kc, _, threshold = prepare(
+            q, k, v, scale=scale, tau=tau, thresh_type=thresh_type
+        )
+
+    padded = F.pad(q, (0, 0, 0, 0, 0, blocks * BLOCK_SIZE - tokens))
+    counts = torch.full(
+        (blocks,), BLOCK_SIZE, device=q.device, dtype=torch.float32
+    )
+    counts[-1] = tokens - (blocks - 1) * BLOCK_SIZE
+    q_bar = padded.view(
+        q.shape[0], blocks, BLOCK_SIZE, q.shape[2], q.shape[3]
+    ).float().sum(dim=2)
+    q_bar.div_(counts.view(1, blocks, 1, 1))
+    scores = torch.einsum("bqhd,bkhd->bqkh", q_bar, kc.float())
+    scores.mul_(scale * math.log2(math.e))
+    routed = scores > threshold[:, :, None, :]
+    threshold_density = float(routed.float().mean().item())
+
+    ids = torch.arange(blocks, device=q.device)
+    routed |= ((ids[:, None] - ids[None, :]).abs() <= 1)[None, :, :, None]
+    sink_first = sink_start // BLOCK_SIZE
+    sink_last = math.ceil((sink_start + sink_tokens) / BLOCK_SIZE)
+    if sink_tokens:
+        routed[:, :, sink_first:sink_last, :] = True
+    return {
+        "blocks": blocks,
+        "heads": int(q.shape[2]),
+        "sink_blocks": max(0, sink_last - sink_first),
+        "threshold_density": threshold_density,
+        "effective_density": float(routed.float().mean().item()),
+    }
+
+
+def _use_dense(layer_index: int | None, context: StepContext | None) -> bool:
+    if os.getenv("H3_SOL_ATTN", "0") != "1":
+        return True
+    if layer_index is None or context is None:
+        return True
+    dense_steps = int(os.getenv("H3_SOL_DENSE_STEPS", "10"))
+    dense_layers = int(os.getenv("H3_SOL_DENSE_LAYERS", "2"))
+    return context.step_index < dense_steps or layer_index < dense_layers
+
+
+def _validate_sparse_policy(tau: float, thresh_type: str) -> str:
+    name = os.getenv("H3_POLICY_NAME", "fullopt_exact")
+    expected = _SPARSE_POLICIES.get(name)
+    if expected is None:
+        raise RuntimeError(f"unknown H100/A100 MiniMax-H3 policy {name!r}")
+    actual = (
+        tau,
+        thresh_type,
+        int(os.getenv("H3_SOL_DENSE_STEPS", "10")),
+        int(os.getenv("H3_SOL_DENSE_LAYERS", "2")),
+    )
+    if actual != expected:
+        raise RuntimeError(
+            f"H100/A100 MiniMax-H3 policy {name!r} requires {expected}, got {actual}"
+        )
+    return name
+
+
+def _should_measure_density(mode: str, context: StepContext) -> bool:
+    if mode == "all":
+        return True
+    if mode != "warmup":
+        return False
+    if ":warmup:" in context.request_epoch:
+        return True
+    return (
+        context.request_epoch == f"auto-{context.request_index}"
+        and context.request_index == 0
+    )
+
+
+@torch.no_grad()
+def _sparse_varlen(
+    attention: Any,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    boundaries: tuple[int, ...],
+    context: StepContext,
+) -> torch.Tensor:
+    tau = float(os.getenv("H3_SOL_TAU", "1.0"))
+    thresh_type = os.getenv("H3_SOL_THRESH_TYPE", "exact")
+    policy_name = _validate_sparse_policy(tau, thresh_type)
+    if os.getenv("H3_SOL_SINK_MODE", "prefix") != "prefix":
+        raise RuntimeError("H100/A100 MiniMax-H3 requires the full prefix sink")
+
+    output = torch.zeros_like(q)
+    for raw_start, raw_end in zip(boundaries, boundaries[1:]):
+        start = min(raw_start, context.live_tokens)
+        end = min(raw_end, context.live_tokens)
+        if end <= start:
+            continue
+        if start != 0:
+            raise RuntimeError("MiniMax-H3 H100/A100 path expects one live packed document")
+        qb = q[start:end].unsqueeze(0).contiguous()
+        kb = k[start:end].unsqueeze(0).contiguous()
+        vb = v[start:end].unsqueeze(0).contiguous()
+        sink_start = 0
+        sink_tokens = context.prefix_tokens
+        kernel, backend = _kernel_and_backend(q.device)
+        _run_correctness_gate(
+            kernel,
+            qb,
+            kb,
+            vb,
+            scale=attention.softmax_scale,
+            thresh_type=thresh_type,
+        )
+
+        shape_key = (
+            context.request_index,
+            int(qb.shape[1]),
+            int(qb.shape[2]),
+            int(qb.shape[3]),
+        )
+        density_mode = os.getenv("H3_SOL_DENSITY_MODE", "warmup")
+        should_measure_density = _should_measure_density(density_mode, context)
+        if should_measure_density and shape_key not in _STATE.density_logged:
+            density = _estimate_density(
+                qb,
+                kb,
+                vb,
+                backend=backend,
+                scale=attention.softmax_scale,
+                tau=tau,
+                thresh_type=thresh_type,
+                sink_start=sink_start,
+                sink_tokens=sink_tokens,
+            )
+            emit_event(
+                "route_density",
+                request_epoch=context.request_epoch,
+                request_index=context.request_index,
+                step_index=context.step_index,
+                tau=tau,
+                thresh_type=thresh_type,
+                backend=backend,
+                policy_name=policy_name,
+                sequence_tokens=end - start,
+                sink_start=sink_start,
+                sink_tokens=sink_tokens,
+                **density,
+            )
+            _STATE.density_logged.add(shape_key)
+
+        segment = kernel(
+            qb,
+            kb,
+            vb,
+            scale=attention.softmax_scale,
+            tau=tau,
+            thresh_type=thresh_type,
+            kv_splits=1,
+            sink_start=sink_start,
+            sink_tokens=sink_tokens,
+        )
+        if sink_tokens:
+            segment[:, :sink_tokens] = _dense_queries(
+                qb,
+                kb,
+                vb,
+                start=0,
+                tokens=sink_tokens,
+                scale=attention.softmax_scale,
+            )
+        output[start:end].copy_(segment[0])
+        if shape_key not in _STATE.sparse_logged:
+            emit_event(
+                "first_sparse_forward",
+                request_epoch=context.request_epoch,
+                request_index=context.request_index,
+                step_index=context.step_index,
+                q_shape=list(qb.shape),
+                backend=backend,
+                policy_name=policy_name,
+                tau=tau,
+                thresh_type=thresh_type,
+                sink_start=sink_start,
+                sink_tokens=sink_tokens,
+            )
+            _STATE.sparse_logged.add(shape_key)
+    return output
+
+
+@torch.no_grad()
+def forward_attention(
+    attention: Any,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor,
+    cu_seqlens_host: tuple[int, ...] | None,
+    max_seqlen: int,
+    ulysses_active: bool,
+) -> torch.Tensor:
+    if ulysses_active:
+        from sglang.multimodal_gen.runtime.layers.usp import (
+            _usp_input_all_to_all_packed_qkv,
+            _usp_output_all_to_all,
+        )
+
+        q, k, v = _usp_input_all_to_all_packed_qkv(q, k, v)
+
+    context = _STATE.context
+    layer_index = getattr(attention, "_sol_engine_layer_index", None)
+    if _use_dense(layer_index, context):
+        output = _dense_varlen(
+            attention,
+            q,
+            k,
+            v,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_host=cu_seqlens_host,
+            max_seqlen=max_seqlen,
+        )
+    else:
+        if context is None:
+            raise RuntimeError("MiniMax-H3 Sol-Engine context was not initialized")
+        output = _sparse_varlen(
+            attention,
+            q,
+            k,
+            v,
+            boundaries=_normalize_boundaries(
+                cu_seqlens_host or context.cu_seqlens_host,
+                int(q.shape[0]),
+            ),
+            context=context,
+        )
+
+    if ulysses_active:
+        output = _usp_output_all_to_all(output[None], head_dim=2)[0]
+    return output
+
+
+__all__ = [
+    "StepContext",
+    "begin_model_forward",
+    "emit_event",
+    "enabled",
+    "forward_attention",
+    "parse_layer_index",
+]

--- a/models/minimax_h3/h100_a100/easycache.py
+++ b/models/minimax_h3/h100_a100/easycache.py
@@ -1,0 +1,284 @@
+"""Collective EasyCache controller for the SGLang MiniMax-H3 block stack."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Literal
+
+import torch
+import torch.distributed as dist
+
+from .adapter import StepContext, emit_event
+
+
+CacheAction = Literal["compute", "reuse"]
+
+
+def enabled() -> bool:
+    return os.getenv("H3_EASYCACHE", "0") == "1"
+
+
+def _env_int(name: str, default: int) -> int:
+    return int(os.getenv(name, str(default)))
+
+
+def _env_float(name: str, default: float) -> float:
+    return float(os.getenv(name, str(default)))
+
+
+@torch.no_grad()
+def _distributed_means(values: list[torch.Tensor]) -> list[float]:
+    sums = torch.stack(
+        [value.abs().sum(dtype=torch.float32) for value in values]
+    )
+    counts = torch.tensor(
+        [value.numel() for value in values],
+        device=sums.device,
+        dtype=torch.float32,
+    )
+    totals = torch.stack((sums, counts))
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(totals, op=dist.ReduceOp.SUM)
+    means = totals[0] / totals[1].clamp_min(1.0)
+    return [float(value) for value in means.cpu().tolist()]
+
+
+@dataclass(frozen=True)
+class EasyCacheConfig:
+    threshold: float
+    retain_steps: int
+    cooldown_steps: int
+    max_hits: int
+    num_forwards: int
+
+    @classmethod
+    def from_env(cls) -> "EasyCacheConfig":
+        config = cls(
+            threshold=_env_float("H3_EASYCACHE_THRESHOLD", 0.30),
+            retain_steps=_env_int("H3_EASYCACHE_RETAIN_STEPS", 6),
+            cooldown_steps=_env_int("H3_EASYCACHE_COOLDOWN_STEPS", 4),
+            max_hits=_env_int("H3_EASYCACHE_MAX_HITS", 2),
+            num_forwards=_env_int("H3_EASYCACHE_NUM_FORWARDS", 49),
+        )
+        if config.threshold <= 0:
+            raise ValueError("H3_EASYCACHE_THRESHOLD must be positive")
+        if min(config.retain_steps, config.cooldown_steps, config.max_hits) < 0:
+            raise ValueError("MiniMax-H3 EasyCache step counts must be non-negative")
+        if config.num_forwards <= 0:
+            raise ValueError("H3_EASYCACHE_NUM_FORWARDS must be positive")
+        return config
+
+
+class _Controller:
+    def __init__(self, config: EasyCacheConfig) -> None:
+        self.config = config
+        self.request_key: tuple[str, int] | None = None
+        self.last_step: int | None = None
+        self.previous_step_input: torch.Tensor | None = None
+        self.last_full_input: torch.Tensor | None = None
+        self.last_full_output: torch.Tensor | None = None
+        self.residual: torch.Tensor | None = None
+        self.pending_input: torch.Tensor | None = None
+        self.k: float | None = None
+        self.accumulator = 0.0
+        self.hits = 0
+        self.calls = 0
+        self.compute = 0
+        self.reuse = 0
+
+    def _finish_request(self) -> None:
+        if self.request_key is None or not self.calls:
+            return
+        emit_event(
+            "easycache_request_summary",
+            request_epoch=self.request_key[0],
+            request_index=self.request_key[1],
+            calls=self.calls,
+            compute=self.compute,
+            reuse=self.reuse,
+            reuse_rate=self.reuse / self.calls,
+            threshold=self.config.threshold,
+            retain_steps=self.config.retain_steps,
+            cooldown_steps=self.config.cooldown_steps,
+            max_hits=self.config.max_hits,
+        )
+
+    def _begin_request(self, context: StepContext) -> None:
+        self._finish_request()
+        self.request_key = (context.request_epoch, context.request_index)
+        self.last_step = None
+        self.previous_step_input = None
+        self.last_full_input = None
+        self.last_full_output = None
+        self.residual = None
+        self.pending_input = None
+        self.k = None
+        self.accumulator = 0.0
+        self.hits = 0
+        self.calls = 0
+        self.compute = 0
+        self.reuse = 0
+        emit_event(
+            "easycache_request_start",
+            request_epoch=context.request_epoch,
+            request_index=context.request_index,
+            threshold=self.config.threshold,
+            retain_steps=self.config.retain_steps,
+            cooldown_steps=self.config.cooldown_steps,
+            max_hits=self.config.max_hits,
+            num_forwards=self.config.num_forwards,
+        )
+
+    @torch.no_grad()
+    def before_blocks(
+        self,
+        hidden: torch.Tensor,
+        *,
+        context: StepContext,
+    ) -> tuple[torch.Tensor, CacheAction]:
+        request_key = (context.request_epoch, context.request_index)
+        if self.request_key != request_key or (
+            self.last_step is not None and context.step_index <= self.last_step
+        ):
+            self._begin_request(context)
+        self.last_step = context.step_index
+
+        step = context.step_index
+        reason: str
+        estimate: float | None = None
+        input_change: float | None = None
+        output_norm: float | None = None
+        must_compute = step < self.config.retain_steps
+        if must_compute:
+            reason = "warmup"
+            self.accumulator = 0.0
+        elif step >= self.config.num_forwards - self.config.cooldown_steps:
+            must_compute = True
+            reason = "cooldown"
+            self.accumulator = 0.0
+        elif (
+            self.previous_step_input is None
+            or self.last_full_output is None
+            or self.residual is None
+            or self.k is None
+        ):
+            must_compute = True
+            reason = "initialize"
+        elif self.residual.shape != hidden.shape:
+            must_compute = True
+            reason = "shape_change"
+        elif self.config.max_hits > 0 and self.hits >= self.config.max_hits:
+            must_compute = True
+            reason = "hit_cap"
+        else:
+            input_change, output_norm = _distributed_means(
+                [hidden - self.previous_step_input, self.last_full_output]
+            )
+            estimate = self.k * input_change / max(output_norm, 1.0e-8)
+            self.accumulator += estimate
+            must_compute = self.accumulator >= self.config.threshold
+            reason = "threshold" if must_compute else "below_threshold"
+            if must_compute:
+                self.accumulator = 0.0
+
+        current_input = hidden.detach().clone()
+        self.previous_step_input = current_input
+        self.calls += 1
+        if must_compute:
+            self.compute += 1
+            self.pending_input = current_input
+            action: CacheAction = "compute"
+        else:
+            self.reuse += 1
+            self.hits += 1
+            self.pending_input = None
+            hidden = hidden + self.residual
+            action = "reuse"
+
+        emit_event(
+            "easycache_decision",
+            request_epoch=context.request_epoch,
+            request_index=context.request_index,
+            step_index=step,
+            action=action,
+            reason=reason,
+            predicted_relative_change=estimate,
+            input_change=input_change,
+            last_full_output_norm=output_norm,
+            accumulator=self.accumulator,
+            k=self.k,
+            continuous_hits=self.hits,
+        )
+        return hidden, action
+
+    @torch.no_grad()
+    def after_blocks(self, hidden: torch.Tensor, *, context: StepContext) -> torch.Tensor:
+        current_input = self.pending_input
+        if current_input is None:
+            raise RuntimeError("MiniMax-H3 EasyCache has no pending block input")
+
+        input_change: float | None = None
+        output_change: float | None = None
+        if self.last_full_input is not None and self.last_full_output is not None:
+            input_change, output_change = _distributed_means(
+                [
+                    current_input - self.last_full_input,
+                    hidden - self.last_full_output,
+                ]
+            )
+            self.k = output_change / max(input_change, 1.0e-8)
+
+        self.last_full_input = current_input
+        self.last_full_output = hidden.detach().clone()
+        self.residual = (hidden - current_input).detach()
+        self.pending_input = None
+        self.accumulator = 0.0
+        self.hits = 0
+        emit_event(
+            "easycache_refresh",
+            request_epoch=context.request_epoch,
+            request_index=context.request_index,
+            step_index=context.step_index,
+            k=self.k,
+            input_change=input_change,
+            output_change=output_change,
+        )
+        return hidden
+
+
+_CONTROLLER: _Controller | None = None
+_CONFIG: EasyCacheConfig | None = None
+
+
+def _controller() -> _Controller:
+    global _CONFIG, _CONTROLLER
+    if not enabled():
+        raise RuntimeError("MiniMax-H3 EasyCache is not enabled")
+    config = EasyCacheConfig.from_env()
+    if _CONTROLLER is None or config != _CONFIG:
+        _CONFIG = config
+        _CONTROLLER = _Controller(config)
+    return _CONTROLLER
+
+
+@torch.no_grad()
+def before_blocks(
+    hidden: torch.Tensor,
+    *,
+    context: StepContext,
+) -> tuple[torch.Tensor, CacheAction]:
+    return _controller().before_blocks(hidden, context=context)
+
+
+@torch.no_grad()
+def after_blocks(hidden: torch.Tensor, *, context: StepContext) -> torch.Tensor:
+    return _controller().after_blocks(hidden, context=context)
+
+
+__all__ = [
+    "EasyCacheConfig",
+    "after_blocks",
+    "before_blocks",
+    "enabled",
+]

--- a/models/minimax_h3/h100_a100/first_block_cache.py
+++ b/models/minimax_h3/h100_a100/first_block_cache.py
@@ -1,0 +1,207 @@
+"""Collective FirstBlockCache for the SGLang MiniMax-H3 block stack."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Literal
+
+import torch
+import torch.distributed as dist
+
+from .adapter import StepContext, emit_event
+
+
+CacheAction = Literal["compute", "reuse"]
+
+
+def enabled() -> bool:
+    return os.getenv("H3_FIRSTBLOCKCACHE", "0") == "1"
+
+
+@dataclass(frozen=True)
+class FirstBlockCacheConfig:
+    threshold: float
+
+    @classmethod
+    def from_env(cls) -> "FirstBlockCacheConfig":
+        config = cls(float(os.getenv("H3_CACHE_THRESHOLD", "0.08")))
+        if config.threshold <= 0:
+            raise ValueError("H3_CACHE_THRESHOLD must be positive")
+        return config
+
+
+@torch.no_grad()
+def _relative_l1(current: torch.Tensor, previous: torch.Tensor) -> float:
+    if current.shape != previous.shape:
+        raise ValueError(
+            f"MiniMax-H3 FirstBlockCache shape changed: {current.shape} != "
+            f"{previous.shape}"
+        )
+    totals = torch.stack(
+        (
+            (current - previous).abs().sum(dtype=torch.float32),
+            previous.abs().sum(dtype=torch.float32),
+        )
+    )
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(totals, op=dist.ReduceOp.SUM)
+    return float((totals[0] / totals[1].clamp_min(1.0e-8)).cpu().item())
+
+
+class _Controller:
+    def __init__(self, config: FirstBlockCacheConfig) -> None:
+        self.config = config
+        self.request_key: tuple[str, int] | None = None
+        self.previous_head_residual: torch.Tensor | None = None
+        self.tail_residual: torch.Tensor | None = None
+        self.pending_head_output: torch.Tensor | None = None
+        self.calls = 0
+        self.compute = 0
+        self.reuse = 0
+
+    def _finish_request(self) -> None:
+        if self.request_key is None or not self.calls:
+            return
+        emit_event(
+            "firstblockcache_request_summary",
+            request_epoch=self.request_key[0],
+            request_index=self.request_key[1],
+            calls=self.calls,
+            compute=self.compute,
+            reuse=self.reuse,
+            reuse_rate=self.reuse / self.calls,
+            threshold=self.config.threshold,
+        )
+
+    def _begin_request(self, context: StepContext) -> None:
+        self._finish_request()
+        self.request_key = (context.request_epoch, context.request_index)
+        self.previous_head_residual = None
+        self.tail_residual = None
+        self.pending_head_output = None
+        self.calls = 0
+        self.compute = 0
+        self.reuse = 0
+        emit_event(
+            "firstblockcache_request_start",
+            request_epoch=context.request_epoch,
+            request_index=context.request_index,
+            threshold=self.config.threshold,
+        )
+
+    @torch.no_grad()
+    def after_head(
+        self,
+        head_input: torch.Tensor,
+        head_output: torch.Tensor,
+        *,
+        context: StepContext,
+    ) -> tuple[torch.Tensor, CacheAction]:
+        request_key = (context.request_epoch, context.request_index)
+        if self.request_key != request_key:
+            self._begin_request(context)
+
+        head_residual = (head_output - head_input).detach()
+        relative_l1: float | None = None
+        shape_changed = (
+            self.previous_head_residual is not None
+            and self.previous_head_residual.shape != head_residual.shape
+        )
+        if shape_changed:
+            emit_event(
+                "firstblockcache_shape_reset",
+                request_epoch=context.request_epoch,
+                request_index=context.request_index,
+                step_index=context.step_index,
+                previous_shape=list(self.previous_head_residual.shape),
+                current_shape=list(head_residual.shape),
+            )
+            self.previous_head_residual = None
+            self.tail_residual = None
+            self.pending_head_output = None
+        must_compute = (
+            self.previous_head_residual is None or self.tail_residual is None
+        )
+        reason = "shape_change" if shape_changed else "initialize"
+        if not must_compute:
+            relative_l1 = _relative_l1(head_residual, self.previous_head_residual)
+            must_compute = relative_l1 > self.config.threshold
+            reason = "threshold" if must_compute else "below_threshold"
+
+        self.calls += 1
+        if must_compute:
+            self.compute += 1
+            self.previous_head_residual = head_residual.clone()
+            self.pending_head_output = head_output.detach().clone()
+            hidden = head_output
+            action: CacheAction = "compute"
+        else:
+            self.reuse += 1
+            self.pending_head_output = None
+            hidden = head_output + self.tail_residual
+            action = "reuse"
+
+        emit_event(
+            "firstblockcache_decision",
+            request_epoch=context.request_epoch,
+            request_index=context.request_index,
+            step_index=context.step_index,
+            action=action,
+            reason=reason,
+            relative_l1=relative_l1,
+            threshold=self.config.threshold,
+        )
+        return hidden, action
+
+    @torch.no_grad()
+    def after_tail(self, hidden: torch.Tensor, *, context: StepContext) -> torch.Tensor:
+        if self.pending_head_output is None:
+            raise RuntimeError("MiniMax-H3 FirstBlockCache has no head-block output")
+        self.tail_residual = (hidden - self.pending_head_output).detach()
+        self.pending_head_output = None
+        emit_event(
+            "firstblockcache_refresh",
+            request_epoch=context.request_epoch,
+            request_index=context.request_index,
+            step_index=context.step_index,
+        )
+        return hidden
+
+
+_CONTROLLER: _Controller | None = None
+_CONFIG: FirstBlockCacheConfig | None = None
+
+
+def _controller() -> _Controller:
+    global _CONFIG, _CONTROLLER
+    if not enabled():
+        raise RuntimeError("MiniMax-H3 FirstBlockCache is not enabled")
+    config = FirstBlockCacheConfig.from_env()
+    if _CONTROLLER is None or config != _CONFIG:
+        _CONFIG = config
+        _CONTROLLER = _Controller(config)
+    return _CONTROLLER
+
+
+@torch.no_grad()
+def after_head(
+    head_input: torch.Tensor,
+    head_output: torch.Tensor,
+    *,
+    context: StepContext,
+) -> tuple[torch.Tensor, CacheAction]:
+    return _controller().after_head(head_input, head_output, context=context)
+
+
+@torch.no_grad()
+def after_tail(hidden: torch.Tensor, *, context: StepContext) -> torch.Tensor:
+    return _controller().after_tail(hidden, context=context)
+
+
+__all__ = [
+    "FirstBlockCacheConfig",
+    "after_head",
+    "after_tail",
+    "enabled",
+]

--- a/models/minimax_h3/h100_a100/gpu_infer.py
+++ b/models/minimax_h3/h100_a100/gpu_infer.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Run one registered MiniMax-H3 profile through SGLang's offline API."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+import time
+from typing import Any
+
+
+RUNTIME_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = RUNTIME_ROOT.parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from models.minimax_h3.h100_a100.registration import (  # noqa: E402
+    register_runtime,
+)
+
+
+# SGLang launches workers with multiprocessing spawn. Registration therefore
+# stays at module scope so every worker receives the same local model class.
+HARDWARE, PROFILE = register_runtime()
+
+from sglang.multimodal_gen.runtime.entrypoints.diffusion_generator import (  # noqa: E402
+    DiffGenerator,
+)
+
+
+DEFAULT_PROMPT_FILE = REPO_ROOT / "models/minimax_h3/prompts/t2va_example_1.json"
+
+
+def _load_prompt() -> tuple[str, str]:
+    direct = os.environ.get("H3_PROMPT")
+    if direct:
+        return direct, "H3_PROMPT"
+    prompt_file = Path(os.environ.get("H3_PROMPT_FILE", str(DEFAULT_PROMPT_FILE)))
+    payload = json.loads(prompt_file.read_text(encoding="utf-8"))
+    prompt = payload.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        raise ValueError(f"Prompt file has no non-empty prompt: {prompt_file}")
+    return prompt, str(prompt_file)
+
+
+def _metric_seconds(metrics: dict[str, Any], fallback: float) -> float:
+    if "total_duration_s" in metrics:
+        return float(metrics["total_duration_s"])
+    if "total_duration_ms" in metrics:
+        return float(metrics["total_duration_ms"]) / 1000.0
+    return float(fallback)
+
+
+def _result_record(result: Any) -> dict[str, Any]:
+    metrics = dict(result.metrics or {})
+    peak_memory = result.peak_memory_mb
+    if isinstance(peak_memory, (list, tuple)):
+        peak_memory = [float(value) for value in peak_memory]
+    elif peak_memory is not None:
+        peak_memory = float(peak_memory)
+    return {
+        "inference_time_s": _metric_seconds(metrics, result.generation_time),
+        "generation_wall_s": float(result.generation_time),
+        "peak_memory_mb_per_gpu": peak_memory,
+        "output_file": result.output_file_path,
+        "metrics": metrics,
+    }
+
+
+def _sampling_params(
+    *,
+    prompt: str,
+    output_dir: Path,
+    output_name: str,
+    steps: int,
+    duration_s: float,
+    seed: int,
+    save_output: bool,
+) -> dict[str, Any]:
+    return {
+        "prompt": prompt,
+        "task": "t2va",
+        "conditions": [],
+        "target": {
+            "short_edge": 768,
+            "aspect_ratio": "16:9",
+            "duration_seconds": duration_s,
+        },
+        "num_outputs_per_prompt": 1,
+        "num_inference_steps": steps,
+        "flow_shift": 12.0,
+        "audio_flow_shift": 3.0,
+        "seed": seed,
+        "output_path": str(output_dir),
+        "output_file_name": output_name,
+        "save_output": save_output,
+        "return_file_paths_only": True,
+    }
+
+
+def _run_request(
+    generator: DiffGenerator,
+    *,
+    phase: str,
+    epoch_file: Path,
+    **sampling_params: Any,
+) -> dict[str, Any]:
+    epoch_file.write_text(
+        f"{PROFILE.name}:{phase}:{time.time_ns()}\n", encoding="utf-8"
+    )
+    result = generator.generate(sampling_params_kwargs=sampling_params)
+    if result is None or isinstance(result, list):
+        raise RuntimeError(f"Expected one MiniMax-H3 result, got {result!r}")
+    return _result_record(result)
+
+
+def _event_files(output_dir: Path) -> list[Path]:
+    return sorted(output_dir.glob("sol_events_rank*.jsonl"))
+
+
+def _collect_events(output_dir: Path) -> dict[str, Any] | None:
+    if not PROFILE.sol_attention:
+        return None
+    events: list[dict[str, Any]] = []
+    for path in _event_files(output_dir):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                events.append(json.loads(line))
+
+    expected_ranks = set(range(int(os.environ["H3_NUM_GPUS"])))
+    measured_sparse_ranks = {
+        int(event["rank"])
+        for event in events
+        if event.get("event") == "first_sparse_forward"
+        and ":measured:" in str(event.get("request_epoch", ""))
+    }
+    if measured_sparse_ranks != expected_ranks:
+        raise RuntimeError(
+            "Sparse attention did not execute on every measured rank: "
+            f"expected {sorted(expected_ranks)}, got {sorted(measured_sparse_ranks)}"
+        )
+
+    density_events = [
+        event for event in events if event.get("event") == "route_density"
+    ]
+    if not density_events:
+        raise RuntimeError("Sparse profile produced no warmup route-density event")
+    weights = [
+        int(event["blocks"]) * int(event["heads"]) for event in density_events
+    ]
+    total_weight = sum(weights)
+    density = {
+        "scope": "first sparse attention call of the warmup request",
+        "threshold_density": sum(
+            float(event["threshold_density"]) * weight
+            for event, weight in zip(density_events, weights)
+        )
+        / total_weight,
+        "effective_density": sum(
+            float(event["effective_density"]) * weight
+            for event, weight in zip(density_events, weights)
+        )
+        / total_weight,
+        "sequence_tokens": int(density_events[0]["sequence_tokens"]),
+        "sink_tokens": int(density_events[0]["sink_tokens"]),
+    }
+
+    cache_kind = None
+    decision_event = None
+    if PROFILE.cache == "easycache":
+        cache_kind = "easycache"
+        decision_event = "easycache_decision"
+    elif PROFILE.cache == "firstblock":
+        cache_kind = "firstblockcache"
+        decision_event = "firstblockcache_decision"
+    cache = None
+    if decision_event is not None:
+        decisions = [
+            event
+            for event in events
+            if event.get("event") == decision_event
+            and int(event.get("rank", -1)) == 0
+            and ":measured:" in str(event.get("request_epoch", ""))
+        ]
+        reuse = sum(event.get("action") == "reuse" for event in decisions)
+        cache = {
+            "kind": cache_kind,
+            "calls": len(decisions),
+            "compute": len(decisions) - reuse,
+            "reuse": reuse,
+            "reuse_rate": reuse / len(decisions) if decisions else 0.0,
+        }
+    return {
+        "measured_sparse_ranks": sorted(measured_sparse_ranks),
+        "route_density": density,
+        "cache": cache,
+    }
+
+
+def _validate_runtime() -> dict[str, Any]:
+    import torch
+    import triton
+
+    expected_torch = os.environ.get("H3_EXPECTED_TORCH", "2.11.0+cu130")
+    expected_triton = os.environ.get("H3_EXPECTED_TRITON", "3.6.0")
+    if torch.__version__ != expected_torch:
+        raise RuntimeError(
+            f"Expected torch {expected_torch}, found {torch.__version__}"
+        )
+    if triton.__version__ != expected_triton:
+        raise RuntimeError(
+            f"Expected Triton {expected_triton}, found {triton.__version__}"
+        )
+    gpu_count = torch.cuda.device_count()
+    if gpu_count != 4:
+        raise RuntimeError(f"MiniMax-H3 release profiles require 4 visible GPUs, got {gpu_count}")
+    devices = []
+    for index in range(gpu_count):
+        capability = tuple(torch.cuda.get_device_capability(index))
+        if capability != HARDWARE.capability:
+            raise RuntimeError(
+                f"GPU {index} has capability {capability}; expected {HARDWARE.capability}"
+            )
+        devices.append(
+            {
+                "index": index,
+                "name": torch.cuda.get_device_name(index),
+                "capability": list(capability),
+            }
+        )
+    backend = None
+    if PROFILE.sol_attention:
+        from sol_attn import get_sol_attn_backend
+
+        backend = get_sol_attn_backend(0)
+        if backend != HARDWARE.sol_backend:
+            raise RuntimeError(
+                f"Expected Sol-Attn backend {HARDWARE.sol_backend}, got {backend}"
+            )
+    return {
+        "torch": torch.__version__,
+        "triton": triton.__version__,
+        "cuda": torch.version.cuda,
+        "devices": devices,
+        "sol_attn_backend": backend,
+    }
+
+
+def main() -> int:
+    output_dir = Path(os.environ.get("OUT_DIR", str(RUNTIME_ROOT / "outputs")))
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for path in _event_files(output_dir):
+        path.unlink()
+
+    prompt, prompt_source = _load_prompt()
+    prompt_sha256 = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+    measured_steps = int(os.environ.get("H3_MEASURED_NUM_STEPS", "50"))
+    warmup_steps = int(os.environ.get("H3_WARMUP_NUM_STEPS", str(measured_steps)))
+    duration_s = float(os.environ.get("H3_DURATION_SECONDS", "5.166667"))
+    seed = int(os.environ.get("H3_SEED", "0"))
+    warmup_seed = int(os.environ.get("H3_WARMUP_SEED", str(seed + 10_000)))
+    os.environ.setdefault("H3_EASYCACHE_NUM_FORWARDS", str(measured_steps - 1))
+    epoch_file = output_dir / "request_epoch.txt"
+    os.environ["H3_REQUEST_EPOCH_FILE"] = str(epoch_file)
+    os.environ["H3_SOL_EVENT_LOG"] = str(output_dir / "sol_events_rank{rank}.jsonl")
+
+    runtime = _validate_runtime()
+    model_path = os.environ.get("H3_MODEL_PATH", "MiniMaxAI/MiniMax-H3")
+    model_subfolder = os.environ.get("H3_MODEL_SUBFOLDER")
+    if not model_subfolder:
+        model_subfolder = "." if Path(model_path).name.lower() == "fl2va" else "FL2VA"
+
+    warmup_path = output_dir / "warmup.mp4"
+    generator = DiffGenerator.from_pretrained(
+        local_mode=True,
+        model_path=model_path,
+        model_subfolder=model_subfolder,
+        model_variant="fl2va",
+        revision=os.environ["H3_MODEL_REVISION"],
+        num_gpus=4,
+        tp_size=1,
+        ulysses_degree=4,
+        enable_cfg_parallel=False,
+        performance_mode="speed",
+        use_fsdp_inference=True,
+        layerwise_offload_components=[],
+        enable_torch_compile=False,
+        regional_compile=False,
+        server_warmup=False,
+        master_port=int(os.environ.get("H3_MASTER_PORT", "30005")),
+    )
+    try:
+        warmup = _run_request(
+            generator,
+            phase="warmup",
+            epoch_file=epoch_file,
+            **_sampling_params(
+                prompt=prompt,
+                output_dir=output_dir,
+                output_name="warmup.mp4",
+                steps=warmup_steps,
+                duration_s=duration_s,
+                seed=warmup_seed,
+                save_output=True,
+            ),
+        )
+        warmup["output_file"] = None
+        measured = _run_request(
+            generator,
+            phase="measured",
+            epoch_file=epoch_file,
+            **_sampling_params(
+                prompt=prompt,
+                output_dir=output_dir,
+                output_name="out.mp4",
+                steps=measured_steps,
+                duration_s=duration_s,
+                seed=seed,
+                save_output=True,
+            ),
+        )
+    finally:
+        generator.shutdown()
+        warmup_path.unlink(missing_ok=True)
+
+    execution = _collect_events(output_dir)
+    for path in _event_files(output_dir):
+        path.unlink()
+    epoch_file.unlink(missing_ok=True)
+
+    benchmark = {
+        "schema_version": 1,
+        "profile": asdict(PROFILE),
+        "hardware": asdict(HARDWARE),
+        "runtime": runtime,
+        "model": {
+            "repo_or_path": model_path,
+            "subfolder": model_subfolder,
+            "revision": os.environ["H3_MODEL_REVISION"],
+            "partition": "FL2VA",
+            "dtype": "bfloat16",
+        },
+        "workload": {
+            "task": "t2va",
+            "width": 1344,
+            "height": 768,
+            "frames": 124,
+            "duration_s": duration_s,
+            "measured_steps": measured_steps,
+            "seed": seed,
+            "prompt_source": prompt_source,
+            "prompt_sha256": prompt_sha256,
+        },
+        "topology": {
+            "num_gpus": 4,
+            "tensor_parallel": 1,
+            "ulysses": 4,
+            "fsdp_inference": True,
+            "offload": False,
+            "torch_compile": False,
+            "reorder": False,
+        },
+        "timing_source": "SGLang GenerationResult.metrics.total_duration_s",
+        "memory_source": "SGLang GenerationResult.peak_memory_mb",
+        "warmup": warmup,
+        "measured": measured,
+        "execution": execution,
+    }
+    benchmark_path = output_dir / "benchmark.json"
+    benchmark_path.write_text(
+        json.dumps(benchmark, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(benchmark, indent=2, sort_keys=True), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/models/minimax_h3/h100_a100/model.py
+++ b/models/minimax_h3/h100_a100/model.py
@@ -1,0 +1,1755 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Registered MiniMax-H3 DiT with the H100/A100 Sol-Engine hooks.
+
+The implementation is pinned to the SGLang source verified by registration.py;
+the installed SGLang package is never copied, patched, or modified at runtime.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+import torch.nn as nn
+from .adapter import (
+    begin_model_forward as _sol_engine_begin_model_forward,
+    enabled as _sol_engine_enabled,
+    forward_attention as _sol_engine_forward_attention,
+    parse_layer_index as _sol_engine_parse_layer_index,
+)
+from .easycache import (
+    after_blocks as _sol_engine_easycache_after_blocks,
+    before_blocks as _sol_engine_easycache_before_blocks,
+    enabled as _sol_engine_easycache_enabled,
+)
+from .first_block_cache import (
+    after_head as _sol_engine_cache_after_head,
+    after_tail as _sol_engine_cache_after_tail,
+    enabled as _sol_engine_cache_enabled,
+)
+
+from sglang.kernels.ops.activation.activation import (
+    silu_and_mul_with_activation_rounding_,
+)
+from sglang.kernels.ops.diffusion.qknorm_rope import (
+    can_use_fused_inplace_qknorm_rope,
+    fused_inplace_qknorm_rope,
+)
+from sglang.kernels.ops.diffusion.triton.indexed_modulation import (
+    indexed_gate_bf16_,
+    indexed_scale_shift_bf16_,
+)
+from sglang.kernels.ops.layernorm.norm import fused_inplace_qknorm
+from sglang.multimodal_gen import envs
+from sglang.multimodal_gen.configs.models.dits.minimax_h3 import (
+    MINIMAX_H3_ADALN_MODALITY_NUM,
+    MINIMAX_H3_PACKED_SEQUENCE_ALIGNMENT,
+    MiniMaxH3DiTArchConfig,
+    MiniMaxH3DiTConfig,
+)
+from sglang.multimodal_gen.runtime.distributed import (
+    get_tp_world_size,
+    tensor_model_parallel_all_gather,
+)
+from sglang.multimodal_gen.runtime.layers.attention.selector import get_attn_backend
+from sglang.multimodal_gen.runtime.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    RowParallelLinear,
+)
+from sglang.multimodal_gen.runtime.layers.quantization.configs.base_config import (
+    QuantizationConfig,
+)
+from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload import (
+    LayerwiseOffloadableModuleMixin,
+    is_layerwise_offloaded_module,
+)
+from sglang.multimodal_gen.runtime.models.dits.base import BaseDiT
+from sglang.multimodal_gen.runtime.platforms import (
+    AttentionBackendEnum,
+    current_platform,
+)
+from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
+    eager_on_graph,
+)
+
+_ARCH_DEFAULTS = MiniMaxH3DiTArchConfig()
+_BF16_DTYPE = torch.bfloat16
+_FP32_DTYPE = torch.float32
+
+_MINIMAX_H3_FP32_PARAM_NAMES_IN_MODEL_ORDER = (
+    "video_patch_proj.weight",
+    "video_patch_proj.bias",
+    "audio_patch_proj.weight",
+    "audio_patch_proj.bias",
+    "time_embedder.proj_in.weight",
+    "time_embedder.proj_in.bias",
+    "time_embedder.proj_out.weight",
+    "time_embedder.proj_out.bias",
+    "final_layer.video_out.weight",
+    "final_layer.video_out.bias",
+    "final_layer.audio_out.weight",
+    "final_layer.audio_out.bias",
+)
+MINIMAX_H3_FP32_PARAM_NAMES = frozenset(_MINIMAX_H3_FP32_PARAM_NAMES_IN_MODEL_ORDER)
+MINIMAX_H3_FP32_BUFFER_NAMES = frozenset({"rope.inv_freq"})
+
+
+def _required_kwarg(kwargs: dict[str, Any], key: str) -> Any:
+    if key not in kwargs or kwargs[key] is None:
+        raise ValueError(f"MiniMaxH3DiTModel.forward requires kwarg {key!r}")
+    return kwargs[key]
+
+
+# The exhaustive keyword contract of MiniMaxH3DiTModel.forward. Anything not
+# listed here is rejected with a TypeError before any tensor work starts.
+_FORWARD_SUPPORTED_KWARGS = frozenset(
+    {
+        "x",
+        "audio_x",
+        "img_position_ids",
+        "rope_cache",
+        "unique_timesteps",
+        "inverse_indices",
+        "update_mask",
+        "update_audio_mask",
+        "token_tags",
+        "block_token_tags",
+        "block_combined_indices",
+        "skip_mask_out_condition",
+        "prompt_embeds",
+        "refined_prompt_embeds_length",
+        "img_pos_info",
+        "audio_pos_info",
+        "text_pos_info",
+        "img_pos_for_infer_output_info",
+        "local_embedding_layout",
+        "packed_seq_params",
+        "refiner_packed_seq_params",
+    }
+)
+
+
+def _ulysses_ctx() -> tuple[int, int]:
+    """(world_size, rank) of the Ulysses sequence-parallel group.
+
+    Returns (1, 0) when model parallelism is not initialized (unit tests /
+    single-process debug paths init tp=1 sp=1 which also yields ws=1).
+    """
+    from sglang.multimodal_gen.runtime.distributed.parallel_state import (
+        get_ulysses_parallel_rank,
+        get_ulysses_parallel_world_size,
+        model_parallel_is_initialized,
+    )
+
+    if not model_parallel_is_initialized():
+        return 1, 0
+    return get_ulysses_parallel_world_size(), get_ulysses_parallel_rank()
+
+
+def _ring_world_size() -> int:
+    from sglang.multimodal_gen.runtime.distributed.parallel_state import (
+        get_ring_parallel_world_size,
+        model_parallel_is_initialized,
+    )
+
+    if not model_parallel_is_initialized():
+        return 1
+    return get_ring_parallel_world_size()
+
+
+def _reorder_grouped_qkv_to_qkv(
+    weight: torch.Tensor,
+    *,
+    num_query_groups: int,
+    heads_per_group: int,
+    head_dim: int,
+) -> torch.Tensor:
+    per_group = (heads_per_group + 2) * head_dim
+    expected_out = num_query_groups * per_group
+    if weight.shape[0] != expected_out:
+        raise ValueError(
+            "qkv weight has incompatible output dim for grouped checkpoint layout: "
+            f"got {tuple(weight.shape)}, expected first dim {expected_out}."
+        )
+
+    rest_shape = weight.shape[1:]
+    grouped = weight.reshape(num_query_groups, per_group, *rest_shape)
+    q, k, v = torch.split(
+        grouped,
+        [heads_per_group * head_dim, head_dim, head_dim],
+        dim=1,
+    )
+    return torch.cat(
+        [
+            q.reshape(num_query_groups * heads_per_group * head_dim, *rest_shape),
+            k.reshape(num_query_groups * head_dim, *rest_shape),
+            v.reshape(num_query_groups * head_dim, *rest_shape),
+        ],
+        dim=0,
+    )
+
+
+def _copy_grouped_qkv_tp_shard(
+    param: torch.Tensor,
+    loaded_weight: torch.Tensor,
+    *,
+    num_query_groups: int,
+    head_dim: int,
+    tp_rank: int,
+    tp_size: int,
+) -> bool:
+    """Copy a dense MHA checkpoint directly into its TP-local Q/K/V rows."""
+    if (
+        tp_size <= 0
+        or not 0 <= tp_rank < tp_size
+        or num_query_groups % tp_size
+        or getattr(param, "output_dim", None) != 0
+        or getattr(param, "is_sharded_weight", False)
+        or getattr(param, "packed_dim", None) is not None
+        or param.dtype != _BF16_DTYPE
+        or loaded_weight.dtype != _BF16_DTYPE
+        or not param.is_contiguous()
+        or not loaded_weight.is_contiguous()
+    ):
+        return False
+
+    expected_rows = num_query_groups * 3 * head_dim
+    local_groups = num_query_groups // tp_size
+    rest_shape = loaded_weight.shape[1:]
+    if loaded_weight.shape[0] != expected_rows or tuple(param.shape) != (
+        3 * local_groups * head_dim,
+        *rest_shape,
+    ):
+        return False
+
+    grouped = loaded_weight.view(num_query_groups, 3, head_dim, *rest_shape)
+    grouped = grouped.narrow(0, tp_rank * local_groups, local_groups)
+    target = param.data.view(3, local_groups, head_dim, *rest_shape)
+    for index in range(3):
+        target[index].copy_(grouped[:, index])
+    return True
+
+
+def _norm(size: int, *, eps: float, dtype: torch.dtype = _BF16_DTYPE) -> nn.RMSNorm:
+    # RMSNorm uses fp32 accumulation with bf16 inputs and outputs.
+    # torch.nn.RMSNorm upcasts reduced-precision inputs for the variance
+    # reduction, matching that accumulation semantic.
+    return nn.RMSNorm(size, eps=eps, dtype=dtype)
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1, x2 = torch.chunk(x, 2, dim=-1)
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _modulate_scale_shift(
+    x: torch.Tensor,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+    indices: torch.Tensor,
+    *,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Apply indexed affine modulation, reusing disposable CUDA BF16 input."""
+    # Apply per-index affine modulation: x * (1 + scale[idx]) + shift[idx].
+    if (
+        x.is_cuda
+        and x.dtype == _BF16_DTYPE
+        and dtype == _BF16_DTYPE
+        and shift.dtype == _BF16_DTYPE
+        and scale.dtype == _BF16_DTYPE
+        and x.is_contiguous()
+    ):
+        return indexed_scale_shift_bf16_(x, shift, scale, indices)
+    return (
+        x * (1.0 + scale.index_select(0, indices)) + shift.index_select(0, indices)
+    ).to(dtype)
+
+
+def _modulate_gate(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    other: torch.Tensor,
+    indices: torch.Tensor,
+    *,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Apply indexed gated residual, reusing disposable CUDA BF16 input."""
+    # Apply the per-index gated residual: x + gate[idx] * other.
+    if (
+        x.is_cuda
+        and x.dtype == _BF16_DTYPE
+        and dtype == _BF16_DTYPE
+        and gate.dtype == _BF16_DTYPE
+        and other.dtype == _BF16_DTYPE
+        and x.is_contiguous()
+        and other.is_contiguous()
+    ):
+        return indexed_gate_bf16_(x, gate, other, indices)
+    return (x + gate.index_select(0, indices) * other).to(dtype)
+
+
+def _silu_mul(hidden: torch.Tensor, *, reuse_input: bool) -> torch.Tensor:
+    if (
+        reuse_input
+        and hidden.is_cuda
+        and hidden.dtype == _BF16_DTYPE
+        and hidden.is_contiguous()
+        and hidden.shape[-1] % 16 == 0
+    ):
+        return silu_and_mul_with_activation_rounding_(hidden)
+    gate, up = hidden.chunk(2, dim=-1)
+    return nn.functional.silu(gate) * up
+
+
+def _apply_qk_norm(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_norm: nn.RMSNorm,
+    k_norm: nn.RMSNorm,
+    head_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if (
+        q.is_cuda
+        and q.dtype == _BF16_DTYPE
+        and q.dtype == k.dtype == q_norm.weight.dtype == k_norm.weight.dtype
+        and q.stride(-1) == k.stride(-1) == 1
+        and q.stride(-2) == k.stride(-2) == head_dim
+        and q_norm.eps == k_norm.eps
+        and not torch.compiler.is_compiling()
+    ):
+        fused_inplace_qknorm(
+            q,
+            k,
+            q_norm.weight,
+            k_norm.weight,
+            eps=q_norm.eps,
+            head_dim=head_dim,
+        )
+        return q, k
+    return q_norm(q), k_norm(k)
+
+
+class MiniMaxH3Rope(nn.Module):
+    """3D rope over (t, h, w); rotates 96 of 128 head dims (rotary_percent 0.75).
+
+    Frequency layout concatenates temporal, height, and width embeddings twice,
+    with 16 frequencies per axis (inv_freq = base^-(arange(0,32,2)/32)).
+    """
+
+    def __init__(self, inv_freq_len: int) -> None:
+        super().__init__()
+        self.register_buffer(
+            "inv_freq",
+            torch.empty(inv_freq_len, dtype=_FP32_DTYPE),
+            persistent=True,
+        )
+
+    def forward(self, img_position_ids: torch.Tensor) -> torch.Tensor:
+        """img_position_ids: [1, S, 3] (t, h, w) -> freqs [S, rot_dim=96]."""
+        if img_position_ids.dim() != 3 or img_position_ids.shape[0] != 1:
+            raise ValueError(
+                "img_position_ids must be [1, S, 3], got "
+                f"{list(img_position_ids.shape)}"
+            )
+        pos = img_position_ids[0].to(_FP32_DTYPE)  # [S, 3]
+        per_axis = pos.unsqueeze(-1) * self.inv_freq.view(1, 1, -1)  # [S, 3, 16]
+        t_f, h_f, w_f = per_axis.unbind(dim=1)  # each [S, 16]
+        half = torch.cat((t_f, h_f, w_f), dim=-1)  # [S, 48]
+        return torch.cat((half, half), dim=-1)  # [S, 96]
+
+
+def _rope_cos_sin_cache(freqs: torch.Tensor, *, dtype: torch.dtype) -> torch.Tensor:
+    """Build the activation-dtype cos|sin cache for fused Q/K RoPE."""
+    half = freqs.shape[-1] // 2
+    return (
+        torch.cat(
+            (torch.cos(freqs[:, :half]), torch.sin(freqs[:, :half])),
+            dim=-1,
+        )
+        .to(dtype=dtype, copy=False)
+        .contiguous()
+    )
+
+
+def _apply_rope_cos_sin(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> torch.Tensor:
+    """Rotate the first cached RoPE dims; pass the remaining head dims through."""
+    rot_dim = cos.shape[-1]
+    x_rot, x_pass = x[..., :rot_dim], x[..., rot_dim:]
+    x_rot = (x_rot * cos) + (_rotate_half(x_rot) * sin)
+    return torch.cat((x_rot, x_pass), dim=-1)
+
+
+def _apply_rope_qk(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if not q.is_cuda:
+        half = cos_sin_cache.shape[-1] // 2
+        cos_half, sin_half = cos_sin_cache.split(half, dim=-1)
+        cos = torch.cat((cos_half, cos_half), dim=-1).unsqueeze(1)
+        sin = torch.cat((sin_half, sin_half), dim=-1).unsqueeze(1)
+        return (
+            _apply_rope_cos_sin(q, cos, sin),
+            _apply_rope_cos_sin(k, cos, sin),
+        )
+
+    from sgl_kernel import rotary_embedding as apply_sgl_kernel_rotary_embedding
+
+    apply_sgl_kernel_rotary_embedding(
+        positions,
+        q.view(q.shape[0], -1),
+        k.view(k.shape[0], -1),
+        q.shape[-1],
+        cos_sin_cache,
+        True,
+    )
+    return q, k
+
+
+class MiniMaxH3TimeEmbedder(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.frequency_embedding_size = arch.timestep_input_dim
+        self.proj_in = ColumnParallelLinear(
+            arch.timestep_input_dim,
+            arch.time_embed_hidden_size,
+            bias=True,
+            gather_output=False,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix=f"{prefix}.proj_in",
+        )
+        self.proj_out = RowParallelLinear(
+            arch.time_embed_hidden_size,
+            arch.time_embed_dim,
+            bias=True,
+            input_is_parallel=True,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix=f"{prefix}.proj_out",
+        )
+        self.register_buffer("_frequency_cache", None, persistent=False)
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        """t: [M] -> [M, time_embed_dim] fp32.
+
+        The sinusoidal embedding stays fp32 throughout and concatenates cosine
+        values before sine values.
+        """
+        half = self.frequency_embedding_size // 2
+        freqs = self._frequency_cache
+        if freqs is None or freqs.device != t.device:
+            # Construct this on the execution device once so the values keep
+            # the established CUDA numerics without repeating arange/exp on
+            # every denoise step.
+            freqs = torch.exp(
+                -math.log(10000.0)
+                * torch.arange(half, dtype=_FP32_DTYPE, device=t.device)
+                / half
+            )
+            self._frequency_cache = freqs
+        args = t.to(_FP32_DTYPE)[:, None] * freqs[None]
+        t_freq = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        hidden, _ = self.proj_in(t_freq)
+        hidden = nn.functional.silu(hidden)
+        out, _ = self.proj_out(hidden)
+        return out
+
+
+def _minimax_h3_attention_core_impl(
+    attention: MiniMaxH3Attention,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor,
+    cu_seqlens_host: tuple[int, ...] | None,
+    max_seqlen: int,
+    ulysses_active: bool,
+) -> torch.Tensor:
+    """Dynamic varlen attention and Ulysses collectives.
+
+    This is the narrow BCG break point: projections, normalization, RoPE,
+    residuals, and MLPs remain captured while the dynamic packed attention
+    kernel and sequence-parallel collectives execute eagerly.
+    """
+
+    return _sol_engine_forward_attention(
+        attention,
+        q,
+        k,
+        v,
+        cu_seqlens=cu_seqlens,
+        cu_seqlens_host=cu_seqlens_host,
+        max_seqlen=max_seqlen,
+        ulysses_active=ulysses_active,
+    )
+
+
+_minimax_h3_attention_core_bcg = eager_on_graph(True)(_minimax_h3_attention_core_impl)
+
+
+class MiniMaxH3Attention(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+        bcg_breakpoint: bool = True,
+    ) -> None:
+        super().__init__()
+        self.bcg_breakpoint = bcg_breakpoint
+        self.tp_size = get_tp_world_size()
+        if arch.num_attention_heads % self.tp_size:
+            raise ValueError(
+                "MiniMax H3 attention heads must be divisible by TP size: "
+                f"{arch.num_attention_heads} % {self.tp_size} != 0"
+            )
+        self.total_num_heads = arch.num_attention_heads
+        self.num_heads = self.total_num_heads // self.tp_size
+        self.head_dim = arch.attention_head_dim
+        self.inner_dim = self.total_num_heads * self.head_dim
+        self.local_inner_dim = self.num_heads * self.head_dim
+        self.softmax_scale = self.head_dim**-0.5
+        self._supported_attention_backends = arch._supported_attention_backends
+        self._attention_impl = None
+        self._sol_engine_layer_index = _sol_engine_parse_layer_index(prefix)
+        # The checkpoint stores one fused qkv tensor. Each logical Q/K/V
+        # matrix must be sharded independently; a plain ColumnParallelLinear
+        # would instead slice across the concatenated tensor and is incorrect
+        # for TP > 1.
+        self.qkv_proj = MergedColumnParallelLinear(
+            arch.hidden_size,
+            [self.inner_dim] * 3,
+            bias=False,
+            gather_output=False,
+            params_dtype=_BF16_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj",
+        )
+        self._install_qkv_weight_loader(arch)
+        self.q_norm = _norm(arch.attention_head_dim, eps=arch.qk_norm_eps)
+        self.k_norm = _norm(arch.attention_head_dim, eps=arch.qk_norm_eps)
+        # cache width covers cos/sin for temporal, height, and width frequencies
+        rope_dim = 6 * arch.rope_inv_freq_len
+        self._use_fused_qknorm_rope = (
+            current_platform.is_cuda()
+            and can_use_fused_inplace_qknorm_rope(
+                arch.attention_head_dim,
+                rope_dim,
+                True,
+                _BF16_DTYPE,
+                cache_dtype=_BF16_DTYPE,
+                round_norm_before_rope=True,
+            )
+        )
+        self.out_proj = RowParallelLinear(
+            self.inner_dim,
+            arch.hidden_size,
+            bias=False,
+            input_is_parallel=True,
+            params_dtype=_BF16_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.out_proj",
+        )
+
+    def _set_attention_backend(self, backend) -> None:
+        impl_cls = backend.get_impl_cls()
+        self._attention_impl = impl_cls(
+            num_heads=self.num_heads,
+            head_size=self.head_dim,
+            causal=False,
+            softmax_scale=self.softmax_scale,
+            num_kv_heads=self.num_heads,
+        )
+
+    def _install_qkv_weight_loader(self, arch: MiniMaxH3DiTArchConfig) -> None:
+        weight = self.qkv_proj.weight
+        base_loader = weight.weight_loader
+
+        def _weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
+            # The grouped checkpoint layout is
+            # [num_query_groups, q_per_group + k + v] before splitting.
+            # MiniMax H3 uses MHA, so checkpoint rows are per-head [q, k, v],
+            # while SGLang stores [q_all, k_all, v_all].
+            if _copy_grouped_qkv_tp_shard(
+                param,
+                loaded_weight,
+                num_query_groups=arch.num_attention_heads,
+                head_dim=arch.attention_head_dim,
+                tp_rank=self.qkv_proj.tp_rank,
+                tp_size=self.tp_size,
+            ):
+                return
+            reordered = _reorder_grouped_qkv_to_qkv(
+                loaded_weight,
+                num_query_groups=arch.num_attention_heads,
+                heads_per_group=1,
+                head_dim=arch.attention_head_dim,
+            )
+            base_loader(param, reordered)
+
+        if hasattr(weight, "_weight_loader"):
+            weight._weight_loader = _weight_loader
+        else:
+            weight.weight_loader = _weight_loader
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        rope_cache: tuple[torch.Tensor, torch.Tensor] | None,
+        cu_seqlens: torch.Tensor,
+        cu_seqlens_host: tuple[int, ...] | None = None,
+        max_seqlen: int,
+        ulysses_active: bool = False,
+    ) -> torch.Tensor:
+        """x: [T, hidden] packed thd rows -> [T, hidden].
+
+        Operation order: fused qkv projection -> per-head q/k RMSNorm -> RoPE
+        on q/k -> variable-length non-causal flash attention -> output projection.
+
+        With Ulysses sequence parallelism, x holds this rank's row shard;
+        qkv/norm/RoPE run locally, an all-to-all trades sequence for heads.
+        Each rank attends the full sequence with heads/world_size local heads,
+        so cu_seqlens retains global packed-document semantics. The inverse
+        all-to-all restores the row shard before the output projection.
+        """
+        total = x.shape[0]
+        qkv, _ = self.qkv_proj(x)
+        q, k, v = qkv.split(self.local_inner_dim, dim=-1)
+        q = q.view(total, self.num_heads, self.head_dim)
+        k = k.view(total, self.num_heads, self.head_dim)
+        v = v.view(total, self.num_heads, self.head_dim)
+        if rope_cache is None:
+            q, k = _apply_qk_norm(
+                q,
+                k,
+                self.q_norm,
+                self.k_norm,
+                self.head_dim,
+            )
+        else:
+            cos_sin_cache, positions = rope_cache
+            if self._use_fused_qknorm_rope and not torch.compiler.is_compiling():
+                fused_inplace_qknorm_rope(
+                    q,
+                    k,
+                    self.q_norm.weight,
+                    self.k_norm.weight,
+                    cos_sin_cache,
+                    positions,
+                    is_neox=True,
+                    eps=self.q_norm.eps,
+                    head_dim=self.head_dim,
+                    rope_dim=cos_sin_cache.shape[-1],
+                    round_norm_before_rope=True,
+                )
+            else:
+                q, k = _apply_qk_norm(
+                    q,
+                    k,
+                    self.q_norm,
+                    self.k_norm,
+                    self.head_dim,
+                )
+                q, k = _apply_rope_qk(q, k, cos_sin_cache, positions)
+
+        attention_core = (
+            _minimax_h3_attention_core_bcg
+            if self.bcg_breakpoint
+            else _minimax_h3_attention_core_impl
+        )
+        out = attention_core(
+            self,
+            q,
+            k,
+            v,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_host=cu_seqlens_host,
+            max_seqlen=max_seqlen,
+            ulysses_active=ulysses_active,
+        )
+        out = out.reshape(total, self.num_heads * self.head_dim)
+        out, _ = self.out_proj(out)
+        return out
+
+
+class MiniMaxH3MLP(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        # As with qkv, gate and up are two independently sharded logical
+        # matrices even though the checkpoint stores them fused.
+        self.fc1 = MergedColumnParallelLinear(
+            arch.hidden_size,
+            [arch.ffn_hidden_size] * 2,
+            bias=False,
+            gather_output=False,
+            params_dtype=_BF16_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.fc1",
+        )
+        # Chunk the fused fc1 output as [gate, up], then compute
+        # silu(gate) * up.
+        self.fc2 = RowParallelLinear(
+            arch.ffn_hidden_size,
+            arch.hidden_size,
+            bias=False,
+            input_is_parallel=True,
+            params_dtype=_BF16_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.fc2",
+        )
+        self.reuse_fc1_activation = quant_config is None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        hidden, _ = self.fc1(x)
+        hidden = _silu_mul(hidden, reuse_input=self.reuse_fc1_activation)
+        out, _ = self.fc2(hidden)
+        return out
+
+
+class MiniMaxH3AdalnProj(nn.Module):
+    """SiLU + zero-init linear over unique condition embeddings.
+
+    Per block, three modalities each produce six H-wide vectors:
+    [M, t_dim] -> [M, 3*6H] -> view(M*3, 6H) -> chunk(6).
+    The final layer uses one modality and produces two H-wide vectors:
+    [M, t_dim] -> [M, 2H] -> chunk(2).
+    """
+
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        out_features: int,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+        expand_ratio: int,
+        modality_num: int,
+    ) -> None:
+        super().__init__()
+        if out_features != expand_ratio * arch.hidden_size * modality_num:
+            raise ValueError(
+                "adaln out_features mismatch: "
+                f"{out_features} != {expand_ratio}*{arch.hidden_size}*{modality_num}"
+            )
+        self.expand_ratio = expand_ratio
+        self.modality_num = modality_num
+        self.hidden_size = arch.hidden_size
+        self.linear = ColumnParallelLinear(
+            arch.time_embed_dim,
+            out_features,
+            bias=True,
+            gather_output=False,
+            params_dtype=_BF16_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.linear",
+        )
+
+    def project_local(self, adaln_input: torch.Tensor) -> torch.Tensor:
+        x, _ = self.linear(adaln_input)
+        return x
+
+    def split_output(self, x: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        m = x.shape[0]
+        x = x.view(m * self.modality_num, self.expand_ratio * self.hidden_size)
+        return tuple(x.chunk(self.expand_ratio, dim=-1))
+
+    def forward(self, adaln_input: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        """adaln_input: SiLU(t_emb) BF16 -> expand_ratio tensors of [M*modality_num, H]."""
+        x = self.project_local(adaln_input)
+        if get_tp_world_size() > 1:
+            x = tensor_model_parallel_all_gather(x)
+        return self.split_output(x)
+
+
+class MiniMaxH3TokenRefinerBlock(nn.Module):
+    """Standard pre-norm transformer block without AdaLN or RoPE."""
+
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.norm1 = _norm(arch.hidden_size, eps=arch.norm_eps)
+        self.norm2 = _norm(arch.hidden_size, eps=arch.norm_eps)
+        # The whole dynamic text-refiner/scatter phase is one BCG break point;
+        # do not nest per-attention graph breaks inside it.
+        self.attn = MiniMaxH3Attention(
+            arch,
+            quant_config,
+            prefix=f"{prefix}.attn",
+            bcg_breakpoint=False,
+        )
+        self.mlp = MiniMaxH3MLP(arch, quant_config, prefix=f"{prefix}.mlp")
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor,
+        cu_seqlens_host: tuple[int, ...] | None = None,
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        x = x + self.attn(
+            self.norm1(x),
+            rope_cache=None,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_host=cu_seqlens_host,
+            max_seqlen=max_seqlen,
+        )
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class MiniMaxH3TokenRefiner(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.blocks = nn.ModuleList(
+            [
+                MiniMaxH3TokenRefinerBlock(
+                    arch,
+                    quant_config,
+                    prefix=f"{prefix}.blocks.{index}",
+                )
+                for index in range(arch.token_refiner_num_layers)
+            ]
+        )
+        self.final_norm = _norm(arch.hidden_size, eps=arch.final_norm_eps)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor,
+        cu_seqlens_host: tuple[int, ...] | None = None,
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        for block in self.blocks:
+            x = block(
+                x,
+                cu_seqlens=cu_seqlens,
+                cu_seqlens_host=cu_seqlens_host,
+                max_seqlen=max_seqlen,
+            )
+        return self.final_norm(x)
+
+
+class MiniMaxH3DiTBlock(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.norm1 = _norm(arch.hidden_size, eps=arch.norm_eps)
+        self.norm2 = _norm(arch.hidden_size, eps=arch.norm_eps)
+        self.attn = MiniMaxH3Attention(
+            arch,
+            quant_config,
+            prefix=f"{prefix}.attn",
+        )
+        self.mlp = MiniMaxH3MLP(arch, quant_config, prefix=f"{prefix}.mlp")
+        self.adaln_proj = MiniMaxH3AdalnProj(
+            arch,
+            arch.adaln_out_features,
+            quant_config,
+            prefix=f"{prefix}.adaln_proj",
+            expand_ratio=6,
+            modality_num=MINIMAX_H3_ADALN_MODALITY_NUM,
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        adaln_input: torch.Tensor,
+        combined_indices: torch.Tensor,
+        rope_cache: tuple[torch.Tensor, torch.Tensor],
+        cu_seqlens: torch.Tensor,
+        cu_seqlens_host: tuple[int, ...] | None = None,
+        max_seqlen: int,
+        ulysses_active: bool = False,
+        adaln_params: tuple[torch.Tensor, ...] | None = None,
+    ) -> torch.Tensor:
+        """x: [T, H]; adaln_input: [M, t_dim]; combined_indices: [T]
+        (= inverse_indices * modality_num + token_tags.clamp(min=0)).
+
+        Each block computes AdaLN parameters once, then applies
+        norm1 -> scale/shift -> attention -> gated residual, followed by
+        norm2 -> scale/shift -> MLP -> gated residual.
+        """
+        if adaln_params is None:
+            adaln_params = self.adaln_proj(adaln_input)
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = adaln_params
+
+        residual = x
+        h = self.norm1(x)
+        h = _modulate_scale_shift(
+            h, shift_msa, scale_msa, combined_indices, dtype=_BF16_DTYPE
+        )
+        h = self.attn(
+            h,
+            rope_cache=rope_cache,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_host=cu_seqlens_host,
+            max_seqlen=max_seqlen,
+            ulysses_active=ulysses_active,
+        )
+        x = _modulate_gate(residual, gate_msa, h, combined_indices, dtype=_BF16_DTYPE)
+
+        residual = x
+        h = self.norm2(x)
+        h = _modulate_scale_shift(
+            h, shift_mlp, scale_mlp, combined_indices, dtype=_BF16_DTYPE
+        )
+        h = self.mlp(h)
+        return _modulate_gate(
+            residual, gate_mlp, h, combined_indices, dtype=_BF16_DTYPE
+        )
+
+
+class MiniMaxH3FinalLayer(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        video_patch_dim = (
+            arch.latents_dim
+            * arch.patch_size[0]
+            * arch.patch_size[1]
+            * arch.patch_size[2]
+        )
+        self.norm = _norm(arch.hidden_size, eps=arch.final_norm_eps)
+        self.adaln_proj = MiniMaxH3AdalnProj(
+            arch,
+            arch.final_adaln_out_features,
+            quant_config,
+            prefix=f"{prefix}.adaln_proj",
+            expand_ratio=2,
+            modality_num=1,
+        )
+        self.video_out = ColumnParallelLinear(
+            arch.hidden_size,
+            video_patch_dim,
+            bias=True,
+            gather_output=False,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix=f"{prefix}.video_out",
+        )
+        self.audio_out = ColumnParallelLinear(
+            arch.hidden_size,
+            arch.audio_latents_dim,
+            bias=True,
+            gather_output=False,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix=f"{prefix}.audio_out",
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        adaln_input: torch.Tensor,
+        inverse_indices: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Project all rows into TP-local video/audio output shards.
+
+        Apply single-modality shift/scale AdaLN to the final normalized
+        activations, cast to fp32, then apply both output heads to all rows.
+        The model gathers output columns only after selecting live media rows,
+        preserving the GEMM shape while reducing collective payload.
+        """
+        shift, scale = self.adaln_proj(adaln_input)
+        h = self.norm(x)
+        h = _modulate_scale_shift(h, shift, scale, inverse_indices, dtype=_BF16_DTYPE)
+        # Preserve full precision through both final output projections.
+        h = h.to(_FP32_DTYPE)
+        video, _ = self.video_out(h)
+        audio, _ = self.audio_out(h)
+        return video, audio
+
+
+class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
+    _fsdp_shard_conditions = _ARCH_DEFAULTS._fsdp_shard_conditions
+    # parameters mix fp32 (patch projections, timestep embedder, and output
+    # heads) with bf16 blocks; FSDP must gather in each parameter's own dtype
+    _fsdp_mixed_dtype_params = True
+    _compile_conditions = _ARCH_DEFAULTS._compile_conditions
+    _supported_attention_backends = _ARCH_DEFAULTS._supported_attention_backends
+    param_names_mapping = _ARCH_DEFAULTS.param_names_mapping
+    reverse_param_names_mapping = _ARCH_DEFAULTS.reverse_param_names_mapping
+    lora_param_names_mapping = _ARCH_DEFAULTS.lora_param_names_mapping
+
+    def _can_batch_block_adaln(self) -> bool:
+        return (
+            get_tp_world_size() > 1
+            and not torch.compiler.is_compiling()
+            and not envs.SGLANG_CACHE_DIT_ENABLED
+            and not hasattr(self, "_sglang_cache_dit_adapter")
+            and not is_layerwise_offloaded_module(self)
+            and all(type(block) is MiniMaxH3DiTBlock for block in self.blocks)
+        )
+
+    def _validate_tp_config(
+        self, *, arch: MiniMaxH3DiTArchConfig, tp_size: int
+    ) -> None:
+        if tp_size <= 0:
+            raise ValueError("TP size must be positive.")
+        if arch.num_attention_heads <= 0:
+            raise ValueError("num_attention_heads must be positive.")
+        if arch.hidden_size <= 0:
+            raise ValueError("hidden_size must be positive.")
+        if arch.attention_head_dim <= 0:
+            raise ValueError("attention_head_dim must be positive.")
+        if arch.ffn_hidden_size <= 0:
+            raise ValueError("ffn_hidden_size must be positive.")
+        for name, value in (
+            ("num_attention_heads", arch.num_attention_heads),
+            ("hidden_size", arch.hidden_size),
+            ("ffn_hidden_size", arch.ffn_hidden_size),
+            ("time_embed_hidden_size", arch.time_embed_hidden_size),
+            ("adaln_out_features", arch.adaln_out_features),
+            ("final_adaln_out_features", arch.final_adaln_out_features),
+            ("video_patch_output_dim", arch.latents_dim * math.prod(arch.patch_size)),
+            ("audio_patch_output_dim", arch.audio_latents_dim),
+        ):
+            if value % tp_size:
+                raise ValueError(
+                    f"MiniMax H3 {name}={value} must be divisible by "
+                    f"TP size {tp_size}."
+                )
+
+    @staticmethod
+    def _validate_sequence_parallel_config(
+        *,
+        arch: MiniMaxH3DiTArchConfig,
+        tp_size: int,
+        ulysses_size: int,
+        ring_size: int,
+    ) -> None:
+        if ulysses_size <= 0:
+            raise ValueError("MiniMax H3 Ulysses size must be positive.")
+        if ring_size != 1:
+            raise NotImplementedError(
+                "MiniMax H3 packed multi-segment attention does not support "
+                "Ring or mixed USP. Set --ring-degree 1 and use Ulysses "
+                "sequence parallelism."
+            )
+        local_heads = arch.num_attention_heads // tp_size
+        if local_heads % ulysses_size:
+            raise ValueError(
+                f"MiniMax H3 TP-local heads {local_heads} must be divisible by "
+                f"Ulysses size {ulysses_size} (total heads="
+                f"{arch.num_attention_heads}, TP={tp_size})."
+            )
+        if MINIMAX_H3_PACKED_SEQUENCE_ALIGNMENT % ulysses_size:
+            raise ValueError(
+                "MiniMax H3 packed sequence alignment "
+                f"{MINIMAX_H3_PACKED_SEQUENCE_ALIGNMENT} must be divisible by "
+                f"Ulysses size {ulysses_size}. Choose a Ulysses size that "
+                "divides both the TP-local attention heads and the packed "
+                "sequence alignment."
+            )
+
+    def __init__(
+        self,
+        config: MiniMaxH3DiTConfig,
+        hf_config: dict[str, Any],
+        quant_config: QuantizationConfig | None = None,
+    ) -> None:
+        super().__init__(config=config, hf_config=hf_config)
+        arch = config.arch_config
+        self.arch = arch
+        self.hidden_size = arch.hidden_size
+        self.num_attention_heads = arch.num_attention_heads
+        self.num_channels_latents = arch.latents_dim
+        tp_size = get_tp_world_size()
+        ulysses_size, _ = _ulysses_ctx()
+        self._validate_tp_config(arch=arch, tp_size=tp_size)
+        self._validate_sequence_parallel_config(
+            arch=arch,
+            tp_size=tp_size,
+            ulysses_size=ulysses_size,
+            ring_size=_ring_world_size(),
+        )
+
+        self.video_patch_proj = ColumnParallelLinear(
+            arch.latents_dim
+            * arch.patch_size[0]
+            * arch.patch_size[1]
+            * arch.patch_size[2],
+            arch.hidden_size,
+            bias=True,
+            gather_output=True,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix="video_patch_proj",
+        )
+        self.audio_patch_proj = ColumnParallelLinear(
+            arch.audio_latents_dim,
+            arch.hidden_size,
+            bias=True,
+            gather_output=True,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix="audio_patch_proj",
+        )
+        self.condition_proj = ColumnParallelLinear(
+            arch.text_dim,
+            arch.hidden_size,
+            bias=True,
+            gather_output=True,
+            params_dtype=_BF16_DTYPE,
+            quant_config=quant_config,
+            prefix="condition_proj",
+        )
+        self.time_embedder = MiniMaxH3TimeEmbedder(
+            arch,
+            prefix="time_embedder",
+        )
+        self.rope = MiniMaxH3Rope(arch.rope_inv_freq_len)
+        self.token_refiner = MiniMaxH3TokenRefiner(
+            arch,
+            quant_config,
+            prefix="token_refiner",
+        )
+        self.blocks = nn.ModuleList(
+            [
+                MiniMaxH3DiTBlock(
+                    arch,
+                    quant_config,
+                    prefix=f"blocks.{index}",
+                )
+                for index in range(arch.num_layers)
+            ]
+        )
+        self.layer_names = ["blocks"]
+        self.final_layer = MiniMaxH3FinalLayer(
+            arch,
+            quant_config,
+            prefix="final_layer",
+        )
+        self._resolved_attention_backend: AttentionBackendEnum | None = None
+        self._mark_missing_params_required()
+
+    def _resolve_attention_backend_once(self) -> None:
+        if self._resolved_attention_backend is not None:
+            return
+        backend = get_attn_backend(
+            self.arch.attention_head_dim,
+            _BF16_DTYPE,
+            supported_attention_backends=self._supported_attention_backends,
+        )
+        for module in self.modules():
+            if isinstance(module, MiniMaxH3Attention):
+                module._set_attention_backend(backend)
+        self._resolved_attention_backend = backend.get_enum()
+
+    def _mark_missing_params_required(self) -> None:
+        for _, param in self.named_parameters():
+            param.missing_param_init = "error"
+
+    def post_load_weights(self) -> None:
+        for name in _MINIMAX_H3_FP32_PARAM_NAMES_IN_MODEL_ORDER:
+            param = self.get_parameter(name)
+            if param.dtype != _FP32_DTYPE:
+                raise ValueError(
+                    f"{name} must stay fp32 after load, got {param.dtype}."
+                )
+        # assign=True loading may re-register this persistent buffer as a parameter
+        rope_inv_freq = self.rope.inv_freq
+        if rope_inv_freq.dtype != _FP32_DTYPE:
+            raise ValueError(
+                f"rope.inv_freq must stay fp32 after load, got {rope_inv_freq.dtype}."
+            )
+
+    @staticmethod
+    def _pos_ids(pos_info: Any, key: str) -> torch.Tensor:
+        if isinstance(pos_info, dict):
+            ids = pos_info.get("position_ids")
+        else:
+            ids = getattr(pos_info, "position_ids", None)
+        if ids is None:
+            raise ValueError(f"{key}.position_ids is required")
+        return ids.view(-1).to(torch.long)
+
+    @staticmethod
+    def _psp_field(psp: Any, key: str, field: str) -> Any:
+        if isinstance(psp, dict):
+            value = psp.get(field)
+        else:
+            value = getattr(psp, field, None)
+        if value is None:
+            raise ValueError(f"{key}.{field} is required")
+        return value
+
+    @staticmethod
+    def _psp_optional_field(psp: Any, field: str) -> Any:
+        if isinstance(psp, dict):
+            return psp.get(field)
+        return getattr(psp, field, None)
+
+    def refine_prompt_embeds(
+        self,
+        prompt_embeds: torch.Tensor,
+        refiner_cu_seqlens: torch.Tensor,
+        *,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Project and refine request-static text conditioning once."""
+        text_len = int(refiner_cu_seqlens[1].item())
+        if text_len <= 0 or text_len > int(prompt_embeds.shape[0]):
+            raise ValueError(
+                "refiner cu_seqlens live text length must be in "
+                f"[1, {int(prompt_embeds.shape[0])}], got {text_len}"
+            )
+        text_rows = prompt_embeds[:text_len].to(device=device, dtype=_BF16_DTYPE)
+        true_refiner_cu = torch.stack(
+            (
+                refiner_cu_seqlens[0],
+                refiner_cu_seqlens[1],
+                refiner_cu_seqlens[1],
+            )
+        )
+        text_embed, _ = self.condition_proj(text_rows)
+        return self.token_refiner(
+            text_embed,
+            cu_seqlens=true_refiner_cu,
+            cu_seqlens_host=(0, text_len, text_len),
+            max_seqlen=text_len,
+        )
+
+    def build_rope_cache(
+        self,
+        img_position_ids: torch.Tensor,
+        *,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build request-static RoPE inputs for this Ulysses rank."""
+        if img_position_ids.dim() != 3 or img_position_ids.shape[0] != 1:
+            raise ValueError(
+                "img_position_ids must be [1, S, 3], got "
+                f"{list(img_position_ids.shape)}"
+            )
+        seq_len = int(img_position_ids.shape[1])
+        sp_ws, sp_rank = _ulysses_ctx()
+        if seq_len % sp_ws:
+            raise ValueError(
+                f"packed seq_len {seq_len} not divisible by ulysses world size {sp_ws}"
+            )
+        local_seq_len = seq_len // sp_ws
+        row_start = sp_rank * local_seq_len
+        rope_freqs = self.rope(
+            img_position_ids[:, row_start : row_start + local_seq_len]
+        ).to(device)
+        return (
+            _rope_cos_sin_cache(rope_freqs, dtype=_BF16_DTYPE),
+            torch.arange(
+                local_seq_len,
+                device=device,
+                dtype=torch.long,
+            ),
+        )
+
+    @eager_on_graph(True)
+    def _embed(
+        self,
+        *,
+        x: torch.Tensor,
+        audio_x: torch.Tensor,
+        text_embeddings_selected: torch.Tensor,
+        unique_timesteps: torch.Tensor,
+        img_pos: torch.Tensor,
+        audio_pos: torch.Tensor,
+        text_pos: torch.Tensor,
+        refiner_cu_seqlens: torch.Tensor,
+        refiner_max_seqlen: int,
+        row_start: int,
+        row_stop: int,
+        device: torch.device,
+        refined_prompt_embeds_length: int | torch.Tensor | None = None,
+        local_embedding_layout: dict[str, torch.Tensor | int] | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build embeddings for one contiguous block-stack row shard.
+
+        Returns (decoder_input [S_local, H] bf16, t_emb [M, t_dim] fp32).
+        """
+        # BCG pads the prompt tensor only to stabilize its input signature.
+        # Raw-input callers recover the live length from refiner metadata;
+        # request-static refined inputs carry it as a host integer and avoid a
+        # per-step device scalar read. Running the refiner at the bucketed M
+        # dimension changes GEMM selection and is not bitwise equivalent.
+        if refined_prompt_embeds_length is None:
+            text_len = int(refiner_cu_seqlens[1].item())
+        elif torch.is_tensor(refined_prompt_embeds_length):
+            # BCG turns this request-varying host constant into a scalar input
+            # so different live lengths can replay one padded-text signature.
+            # _embed is an eager graph break, so this value is read outside
+            # captured CUDA graphs.
+            text_len = int(refined_prompt_embeds_length.item())
+        else:
+            text_len = int(refined_prompt_embeds_length)
+        if text_len <= 0 or text_len > int(text_embeddings_selected.shape[0]):
+            raise ValueError(
+                "refiner cu_seqlens live text length must be in "
+                f"[1, {int(text_embeddings_selected.shape[0])}], got {text_len}"
+            )
+        text_pos = text_pos[:text_len]
+        if refined_prompt_embeds_length is not None:
+            text_embed = text_embeddings_selected[:text_len].to(
+                device=device, dtype=_BF16_DTYPE
+            )
+            if int(text_embed.shape[-1]) != self.hidden_size:
+                raise ValueError(
+                    "refined prompt embeddings must have hidden width "
+                    f"{self.hidden_size}, got {int(text_embed.shape[-1])}"
+                )
+        else:
+            text_embed = self.refine_prompt_embeds(
+                text_embeddings_selected,
+                refiner_cu_seqlens,
+                device=device,
+            )
+
+        local_seq_len = row_stop - row_start
+        trusted_layout = local_embedding_layout is not None
+        if trusted_layout:
+            used_len = text_len + int(img_pos.numel()) + int(audio_pos.numel())
+            local_live_rows = min(max(used_len - row_start, 0), local_seq_len)
+            embeddings = torch.empty(
+                (local_seq_len, self.hidden_size), device=device, dtype=_BF16_DTYPE
+            )
+            if local_live_rows < local_seq_len:
+                embeddings[local_live_rows:].zero_()
+        else:
+            # Direct model callers do not provide the serving-time partition
+            # contract. Preserve their historical zero-fill/add semantics for
+            # sparse or overlapping row maps.
+            embeddings = torch.zeros(
+                (local_seq_len, self.hidden_size), device=device, dtype=_BF16_DTYPE
+            )
+
+        if local_embedding_layout is None:
+            text_source_ids = torch.nonzero(
+                (text_pos >= row_start) & (text_pos < row_stop),
+                as_tuple=False,
+            ).view(-1)
+            text_row_ids = text_pos.index_select(0, text_source_ids) - row_start
+            img_global_ids = img_pos.index_select(
+                0,
+                torch.nonzero(
+                    (img_pos >= row_start) & (img_pos < row_stop),
+                    as_tuple=False,
+                ).view(-1),
+            )
+            img_row_ids = img_global_ids - row_start
+            audio_global_ids = audio_pos.index_select(
+                0,
+                torch.nonzero(
+                    (audio_pos >= row_start) & (audio_pos < row_stop),
+                    as_tuple=False,
+                ).view(-1),
+            )
+            audio_row_ids = audio_global_ids - row_start
+        else:
+            text_source_start = int(local_embedding_layout["text_source_start"])
+            text_source_stop = int(local_embedding_layout["text_source_stop"])
+            img_global_ids = local_embedding_layout["img_global_ids"]
+            img_row_ids = local_embedding_layout["img_row_ids"]
+            audio_global_ids = local_embedding_layout["audio_global_ids"]
+            audio_row_ids = local_embedding_layout["audio_row_ids"]
+
+        write_rows = embeddings.index_copy_ if trusted_layout else embeddings.index_add_
+        if trusted_layout:
+            text_rows = text_source_stop - text_source_start
+            if text_rows:
+                embeddings[:text_rows].copy_(
+                    text_embed[text_source_start:text_source_stop]
+                )
+        elif text_row_ids.numel():
+            write_rows(
+                0,
+                text_row_ids,
+                text_embed.index_select(0, text_source_ids).to(_BF16_DTYPE),
+            )
+
+        # latent embedders stay fp32; only rows owned by this SP rank are
+        # projected, then cast during scattering into the bf16 sequence
+        if img_row_ids.numel():
+            x_rows = (
+                x.view(-1, x.shape[-1]).index_select(0, img_global_ids).to(_FP32_DTYPE)
+            )
+            video_embed, _ = self.video_patch_proj(x_rows)
+            write_rows(
+                0,
+                img_row_ids,
+                video_embed.to(_BF16_DTYPE),
+            )
+
+        if audio_row_ids.numel():
+            audio_rows = (
+                audio_x.view(-1, audio_x.shape[-1])
+                .index_select(0, audio_global_ids)
+                .to(_FP32_DTYPE)
+            )
+            audio_embed, _ = self.audio_patch_proj(audio_rows)
+            write_rows(
+                0,
+                audio_row_ids,
+                audio_embed.to(_BF16_DTYPE),
+            )
+
+        t_emb = self.time_embedder(unique_timesteps)
+        return embeddings, t_emb
+
+    def forward(self, **kwargs: Any) -> tuple[torch.Tensor, torch.Tensor]:
+        """Packed inference forward.
+
+        Keyword names follow the checkpoint's serving contract.
+        Returns `(video_logits, audio_logits)` from rows selected by
+        `img_pos_for_infer_output_info` and `audio_pos_info`, with condition
+        rows zeroed by update masks.
+        """
+        # Strict keyword contract: refuse any kwarg forward does not consume.
+        unexpected = sorted(set(kwargs) - _FORWARD_SUPPORTED_KWARGS)
+        if unexpected:
+            raise TypeError(
+                "MiniMaxH3DiTModel.forward received unexpected kwargs: "
+                f"{unexpected}; supported kwargs: "
+                f"{sorted(_FORWARD_SUPPORTED_KWARGS)}"
+            )
+
+        x = _required_kwarg(kwargs, "x")
+        audio_x = _required_kwarg(kwargs, "audio_x")
+        img_position_ids = _required_kwarg(kwargs, "img_position_ids")
+        unique_timesteps = _required_kwarg(kwargs, "unique_timesteps")
+        inverse_indices = (
+            _required_kwarg(kwargs, "inverse_indices").view(-1).to(torch.long)
+        )
+        update_mask = _required_kwarg(kwargs, "update_mask")
+        block_token_tags = kwargs.get("block_token_tags")
+        token_tags = kwargs.get("token_tags")
+        if block_token_tags is None:
+            token_tags = _required_kwarg(kwargs, "token_tags").view(-1).to(torch.long)
+        else:
+            block_token_tags = block_token_tags.view(-1).to(torch.long)
+            token_tags = None
+        skip_mask_out_condition = bool(kwargs.get("skip_mask_out_condition", False))
+
+        text_selected = _required_kwarg(kwargs, "prompt_embeds")
+
+        img_pos = self._pos_ids(_required_kwarg(kwargs, "img_pos_info"), "img_pos_info")
+        audio_pos = self._pos_ids(
+            _required_kwarg(kwargs, "audio_pos_info"), "audio_pos_info"
+        )
+        text_pos = self._pos_ids(
+            _required_kwarg(kwargs, "text_pos_info"),
+            "text_pos_info",
+        )
+        infer_out_pos = self._pos_ids(
+            _required_kwarg(kwargs, "img_pos_for_infer_output_info"),
+            "img_pos_for_infer_output_info",
+        )
+
+        psp = _required_kwarg(kwargs, "packed_seq_params")
+        cu_seqlens = self._psp_field(psp, "packed_seq_params", "cu_seqlens_q").to(
+            torch.int32
+        )
+        raw_cu_seqlens_host = self._psp_optional_field(psp, "cu_seqlens_q_host")
+        cu_seqlens_host = tuple(
+            int(value)
+            for value in (
+                cu_seqlens.tolist()
+                if raw_cu_seqlens_host is None
+                else raw_cu_seqlens_host
+            )
+        )
+        max_seqlen = int(self._psp_field(psp, "packed_seq_params", "max_seqlen_q"))
+        refiner_psp = _required_kwarg(kwargs, "refiner_packed_seq_params")
+        refiner_cu = self._psp_field(
+            refiner_psp, "refiner_packed_seq_params", "cu_seqlens_q"
+        ).to(torch.int32)
+        refiner_max = int(
+            self._psp_field(refiner_psp, "refiner_packed_seq_params", "max_seqlen_q")
+        )
+
+        if x.dim() != 3 or x.shape[0] != 1:
+            raise ValueError(f"x must be [1, S, C], got {list(x.shape)}")
+        seq_len = int(x.shape[1])
+        if token_tags is not None and token_tags.shape[0] != seq_len:
+            raise ValueError(
+                "token_tags must cover the full packed sequence "
+                f"({seq_len}), got {token_tags.shape[0]}."
+            )
+        if inverse_indices.shape[0] != seq_len:
+            raise ValueError(
+                f"inverse_indices must be [{seq_len}], got {list(inverse_indices.shape)}"
+            )
+        _sol_engine_context = None
+        if _sol_engine_enabled():
+            _sol_engine_context = _sol_engine_begin_model_forward(
+                unique_timesteps=unique_timesteps,
+                text_positions=text_pos,
+                image_positions=img_pos,
+                audio_positions=audio_pos,
+                cu_seqlens_host=cu_seqlens_host,
+                total_tokens=seq_len,
+                num_layers=len(self.blocks),
+            )
+        device = x.device
+        self._resolve_attention_backend_once()
+        if _ring_world_size() != 1:
+            raise NotImplementedError(
+                "MiniMax H3 packed multi-segment attention requires "
+                "--ring-degree 1; Ring and mixed USP are unsupported."
+            )
+
+        sp_ws, sp_rank = _ulysses_ctx()
+        local_seq_len = seq_len
+        if sp_ws > 1:
+            if seq_len % sp_ws:
+                raise ValueError(
+                    f"packed seq_len {seq_len} not divisible by ulysses "
+                    f"world size {sp_ws}"
+                )
+            local_heads = self.num_attention_heads // get_tp_world_size()
+            if local_heads % sp_ws:
+                raise ValueError(
+                    f"TP-local heads {local_heads} not divisible by Ulysses "
+                    f"world size {sp_ws} (total heads={self.num_attention_heads}, "
+                    f"TP={get_tp_world_size()})"
+                )
+            local_seq_len = seq_len // sp_ws
+        row_start = sp_rank * local_seq_len
+        row_stop = row_start + local_seq_len
+
+        # RoPE and latent projections are row-local before Ulysses exchanges
+        # sequence for heads inside attention. Serving normally prepares the
+        # request-static cache once; direct model callers use this fallback.
+        rope_cache = kwargs.get("rope_cache")
+        if rope_cache is None:
+            rope_freqs = self.rope(img_position_ids[:, row_start:row_stop]).to(device)
+            rope_cache = (
+                _rope_cos_sin_cache(rope_freqs, dtype=_BF16_DTYPE),
+                torch.arange(
+                    local_seq_len,
+                    device=device,
+                    dtype=torch.long,
+                ),
+            )
+        img_pos = img_pos.to(device)
+        audio_pos = audio_pos.to(device)
+        text_pos = text_pos.to(device)
+
+        decoder_input, t_emb = self._embed(
+            x=x,
+            audio_x=audio_x,
+            text_embeddings_selected=text_selected,
+            unique_timesteps=unique_timesteps.view(-1).to(device),
+            img_pos=img_pos,
+            audio_pos=audio_pos,
+            text_pos=text_pos,
+            refiner_cu_seqlens=refiner_cu.to(device),
+            refiner_max_seqlen=refiner_max,
+            row_start=row_start,
+            row_stop=row_stop,
+            device=device,
+            refined_prompt_embeds_length=kwargs.get("refined_prompt_embeds_length"),
+            local_embedding_layout=kwargs.get("local_embedding_layout"),
+        )
+        # request-step AdaLN input shared by all blocks
+        adaln_input = nn.functional.silu(t_emb).to(_BF16_DTYPE)
+        inverse_indices = inverse_indices.to(device)
+        block_inverse = inverse_indices[row_start:row_stop]
+        if block_token_tags is None:
+            assert token_tags is not None
+            token_tags = token_tags.to(device)
+            block_token_tags = token_tags[row_start:row_stop].clamp(min=0)
+        else:
+            block_token_tags = block_token_tags.to(device)
+            if block_token_tags.shape[0] != local_seq_len:
+                raise ValueError(
+                    "block_token_tags must cover the rank-local packed sequence "
+                    f"({local_seq_len}), got {block_token_tags.shape[0]}."
+                )
+        block_combined = kwargs.get("block_combined_indices")
+        if block_combined is None:
+            block_combined = torch.add(
+                block_token_tags,
+                block_inverse,
+                alpha=MINIMAX_H3_ADALN_MODALITY_NUM,
+            )
+
+        firstblockcache_enabled = _sol_engine_cache_enabled()
+        easycache_enabled = _sol_engine_easycache_enabled()
+        if firstblockcache_enabled and easycache_enabled:
+            raise RuntimeError(
+                "MiniMax-H3 cannot enable EasyCache and FirstBlockCache together"
+            )
+        hidden = decoder_input
+        cache_action = None
+        if easycache_enabled:
+            if _sol_engine_context is None:
+                raise RuntimeError("MiniMax-H3 cache context was not initialized")
+            hidden, cache_action = _sol_engine_easycache_before_blocks(
+                hidden,
+                context=_sol_engine_context,
+            )
+        cu_seqlens = cu_seqlens.to(device)
+        block_adaln_params = None
+        if cache_action != "reuse" and self._can_batch_block_adaln():
+            local_adaln = torch.stack(
+                [block.adaln_proj.project_local(adaln_input) for block in self.blocks]
+            )
+            gathered_adaln = tensor_model_parallel_all_gather(local_adaln)
+            block_adaln_params = tuple(
+                block.adaln_proj.split_output(output)
+                for block, output in zip(self.blocks, gathered_adaln)
+            )
+        first_tail_index = 0
+        if firstblockcache_enabled:
+            if _sol_engine_context is None:
+                raise RuntimeError("MiniMax-H3 cache context was not initialized")
+            head_input = hidden.detach().clone()
+            hidden = self.blocks[0](
+                hidden,
+                adaln_input=adaln_input,
+                combined_indices=block_combined,
+                rope_cache=rope_cache,
+                cu_seqlens=cu_seqlens,
+                cu_seqlens_host=cu_seqlens_host,
+                max_seqlen=max_seqlen,
+                ulysses_active=sp_ws > 1,
+                adaln_params=(
+                    None if block_adaln_params is None else block_adaln_params[0]
+                ),
+            )
+            hidden, cache_action = _sol_engine_cache_after_head(
+                head_input,
+                hidden,
+                context=_sol_engine_context,
+            )
+            first_tail_index = 1
+        # With Ulysses sequence parallelism, shard rows across the group for
+        # the block stack. Attention trades sequence for heads internally;
+        # everything else, including the final layer, is row-local.
+        if cache_action != "reuse":
+            for index in range(first_tail_index, len(self.blocks)):
+                block = self.blocks[index]
+                hidden = block(
+                    hidden,
+                    adaln_input=adaln_input,
+                    combined_indices=block_combined,
+                    rope_cache=rope_cache,
+                    cu_seqlens=cu_seqlens,
+                    cu_seqlens_host=cu_seqlens_host,
+                    max_seqlen=max_seqlen,
+                    ulysses_active=sp_ws > 1,
+                    adaln_params=(
+                        None
+                        if block_adaln_params is None
+                        else block_adaln_params[index]
+                    ),
+                )
+        if firstblockcache_enabled and cache_action == "compute":
+            hidden = _sol_engine_cache_after_tail(
+                hidden,
+                context=_sol_engine_context,
+            )
+        if easycache_enabled and cache_action == "compute":
+            hidden = _sol_engine_easycache_after_blocks(
+                hidden,
+                context=_sol_engine_context,
+            )
+        video_logits, audio_logits = self.final_layer(
+            hidden,
+            adaln_input=adaln_input,
+            inverse_indices=block_inverse,
+        )
+        if sp_ws > 1:
+            from sglang.multimodal_gen.runtime.distributed.parallel_state import (
+                get_sp_group,
+            )
+
+            video_width = video_logits.shape[-1]
+            logits = get_sp_group().all_gather(
+                torch.cat((video_logits, audio_logits), dim=-1), dim=0
+            )
+            video_logits, audio_logits = logits.split(
+                (video_width, logits.shape[-1] - video_width), dim=-1
+            )
+
+        # Preserve the full-row output GEMM (and therefore its numerical
+        # contract), but defer TP column gathers until after dead text/padding
+        # rows have been removed. For hybrid TP+Ulysses, the preceding SP row
+        # gather also carries only the TP-local output width.
+        video_logits = video_logits.index_select(0, infer_out_pos.to(device))
+        audio_logits = audio_logits.index_select(0, audio_pos.to(device))
+        if get_tp_world_size() > 1:
+            video_logits = tensor_model_parallel_all_gather(video_logits)
+            audio_logits = tensor_model_parallel_all_gather(audio_logits)
+        if not skip_mask_out_condition:
+            update_mask = update_mask.view(-1).to(device)
+            if update_mask.shape[0] != video_logits.shape[0]:
+                raise ValueError(
+                    "update_mask length mismatch: "
+                    f"{update_mask.shape[0]} != {video_logits.shape[0]}"
+                )
+            video_logits = video_logits * update_mask.unsqueeze(-1)
+            # Audio has no condition rows in the supported tasks, so its
+            # derived update mask is all ones. Honor an explicit mask when
+            # provided.
+            update_audio_mask = kwargs.get("update_audio_mask")
+            if update_audio_mask is not None:
+                audio_logits = audio_logits * update_audio_mask.view(-1).unsqueeze(-1)
+        return video_logits, audio_logits
+
+
+EntryClass = MiniMaxH3DiTModel
+
+__all__ = [
+    "MINIMAX_H3_FP32_BUFFER_NAMES",
+    "MINIMAX_H3_FP32_PARAM_NAMES",
+    "MiniMaxH3DiTModel",
+    "_reorder_grouped_qkv_to_qkv",
+]

--- a/models/minimax_h3/h100_a100/profiles.py
+++ b/models/minimax_h3/h100_a100/profiles.py
@@ -1,0 +1,184 @@
+"""Locked MiniMax-H3 profiles shared by H100 and A100."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+
+PINNED_IMAGE = (
+    "docker://lmsysorg/sglang:nightly-dev-cu13-20260803-12eadf86"
+)
+PINNED_MODEL_REVISION = "bfc8ed0353f5a9733be73e6b2c98ec0948195b86"
+PINNED_SGLANG_MODEL_SHA256 = (
+    "5f87319969c446685ee93d422fc34a7c040defb238eff2274d664f2f8310e997"
+)
+
+
+@dataclass(frozen=True)
+class HardwareProfile:
+    name: str
+    display_name: str
+    capability: tuple[int, int]
+    sol_backend: str
+
+
+@dataclass(frozen=True)
+class RuntimeProfile:
+    name: str
+    sol_attention: bool
+    tau: float
+    threshold_type: str
+    dense_steps: int
+    dense_layers: int
+    cache: str
+    cache_threshold: float
+    easycache_retain_steps: int = 0
+    easycache_cooldown_steps: int = 0
+    easycache_max_hits: int = 0
+
+
+HARDWARE = {
+    "h100": HardwareProfile(
+        name="h100",
+        display_name="4x NVIDIA H100 80GB HBM3",
+        capability=(9, 0),
+        sol_backend="cute_sm90",
+    ),
+    "a100": HardwareProfile(
+        name="a100",
+        display_name="4x NVIDIA A100-SXM4-80GB",
+        capability=(8, 0),
+        sol_backend="triton",
+    ),
+}
+
+
+PROFILES = {
+    "dense": RuntimeProfile(
+        name="dense",
+        sol_attention=False,
+        tau=1.0,
+        threshold_type="exact",
+        dense_steps=10,
+        dense_layers=2,
+        cache="none",
+        cache_threshold=0.08,
+    ),
+    "quality": RuntimeProfile(
+        name="quality",
+        sol_attention=True,
+        tau=0.5,
+        threshold_type="diag",
+        dense_steps=15,
+        dense_layers=2,
+        cache="easycache",
+        cache_threshold=0.30,
+        easycache_retain_steps=10,
+        easycache_cooldown_steps=4,
+        easycache_max_hits=1,
+    ),
+    "balanced": RuntimeProfile(
+        name="balanced",
+        sol_attention=True,
+        tau=1.0,
+        threshold_type="diag",
+        dense_steps=10,
+        dense_layers=2,
+        cache="easycache",
+        cache_threshold=0.30,
+        easycache_retain_steps=6,
+        easycache_cooldown_steps=4,
+        easycache_max_hits=2,
+    ),
+    "aggressive": RuntimeProfile(
+        name="aggressive",
+        sol_attention=True,
+        tau=1.0,
+        threshold_type="diag",
+        dense_steps=10,
+        dense_layers=2,
+        cache="firstblock",
+        cache_threshold=0.08,
+    ),
+    "fullopt_exact": RuntimeProfile(
+        name="fullopt_exact",
+        sol_attention=True,
+        tau=1.0,
+        threshold_type="exact",
+        dense_steps=10,
+        dense_layers=2,
+        cache="firstblock",
+        cache_threshold=0.08,
+    ),
+}
+
+
+def _locked_env(name: str, value: str) -> None:
+    current = os.environ.get(name)
+    if current is not None and current != value:
+        raise RuntimeError(
+            f"{name} is locked by the selected MiniMax-H3 profile: "
+            f"expected {value!r}, got {current!r}"
+        )
+    os.environ[name] = value
+
+
+def configure_runtime() -> tuple[HardwareProfile, RuntimeProfile]:
+    """Resolve one hardware/profile pair and lock its algorithm settings."""
+
+    hardware_name = os.environ.get("H3_HARDWARE", "h100").strip().lower()
+    profile_name = os.environ.get("H3_SOL_PROFILE", "dense").strip().lower()
+    try:
+        hardware = HARDWARE[hardware_name]
+    except KeyError as exc:
+        raise ValueError("H3_HARDWARE must be h100 or a100") from exc
+    try:
+        profile = PROFILES[profile_name]
+    except KeyError as exc:
+        raise ValueError(
+            "H3_SOL_PROFILE must be dense, quality, balanced, aggressive, "
+            "or fullopt_exact"
+        ) from exc
+
+    values = {
+        "H3_NUM_GPUS": "4",
+        "H3_ULYSSES_DEGREE": "4",
+        "H3_MODEL_REVISION": PINNED_MODEL_REVISION,
+        "H3_OFFLOAD": "0",
+        "H3_TORCH_COMPILE": "0",
+        "H3_REORDER": "0",
+        "H3_POLICY_NAME": profile.name,
+        "H3_SOL_ATTN": "1" if profile.sol_attention else "0",
+        "H3_SOL_TAU": str(profile.tau),
+        "H3_SOL_THRESH_TYPE": profile.threshold_type,
+        "H3_SOL_DENSE_STEPS": str(profile.dense_steps),
+        "H3_SOL_DENSE_LAYERS": str(profile.dense_layers),
+        "H3_SOL_SINK_MODE": "prefix",
+        "H3_SOL_DENSITY_MODE": "warmup",
+        "H3_SOL_CORRECTNESS_GATE": "1",
+        "H3_FIRSTBLOCKCACHE": "1" if profile.cache == "firstblock" else "0",
+        "H3_EASYCACHE": "1" if profile.cache == "easycache" else "0",
+        "H3_CACHE_THRESHOLD": str(profile.cache_threshold),
+        "H3_EASYCACHE_THRESHOLD": str(profile.cache_threshold),
+        "H3_EASYCACHE_RETAIN_STEPS": str(profile.easycache_retain_steps),
+        "H3_EASYCACHE_COOLDOWN_STEPS": str(profile.easycache_cooldown_steps),
+        "H3_EASYCACHE_MAX_HITS": str(profile.easycache_max_hits),
+        "H3_EXPECTED_SOL_BACKEND": hardware.sol_backend,
+        "SOL_ATTN_STRICT": "1",
+    }
+    for name, value in values.items():
+        _locked_env(name, value)
+    return hardware, profile
+
+
+__all__ = [
+    "HARDWARE",
+    "PINNED_IMAGE",
+    "PINNED_MODEL_REVISION",
+    "PINNED_SGLANG_MODEL_SHA256",
+    "PROFILES",
+    "HardwareProfile",
+    "RuntimeProfile",
+    "configure_runtime",
+]

--- a/models/minimax_h3/h100_a100/registration.py
+++ b/models/minimax_h3/h100_a100/registration.py
@@ -1,0 +1,50 @@
+"""Register the H100/A100 MiniMax-H3 model without patching SGLang."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+from pathlib import Path
+
+from .profiles import (
+    PINNED_SGLANG_MODEL_SHA256,
+    HardwareProfile,
+    RuntimeProfile,
+    configure_runtime,
+)
+
+
+UPSTREAM_MODEL_MODULE = "sglang.multimodal_gen.runtime.models.dits.minimax_h3"
+
+
+def _verify_upstream_model() -> Path:
+    spec = importlib.util.find_spec(UPSTREAM_MODEL_MODULE)
+    if spec is None or spec.origin is None:
+        raise RuntimeError(f"Pinned SGLang module is unavailable: {UPSTREAM_MODEL_MODULE}")
+    path = Path(spec.origin)
+    actual = hashlib.sha256(path.read_bytes()).hexdigest()
+    if actual != PINNED_SGLANG_MODEL_SHA256:
+        raise RuntimeError(
+            f"Unexpected SGLang MiniMax-H3 source: {actual}; "
+            f"expected {PINNED_SGLANG_MODEL_SHA256}"
+        )
+    return path
+
+
+def register_runtime() -> tuple[HardwareProfile, RuntimeProfile]:
+    """Install the process-local model entry used by sparse/cache profiles."""
+
+    hardware, profile = configure_runtime()
+    _verify_upstream_model()
+    if not profile.sol_attention and profile.cache == "none":
+        return hardware, profile
+
+    from .model import MiniMaxH3DiTModel
+    from sglang.multimodal_gen.runtime.models.registry import ModelRegistry
+
+    ModelRegistry.register_model("MiniMaxH3DiTModel", MiniMaxH3DiTModel)
+    ModelRegistry.register_model("MiniMaxH3Transformer3DModel", MiniMaxH3DiTModel)
+    return hardware, profile
+
+
+__all__ = ["register_runtime"]

--- a/models/minimax_h3/h100_a100/scripts/run_minimax_h3_gpu.sh
+++ b/models/minimax_h3/h100_a100/scripts/run_minimax_h3_gpu.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${OUT_DIR:?OUT_DIR must be set by scripts/launch_candidate.py}"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+RUNTIME_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd -P)
+REPO_ROOT=$(cd "${RUNTIME_ROOT}/../../.." && pwd -P)
+
+export H3_CONTAINER_RUNTIME=${H3_CONTAINER_RUNTIME:-none}
+requested_runtime=${H3_CONTAINER_RUNTIME}
+export H3_CONTAINER_IMAGE=${H3_CONTAINER_IMAGE:-docker://lmsysorg/sglang:nightly-dev-cu13-20260803-12eadf86}
+export H3_MODEL_PATH=${H3_MODEL_PATH:-MiniMaxAI/MiniMax-H3}
+export H3_MODEL_REVISION=${H3_MODEL_REVISION:-bfc8ed0353f5a9733be73e6b2c98ec0948195b86}
+export H3_PROMPT_FILE=${H3_PROMPT_FILE:-${REPO_ROOT}/models/minimax_h3/prompts/t2va_example_1.json}
+export H3_WARMUP_NUM_STEPS=${H3_WARMUP_NUM_STEPS:-50}
+export H3_MEASURED_NUM_STEPS=${H3_MEASURED_NUM_STEPS:-50}
+export H3_DURATION_SECONDS=${H3_DURATION_SECONDS:-5.166667}
+export H3_SEED=${H3_SEED:-0}
+export H3_WARMUP_SEED=${H3_WARMUP_SEED:-10000}
+export H3_MASTER_PORT=${H3_MASTER_PORT:-30005}
+export H3_MODEL_SUBFOLDER=${H3_MODEL_SUBFOLDER:-}
+export H3_EXPECTED_TORCH=${H3_EXPECTED_TORCH:-2.11.0+cu130}
+export H3_EXPECTED_TRITON=${H3_EXPECTED_TRITON:-3.6.0}
+export H3_STORAGE_ROOT=${H3_STORAGE_ROOT:-${REPO_ROOT}}
+export H3_CACHE_ROOT=${H3_CACHE_ROOT:-${H3_STORAGE_ROOT}/cache}
+export H3_SGLANG_PYTHON_ROOT=${H3_SGLANG_PYTHON_ROOT:-/sgl-workspace/sglang/python}
+export H3_PYTHON_BIN=${H3_PYTHON_BIN:-python3}
+export OUT_DIR
+
+if [[ "${H3_PROMPT_FILE}" != /* ]]; then
+  export H3_PROMPT_FILE=${REPO_ROOT}/${H3_PROMPT_FILE}
+fi
+
+export OMP_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export NUMEXPR_NUM_THREADS=1
+export TOKENIZERS_PARALLELISM=false
+export PYTHONUNBUFFERED=1
+export HF_HOME=${HF_HOME:-${H3_CACHE_ROOT}/huggingface}
+export HUGGINGFACE_HUB_CACHE=${HUGGINGFACE_HUB_CACHE:-${HF_HOME}/hub}
+export HF_HUB_DISABLE_XET=${HF_HUB_DISABLE_XET:-1}
+export HF_HUB_DOWNLOAD_TIMEOUT=${HF_HUB_DOWNLOAD_TIMEOUT:-600}
+export TRITON_CACHE_DIR=${TRITON_CACHE_DIR:-${H3_CACHE_ROOT}/triton}
+export TORCH_HOME=${TORCH_HOME:-${H3_CACHE_ROOT}/torch}
+export XDG_CACHE_HOME=${XDG_CACHE_HOME:-${H3_CACHE_ROOT}/xdg}
+export TMPDIR=${TMPDIR:-/tmp}
+export PYTHONPATH=${REPO_ROOT}:${REPO_ROOT}/techniques/sparse_backends:${H3_SGLANG_PYTHON_ROOT}${PYTHONPATH:+:${PYTHONPATH}}
+
+mkdir -p "${OUT_DIR}" "${HF_HOME}" "${TRITON_CACHE_DIR}" "${TORCH_HOME}" "${XDG_CACHE_HOME}" "${TMPDIR}"
+
+if [[ "${H3_CONTAINER_RUNTIME}" == none ]]; then
+  "${H3_PYTHON_BIN}" "${RUNTIME_ROOT}/gpu_infer.py" 2>&1 | tee "${OUT_DIR}/run.log"
+  exit "${PIPESTATUS[0]}"
+fi
+
+H3_STORAGE_ROOT=$(cd "${H3_STORAGE_ROOT}" && pwd -P)
+host_storage_root=${H3_STORAGE_ROOT}
+OUT_DIR=$(cd "${OUT_DIR}" && pwd -P)
+H3_CACHE_ROOT=$(cd "${H3_CACHE_ROOT}" && pwd -P)
+prompt_dir=$(cd "$(dirname "${H3_PROMPT_FILE}")" && pwd -P)
+H3_PROMPT_FILE=${prompt_dir}/$(basename "${H3_PROMPT_FILE}")
+
+require_below_storage() {
+  local label=$1
+  local path=$2
+  case "${path}" in
+    "${H3_STORAGE_ROOT}"|"${H3_STORAGE_ROOT}"/*) ;;
+    *)
+      echo "${label} must be below H3_STORAGE_ROOT for container runs: ${path}" >&2
+      exit 2
+      ;;
+  esac
+}
+
+to_inside_path() {
+  local path=$1
+  if [[ "${path}" == "${H3_STORAGE_ROOT}" ]]; then
+    printf '/h3'
+  else
+    printf '/h3/%s' "${path#${H3_STORAGE_ROOT}/}"
+  fi
+}
+
+require_below_storage REPO_ROOT "${REPO_ROOT}"
+require_below_storage OUT_DIR "${OUT_DIR}"
+require_below_storage H3_CACHE_ROOT "${H3_CACHE_ROOT}"
+require_below_storage H3_PROMPT_FILE "${H3_PROMPT_FILE}"
+inside_repo=$(to_inside_path "${REPO_ROOT}")
+inside_output=$(to_inside_path "${OUT_DIR}")
+inside_cache=$(to_inside_path "${H3_CACHE_ROOT}")
+inside_prompt=$(to_inside_path "${H3_PROMPT_FILE}")
+inside_model=${H3_MODEL_PATH}
+if [[ "${H3_MODEL_PATH}" == /* ]]; then
+  model_dir=$(cd "${H3_MODEL_PATH}" && pwd -P)
+  require_below_storage H3_MODEL_PATH "${model_dir}"
+  inside_model=$(to_inside_path "${model_dir}")
+fi
+
+export H3_CONTAINER_RUNTIME=none
+export H3_STORAGE_ROOT=/h3
+export H3_CACHE_ROOT=${inside_cache}
+export H3_PROMPT_FILE=${inside_prompt}
+export H3_MODEL_PATH=${inside_model}
+export OUT_DIR=${inside_output}
+export PYTHONPATH=${inside_repo}:${inside_repo}/techniques/sparse_backends:${H3_SGLANG_PYTHON_ROOT}
+export HF_HOME=${inside_cache}/huggingface
+export HUGGINGFACE_HUB_CACHE=${HF_HOME}/hub
+export TRITON_CACHE_DIR=${inside_cache}/triton
+export TORCH_HOME=${inside_cache}/torch
+export XDG_CACHE_HOME=${inside_cache}/xdg
+export TMPDIR=/tmp
+
+case "${requested_runtime}" in
+  pyxis)
+    container_env=OUT_DIR,PYTHONPATH,H3_CONTAINER_RUNTIME,H3_STORAGE_ROOT,H3_CACHE_ROOT,H3_SGLANG_PYTHON_ROOT,H3_PYTHON_BIN,H3_MODEL_PATH,H3_MODEL_REVISION,H3_MODEL_SUBFOLDER,H3_PROMPT_FILE,H3_WARMUP_NUM_STEPS,H3_MEASURED_NUM_STEPS,H3_DURATION_SECONDS,H3_SEED,H3_WARMUP_SEED,H3_MASTER_PORT,H3_HARDWARE,H3_SOL_PROFILE,H3_EXPECTED_TORCH,H3_EXPECTED_TRITON,HF_HOME,HUGGINGFACE_HUB_CACHE,HF_HUB_DISABLE_XET,HF_HUB_DOWNLOAD_TIMEOUT,HF_HUB_OFFLINE,TRITON_CACHE_DIR,TORCH_HOME,XDG_CACHE_HOME,TMPDIR,OMP_NUM_THREADS,OPENBLAS_NUM_THREADS,MKL_NUM_THREADS,NUMEXPR_NUM_THREADS,TOKENIZERS_PARALLELISM,PYTHONUNBUFFERED
+    exec srun \
+      --ntasks=1 \
+      --nodes=1 \
+      --container-image="${H3_CONTAINER_IMAGE}" \
+      --container-mounts="${host_storage_root}:/h3" \
+      --container-env="${container_env}" \
+      --no-container-mount-home \
+      --container-workdir="${inside_output}" \
+      --no-container-entrypoint \
+      bash "${inside_repo}/models/minimax_h3/h100_a100/scripts/run_minimax_h3_gpu.sh"
+    ;;
+  apptainer|singularity)
+    if ! command -v "${requested_runtime}" >/dev/null 2>&1; then
+      for init_script in /etc/profile.d/modules.sh /usr/share/Modules/init/bash; do
+        if [[ -f "${init_script}" ]]; then
+          # shellcheck disable=SC1090
+          source "${init_script}"
+          break
+        fi
+      done
+      module load "${H3_CONTAINER_MODULE:-singularity/4.4.1}"
+    fi
+    exec "${requested_runtime}" exec \
+      --nv \
+      --bind "${host_storage_root}:/h3" \
+      "${H3_CONTAINER_IMAGE}" \
+      bash "${inside_repo}/models/minimax_h3/h100_a100/scripts/run_minimax_h3_gpu.sh"
+    ;;
+  *)
+    echo "H3_CONTAINER_RUNTIME must be none, pyxis, apptainer, or singularity" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/launch_candidate.py
+++ b/scripts/launch_candidate.py
@@ -135,10 +135,18 @@ def merge_model_profile(data: dict[str, Any]) -> dict[str, Any]:
         return data
 
     merged = dict(data)
-    for key in ("submodule", "base_commit", "run_script", "eval_profile", "official_config"):
+    for key in ("submodule", "base_commit", "run_script", "eval_profile"):
         if key not in merged and key in profile:
             merged[key] = profile[key]
-    merged["env"] = {**profile.get("env", {}), **data.get("env", {})}
+    if profile.get("official_config") or data.get("official_config"):
+        merged["official_config"] = {
+            **profile.get("official_config", {}),
+            **data.get("official_config", {}),
+        }
+    profile_env = (
+        profile.get("env", {}) if data.get("inherit_profile_env", True) else {}
+    )
+    merged["env"] = {**profile_env, **data.get("env", {})}
     merged["slurm"] = {
         **default_slurm(merged, profile),
         **profile.get("slurm", {}),

--- a/techniques/sparse_backends/sol_attn/__init__.py
+++ b/techniques/sparse_backends/sol_attn/__init__.py
@@ -1,5 +1,5 @@
 """Sol-Attn."""
 
-from .interface import sol_attn
+from .interface import get_sol_attn_backend, sol_attn
 
-__all__ = ["sol_attn"]
+__all__ = ["get_sol_attn_backend", "sol_attn"]

--- a/techniques/sparse_backends/sol_attn/interface.py
+++ b/techniques/sparse_backends/sol_attn/interface.py
@@ -86,6 +86,14 @@ def _backend_for_arch(
     return "triton"
 
 
+def get_sol_attn_backend(device: torch.device | str | int | None = None) -> str:
+    """Return the backend selected for ``device`` without compiling it."""
+
+    if device is None:
+        device = torch.cuda.current_device()
+    return _backend_for_arch(tuple(torch.cuda.get_device_capability(device)))
+
+
 def _validate_cute(arch, tokens, kv_splits):
     if arch != (9, 0) and kv_splits != 1:
         raise ValueError("kv_splits=2/4 is currently available on SM90 only")
@@ -396,4 +404,4 @@ def sol_attn(
     )
 
 
-__all__ = ["sol_attn"]
+__all__ = ["get_sol_attn_backend", "sol_attn"]

--- a/tests/test_minimax_h3_h100_a100.py
+++ b/tests/test_minimax_h3_h100_a100.py
@@ -1,0 +1,175 @@
+"""Dependency-light contracts for the registered H100/A100 runtime."""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+import runpy
+import tomllib
+import unittest
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNTIME = ROOT / "models/minimax_h3/h100_a100"
+CANDIDATES = ROOT / "candidates"
+PINNED_IMAGE = "docker://lmsysorg/sglang:nightly-dev-cu13-20260803-12eadf86"
+
+
+def _candidate(hardware: str, profile: str) -> dict:
+    path = CANDIDATES / f"minimax_h3_{hardware}_{profile}.toml"
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def test_candidates_cover_both_hardware_targets_and_all_profiles() -> None:
+    profiles = ("dense", "quality", "balanced", "aggressive", "fullopt_exact")
+    for hardware in ("h100", "a100"):
+        for profile in profiles:
+            candidate = _candidate(hardware, profile)
+            assert candidate["env"]["H3_HARDWARE"] == hardware
+            assert candidate["env"]["H3_SOL_PROFILE"] == profile
+            assert candidate["env"]["H3_CONTAINER_IMAGE"] == PINNED_IMAGE
+            assert not candidate["inherit_profile_env"]
+            assert candidate["official_config"]["num_gpus"] == 4
+            assert candidate["official_config"]["context_parallel_degree"] == 4
+            assert candidate["artifacts"] == {
+                "output_dir": "outputs",
+                "video": "out.mp4",
+                "log": "run.log",
+                "benchmark": "benchmark.json",
+            }
+
+
+def test_h100_and_a100_share_the_same_algorithm_profiles() -> None:
+    from models.minimax_h3.h100_a100 import profiles
+
+    assert profiles.PROFILES["quality"].tau == 0.5
+    assert profiles.PROFILES["quality"].dense_steps == 15
+    assert profiles.PROFILES["balanced"].cache == "easycache"
+    assert profiles.PROFILES["aggressive"].threshold_type == "diag"
+    assert profiles.PROFILES["fullopt_exact"].threshold_type == "exact"
+    assert profiles.HARDWARE["h100"].sol_backend == "cute_sm90"
+    assert profiles.HARDWARE["a100"].sol_backend == "triton"
+
+    with patch.dict(
+        os.environ,
+        {"H3_HARDWARE": "a100", "H3_SOL_PROFILE": "fullopt_exact"},
+        clear=True,
+    ):
+        hardware, profile = profiles.configure_runtime()
+        assert hardware.name == "a100"
+        assert profile.name == "fullopt_exact"
+        assert os.environ["H3_SOL_SINK_MODE"] == "prefix"
+        assert os.environ["H3_REORDER"] == "0"
+        assert os.environ["H3_OFFLOAD"] == "0"
+
+
+def test_locked_profile_rejects_policy_drift() -> None:
+    from models.minimax_h3.h100_a100 import profiles
+
+    environment = {
+        "H3_HARDWARE": "h100",
+        "H3_SOL_PROFILE": "fullopt_exact",
+        "H3_SOL_TAU": "0.5",
+    }
+    with patch.dict(os.environ, environment, clear=True):
+        try:
+            profiles.configure_runtime()
+        except RuntimeError as exc:
+            assert "H3_SOL_TAU is locked" in str(exc)
+        else:
+            raise AssertionError("conflicting profile override was accepted")
+
+
+def test_candidates_do_not_inherit_the_legacy_diffusers_environment() -> None:
+    namespace = runpy.run_path(str(ROOT / "scripts/launch_candidate.py"))
+    merge = namespace["merge_model_profile"]
+    merged = merge(_candidate("h100", "fullopt_exact"))
+    assert "H3_CONDA_ROOT" not in merged["env"]
+    assert "H3_CONDA_ENV" not in merged["env"]
+    assert "PYTHON_BIN" not in merged["env"]
+    assert merged["official_config"]["width"] == 1344
+    assert merged["official_config"]["revision"] == (
+        "bfc8ed0353f5a9733be73e6b2c98ec0948195b86"
+    )
+
+
+def test_runtime_registers_locally_and_never_patches_sglang() -> None:
+    files = {path.name for path in RUNTIME.iterdir() if path.is_file()}
+    assert "model.py" in files
+    assert "registration.py" in files
+    assert "request.py" not in files
+    assert "summarize.py" not in files
+    assert not list(RUNTIME.rglob("*.patch"))
+
+    registration = (RUNTIME / "registration.py").read_text(encoding="utf-8")
+    runner = (RUNTIME / "scripts/run_minimax_h3_gpu.sh").read_text(
+        encoding="utf-8"
+    )
+    assert "ModelRegistry.register_model" in registration
+    assert "PINNED_SGLANG_MODEL_SHA256" in registration
+    assert "sglang serve" not in runner
+    assert "git apply" not in runner
+    assert "cp -a" not in runner
+
+
+def test_model_contains_only_the_required_attention_and_cache_hooks() -> None:
+    source = (RUNTIME / "model.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    assert tree is not None
+    assert "_sol_engine_forward_attention" in source
+    assert "_sol_engine_easycache_before_blocks" in source
+    assert "_sol_engine_easycache_after_blocks" in source
+    assert "_sol_engine_cache_after_head" in source
+    assert "_sol_engine_cache_after_tail" in source
+    assert "models.minimax_h3.portable" not in source
+
+
+def test_adapter_uses_full_prefix_sink_without_reordering() -> None:
+    source = (RUNTIME / "adapter.py").read_text(encoding="utf-8")
+    assert "sink_start = 0" in source
+    assert "sink_tokens = context.prefix_tokens" in source
+    assert "segment[:, :sink_tokens] = _dense_queries" in source
+    assert "from sol_attn import get_sol_attn_backend, sol_attn" in source
+    assert "reorder" not in source.lower()
+
+
+def test_offline_runner_uses_official_metrics_and_four_way_ulysses() -> None:
+    source = (RUNTIME / "gpu_infer.py").read_text(encoding="utf-8")
+    assert "DiffGenerator.from_pretrained" in source
+    assert '"total_duration_s"' in source
+    assert "result.peak_memory_mb" in source
+    assert "num_gpus=4" in source
+    assert "ulysses_degree=4" in source
+    assert "use_fsdp_inference=True" in source
+    assert "layerwise_offload_components=[]" in source
+    assert "enable_torch_compile=False" in source
+    assert "generator.shutdown()" in source
+
+
+def test_backend_selection_is_public() -> None:
+    interface = (
+        ROOT / "techniques/sparse_backends/sol_attn/interface.py"
+    ).read_text(encoding="utf-8")
+    package = (
+        ROOT / "techniques/sparse_backends/sol_attn/__init__.py"
+    ).read_text(encoding="utf-8")
+    assert "def get_sol_attn_backend" in interface
+    assert "get_sol_attn_backend" in package
+
+
+ContractsTest = type(
+    "ContractsTest",
+    (unittest.TestCase,),
+    {
+        name: staticmethod(value)
+        for name, value in tuple(globals().items())
+        if name.startswith("test_") and callable(value)
+    },
+)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a shared, process-local MiniMax-H3 runtime for 4x H100-80GB and 4x A100-80GB, following the registered-runtime structure introduced by the RTX 5090 cleanup.
- Keep the installed SGLang checkout immutable: the pinned upstream model source is verified before the local model class is registered with `ModelRegistry`, and inference uses the offline `DiffGenerator` API.
- Add locked `dense`, `quality`, `balanced`, `aggressive`, and `fullopt_exact` profiles for both hardware targets.
- Add candidate manifests, reproducibility metadata, official SGLang timing/memory collection, and dependency-light contract tests.

## Runtime policy

- BF16 MiniMax-H3 FL2VA revision `bfc8ed0353f5a9733be73e6b2c98ec0948195b86`
- 1344x768, 124 frames, 50-step release candidates
- FSDP inference with Ulysses-4 on four GPUs
- No offload, token reorder, or `torch.compile`
- First two transformer layers dense
- Full multimodal prefix as an exact KV sink; prefix query rows recomputed densely
- H100: CuTe SM90 Sol-Attn backend
- A100: Triton Sol-Attn backend
- Pinned SGLang container with PyTorch 2.11.0+cu130 and Triton 3.6.0

## Validation

Local checks:

- 9 MiniMax-H3 H100/A100 contract tests
- Python compileall
- runner `bash -n`
- H100 exact and A100 quality candidate dry-runs
- all 8 core source hashes verified against `SOURCE_SNAPSHOT.json`
- `git diff --check`

Real four-GPU smoke tests used the pinned container and model revision at 1344x768, 124 frames, with one full warmup followed by one measured 12-step request. These jobs validate the registered runtime and sparse path; the timings below are smoke results, not the 50-step release benchmark.

| Hardware | Slurm job | Backend | Measured time | Peak memory/GPU | Effective density |
|---|---:|---|---:|---:|---:|
| 4x H100-80GB | 15360270 | `cute_sm90` | 18.899 s | 48,130 MiB | 18.52% |
| 4x A100-80GB | 31705191 | `triton` | 50.303 s | 48,106 MiB | 18.50% |

Both jobs passed the real-QKV correctness gate, executed the measured sparse forward on ranks 0-3, used a 951-token full-prefix sink, and left only `out.mp4`, `benchmark.json`, and `run.log` in the output directory.

No generated media, cluster logs, or site-specific scheduler settings are included in this PR.
