### PR TITLE
Add MiniMax-H3 code link to H3-OnDevice page

### DIFF
--- a/Sol-Engine/H3-OnDevice/index.html
+++ b/Sol-Engine/H3-OnDevice/index.html
@@ -59,6 +59,12 @@ h1 .h1a{display:block;font-size:clamp(34px,5.2vw,54px);color:#fff}
 h1 .h1b{display:block;margin-top:12px;font-size:clamp(24px,3.4vw,34px);line-height:1.16;letter-spacing:-.02em;color:var(--text-2);font-weight:650}
 .dek{font-size:21px;line-height:1.56;color:var(--text-2);margin:0 0 32px;letter-spacing:-.008em}
 .dek b{color:#fff;font-weight:650}
+.hero-links{display:flex;flex-wrap:wrap;gap:12px;margin:-4px 0 32px}
+.hero-links a{
+    display:inline-flex;align-items:center;padding:9px 16px;border:1px solid var(--green-line);
+    border-radius:6px;background:var(--green-soft);color:var(--green);font-size:16px;font-weight:650;
+  }
+.hero-links a:hover{border-color:var(--green);background:rgba(118,185,0,.15)}
 .byline{
     display:flex;flex-direction:column;gap:7px;align-items:flex-start;
     color:var(--text-2);font-size:19px;padding-top:24px;border-top:1px solid var(--line-soft);
@@ -306,6 +312,9 @@ footer p{margin:12px 0}
       near-lossless quality. It gets there without distillation, without LoRA or fine-tuning, and
       without an offline calibration pass.
     </p>
+    <div class="hero-links">
+      <a href="https://github.com/NVlabs/Sana/tree/sol-engine/models/minimax_h3">MiniMax-H3 Code</a>
+    </div>
     <div class="byline">
       <span class="authors">Yitong Li<sup>*</sup>, Haopeng Li<sup>*</sup>, Enze Xie</span>
       <span class="meta-row">


### PR DESCRIPTION
Adds a prominent MiniMax-H3 Code link in the H3-OnDevice hero, pointing to the implementation on the sol-engine branch. No other page content is changed.