### PR TITLE
Add Sol-Engine model links

### DIFF
--- a/Sol-Engine/index.html
+++ b/Sol-Engine/index.html
@@ -263,7 +263,7 @@
         const venue = root.querySelector('.hero .venue');
         if (venue) venue.textContent = 'Technical Report · 2026';
 
-        const badges = root.querySelector('.badges');
+        const badges = root.querySelector('.badges, .hero-actions');
         if (badges) {
           badges.innerHTML = '';
           const paperBadge = document.createElement('a');
@@ -276,7 +276,17 @@
           codeBadge.href = 'https://github.com/NVlabs/Sana/tree/sol-engine';
           codeBadge.target = '_blank';
           codeBadge.rel = 'noopener noreferrer';
-          badges.append(paperBadge, codeBadge);
+          const h3Badge = document.createElement('a');
+          h3Badge.textContent = 'MiniMax H3';
+          h3Badge.href = 'https://nvlabs.github.io/Sana/Sol-Engine/H3/';
+          h3Badge.target = '_blank';
+          h3Badge.rel = 'noopener noreferrer';
+          const ltx25Badge = document.createElement('a');
+          ltx25Badge.textContent = 'LTX-2.5';
+          ltx25Badge.href = 'https://nvlabs.github.io/Sana/Sol-Engine/LTX25/';
+          ltx25Badge.target = '_blank';
+          ltx25Badge.rel = 'noopener noreferrer';
+          badges.append(paperBadge, codeBadge, h3Badge, ltx25Badge);
         }
 
         const heroLinks = Array.from(root.querySelectorAll('.hero a, .hero-shell a'));


### PR DESCRIPTION
## What changed

- Add a **MiniMax H3** button to the Sol-Engine hero actions.
- Add an **LTX-2.5** button to the Sol-Engine hero actions.
- Support the current `.hero-actions` container while retaining compatibility with the legacy `.badges` selector.

## Why

The Sol-Engine homepage only exposed Paper and Code links, while the dedicated MiniMax H3 and LTX-2.5 result pages had no entry points in the hero section. The old patch script also queried a stale container class, preventing newly injected links from rendering.

## Impact

Visitors can open the H3 and LTX-2.5 pages directly from the Sol-Engine homepage. Both links open in a new tab with `noopener noreferrer`.

## Validation

- `git diff --check`
- Local Chrome render at 2048×960 confirmed both new buttons are visible.
- Confirmed `Sol-Engine/H3/index.html` and `Sol-Engine/LTX25/index.html` exist.
