### PR TITLE
Add prominent Sol-Engine CTA to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,6 @@
 </h3>
 
 <p align="center">
-  <a href="https://github.com/NVlabs/Sana/tree/sol-engine">
-    <img src="https://img.shields.io/badge/⚡_SOL--ENGINE-OPEN_THE_INFERENCE_ENGINE_BRANCH_→-76B900?style=for-the-badge" height="42" alt="Open the Sol-Engine branch"/>
-  </a>
-</p>
-<p align="center">
-  <b>Agent-native full-stack acceleration for video diffusion inference</b><br>
-  <sub>Cache · Sparse Attention · Token Pruning · Quantization · Kernel Fusion</sub>
-</p>
-
-<p align="center">
   <a href="https://nv-sana.mit.edu/"><img src="https://img.shields.io/static/v1?label=Demo:6x3090&message=SANA&color=yellow"></a> &ensp;
   <a href="https://nv-sana.mit.edu/4bit/"><img src="https://img.shields.io/static/v1?label=Demo:1x3090&message=4bit&color=yellow"></a> &ensp;
   <a href="https://nv-sana.mit.edu/ctrlnet/"><img src="https://img.shields.io/static/v1?label=Demo:1x3090&message=ControlNet&color=yellow"></a> &ensp;
@@ -32,6 +22,12 @@
   <a href="https://discord.gg/rde6eaE5Ta"><img src="https://img.shields.io/static/v1?label=Discuss&message=Discord&color=purple&logo=discord"></a> &ensp;
   <a href="https://sana-wm.reactor.inc/"><img src="https://img.shields.io/static/v1?label=Reactor%20Demo&message=SANA-WM&color=yellow"></a> &ensp;
   <a href="https://sana-streaming.reactor.inc/"><img src="https://img.shields.io/static/v1?label=Reactor%20Demo&message=SANA-Streaming&color=yellow"></a> &ensp;
+</p>
+
+<p align="center">
+  <a href="https://github.com/NVlabs/Sana/tree/sol-engine">
+    <img src="asset/sol-engine-branch-banner.svg" width="100%" alt="Open the Sol-Engine inference engine branch"/>
+  </a>
 </p>
 
 <h4 align="center">ICLR 2025 Oral | ICML 2025 | ICCV 2025 Highlight | ICLR 2026 Oral </h4>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@
 </h3>
 
 <p align="center">
+  <a href="https://github.com/NVlabs/Sana/tree/sol-engine">
+    <img src="https://img.shields.io/badge/⚡_SOL--ENGINE-OPEN_THE_INFERENCE_ENGINE_BRANCH_→-76B900?style=for-the-badge" height="42" alt="Open the Sol-Engine branch"/>
+  </a>
+</p>
+<p align="center">
+  <b>Agent-native full-stack acceleration for video diffusion inference</b><br>
+  <sub>Cache · Sparse Attention · Token Pruning · Quantization · Kernel Fusion</sub>
+</p>
+
+<p align="center">
   <a href="https://nv-sana.mit.edu/"><img src="https://img.shields.io/static/v1?label=Demo:6x3090&message=SANA&color=yellow"></a> &ensp;
   <a href="https://nv-sana.mit.edu/4bit/"><img src="https://img.shields.io/static/v1?label=Demo:1x3090&message=4bit&color=yellow"></a> &ensp;
   <a href="https://nv-sana.mit.edu/ctrlnet/"><img src="https://img.shields.io/static/v1?label=Demo:1x3090&message=ControlNet&color=yellow"></a> &ensp;

--- a/asset/sol-engine-branch-banner.svg
+++ b/asset/sol-engine-branch-banner.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="112" viewBox="0 0 1600 112" role="img" aria-labelledby="title desc">
+  <title id="title">Open the Sol-Engine branch</title>
+  <desc id="desc">A full-width link banner for the Sol-Engine video inference engine branch.</desc>
+  <defs>
+    <clipPath id="rounded">
+      <rect x="2" y="2" width="1596" height="108" rx="16"/>
+    </clipPath>
+  </defs>
+  <g clip-path="url(#rounded)">
+    <rect width="1600" height="112" fill="#76b900"/>
+    <rect width="430" height="112" fill="#3d4248"/>
+  </g>
+  <rect x="2" y="2" width="1596" height="108" rx="16" fill="none" stroke="#8bd000" stroke-width="4"/>
+  <path d="M57 25 34 59h20l-9 28 34-40H58l14-22Z" fill="#f5b82e"/>
+  <text x="96" y="69" fill="#fff" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="34" font-weight="750" letter-spacing="3">SOL-ENGINE</text>
+  <text x="1002" y="68" fill="#fff" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="27" font-weight="750" letter-spacing="2" text-anchor="middle">OPEN THE INFERENCE ENGINE BRANCH</text>
+  <path d="M1450 56h58m0 0-17-17m17 17-17 17" fill="none" stroke="#fff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## What changed

- Add a responsive, full-width Sol-Engine banner below all navigation, demo, and API links.
- Link the entire banner directly to the `sol-engine` branch.
- Keep the CTA to one visual line with no additional description text.
- Rebase the PR onto the latest `main` (`639fdbc`) so current SANA-WM, SANA-Streaming, Sol-RL, and Sol-Engine News updates are preserved.

## Why

Sol-Engine is a major inference component of the Sana repository, but the main README did not expose the branch. A dedicated full-width CTA makes the engine discoverable from the first screen without competing with the primary Sana logo or fragmenting the existing link groups.

## Impact

Visitors can move from the default branch to the dedicated inference-engine branch in one click and immediately understand what the branch provides.

## Validation

- `git diff --check`
- `xmllint --noout asset/sol-engine-branch-banner.svg`
- Rendered the SVG at 1600 px in headless Chrome and visually verified the complete one-line banner.
- Confirmed the CTA target is `https://github.com/NVlabs/Sana/tree/sol-engine`.
