### PR TITLE
Add RTX 5090 LTX-2.5 Sol-Attn profiles

### DIFF
--- a/models/ltx25/README.md
+++ b/models/ltx25/README.md
@@ -7,6 +7,7 @@ runtime snapshot, launch configs, and tuning decisions.
 | Hardware | GPUs | Runtime | Delivered stack |
 |---|---:|---|---|
 | [GB200](GB200/README.md) | 4 | Lightricks native two-stage MGPU pipeline | Stage-1 CFG parallelism + FBCache 0.08 + cache-aware compile; Stage-2 2x2 TDP |
+| [RTX 5090](RTX5090/README.md) | 1 | Lightricks native two-stage pipeline | Stage-2 Sol-Attn for Distilled BF16 and NVFP4 |
 
 The GB200 delivery vendors its runtime and environment workspace, defaults to
 the repository-local `.venv`, and has no code, environment, or Git-metadata

--- a/models/ltx25/RTX5090/README.md
+++ b/models/ltx25/RTX5090/README.md
@@ -1,0 +1,51 @@
+# LTX-2.5 on RTX 5090
+
+Single-GPU Sol-Engine acceleration for the official LTX-2.5 distilled BF16
+and NVFP4 pipelines with the Conv VAE.
+
+## Performance
+
+| Workload | Pipeline | Dense Stage 2 | Sol Stage 2 | Stage 2 speedup | Dense E2E | Sol E2E | E2E speedup |
+|---|---|---:|---:|---:|---:|---:|---:|
+| 4K / 5s | Distilled BF16 | 270.78 s | 130.32 s | **2.08x** | 413.20 s | 273.63 s | **1.51x** |
+| 4K / 5s | Distilled NVFP4 | 217.63 s | 72.82 s | **2.99x** | 316.34 s | 171.82 s | **1.84x** |
+| 1080p / 20s | Distilled BF16 | 253.48 s | 122.27 s | **2.07x** | 393.42 s | 261.65 s | **1.50x** |
+| 1080p / 20s | Distilled NVFP4 | 200.14 s | 66.78 s | **3.00x** | 297.59 s | 164.40 s | **1.81x** |
+
+Sol-Attn is enabled for Stage 2 video self-attention. The three Stage 2
+forwards use `tau=1.0`, `1.25`, and `1.5`; layer 0 remains dense.
+
+## Setup
+
+Checkout the official LTX-2 source and create its environment:
+
+```bash
+git clone https://github.com/Lightricks/LTX-2.git
+git -C LTX-2 checkout fd4ded7f2d88d3da713abcdd4ad41ecc4a9314ca
+cd LTX-2 && uv sync && cd -
+uv pip install --python LTX-2/.venv/bin/python "nvidia-cutlass-dsl>=4.5" cuda-python
+LTX-2/.venv/bin/python -m pip install -e techniques/sparse_backends
+```
+
+Set the source and model paths:
+
+```bash
+export LTX25_LTX_ROOT=/path/to/LTX-2
+export LTX25_WEIGHTS_ROOT=/path/to/LTX-2.5
+```
+
+## Run
+
+```bash
+python3 scripts/run.py models/ltx25/RTX5090/ltx25_rtx5090_distill_bf16.toml
+python3 scripts/run.py models/ltx25/RTX5090/ltx25_rtx5090_distill_nvfp4.toml
+```
+
+Both configs default to 4K / 5s. Select the 1080p / 20s workload with:
+
+```bash
+python3 scripts/run.py models/ltx25/RTX5090/ltx25_rtx5090_distill_nvfp4.toml \
+  --set LTX25_WORKLOAD=1080p20s
+```
+
+Each run writes `out.mp4` and `benchmark.json` under its output directory.

--- a/models/ltx25/RTX5090/SOURCE_SNAPSHOT.json
+++ b/models/ltx25/RTX5090/SOURCE_SNAPSHOT.json
@@ -1,0 +1,14 @@
+{
+  "component": "ltx25_rtx5090",
+  "upstream_repo": "https://github.com/Lightricks/LTX-2.git",
+  "upstream_commit": "fd4ded7f2d88d3da713abcdd4ad41ecc4a9314ca",
+  "model_repo": "Lightricks/LTX-2.5",
+  "pipelines": [
+    "ltx-2.5-22b-distilled-transformer-bf16.safetensors",
+    "ltx-2.5-22b-distilled-transformer-nvfp4.safetensors"
+  ],
+  "video_vae": "ltx-2.5-video-vae-conv-bf16.safetensors",
+  "python": "3.13",
+  "torch": "2.13.0+cu132",
+  "hardware": "NVIDIA GeForce RTX 5090"
+}

--- a/models/ltx25/RTX5090/__init__.py
+++ b/models/ltx25/RTX5090/__init__.py
@@ -1,0 +1,1 @@
+"""RTX 5090 runtime for LTX-2.5."""

--- a/models/ltx25/RTX5090/attention.py
+++ b/models/ltx25/RTX5090/attention.py
@@ -1,0 +1,117 @@
+"""Stage-2 Sol-Attn adapter for the distilled LTX-2.5 pipeline."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+STAGE2_TAUS = (1.0, 1.25, 1.5)
+LAYERS_PER_FORWARD = 48
+
+
+def route_for_call(call_index: int) -> tuple[float | None, int, int]:
+    """Return ``(tau, forward, layer)``; ``tau=None`` selects dense attention."""
+
+    forward_index, layer_index = divmod(call_index, LAYERS_PER_FORWARD)
+    if forward_index >= len(STAGE2_TAUS):
+        raise RuntimeError(f"unexpected Stage-2 video attention call {call_index}")
+    tau = None if layer_index == 0 else STAGE2_TAUS[forward_index]
+    return tau, forward_index, layer_index
+
+
+def _disable_torch_compile(function):
+    import torch
+
+    return torch.compiler.disable(function)
+
+
+class LTX25Stage2SolAttention:
+    """Keep non-video calls and layer 0 dense; route the remaining calls to Sol."""
+
+    def __init__(self) -> None:
+        from ltx_core.model.transformer.attention import AttentionFunction
+
+        self._dense = AttentionFunction.AUTOMATIC.to_callable()
+        self.reset()
+
+    @property
+    def label(self) -> str:
+        return f"LTX25-Stage2-Sol({self._dense.label})"
+
+    def reset(self) -> None:
+        from techniques.sparse_backends.sol_attn_backend import reset_sol_attn_state
+
+        self.video_calls = 0
+        self.sol_calls = 0
+        self.dense_video_calls = 0
+        self.tau_calls: Counter[float] = Counter()
+        self.enabled = False
+        reset_sol_attn_state()
+
+    @contextmanager
+    def stage2(self, enabled: bool) -> Iterator[None]:
+        previous = self.enabled
+        self.enabled = enabled
+        try:
+            yield
+        finally:
+            self.enabled = previous
+
+    @staticmethod
+    def _is_video_self(q, k, v, heads: int) -> bool:
+        return q.shape == k.shape == v.shape and q.shape[-1] // heads == 128
+
+    def _dense_bthd(self, q, k, v):
+        batch, tokens, heads, head_dim = q.shape
+        output = self._dense(
+            q.reshape(batch, tokens, heads * head_dim),
+            k.reshape(batch, tokens, heads * head_dim),
+            v.reshape(batch, tokens, heads * head_dim),
+            heads,
+        )
+        return output.view(batch, tokens, heads, head_dim)
+
+    @_disable_torch_compile
+    def __call__(self, q, k, v, heads: int):
+        if not self.enabled or not self._is_video_self(q, k, v, heads):
+            return self._dense(q, k, v, heads)
+
+        call_index = self.video_calls
+        self.video_calls += 1
+        tau, _forward_index, _layer_index = route_for_call(call_index)
+        if tau is None:
+            self.dense_video_calls += 1
+            return self._dense(q, k, v, heads)
+
+        from techniques.sparse_backends.sol_attn_backend import _run_sol_attn_bthd
+
+        batch, tokens, channels = q.shape
+        head_dim = channels // heads
+        q_bthd = q.view(batch, tokens, heads, head_dim).contiguous()
+        k_bthd = k.view(batch, tokens, heads, head_dim).contiguous()
+        v_bthd = v.view(batch, tokens, heads, head_dim).contiguous()
+        output = _run_sol_attn_bthd(
+            q_bthd,
+            k_bthd,
+            v_bthd,
+            tau=tau,
+            thresh_type="diag",
+            kv_splits=1,
+            dense_fn=self._dense_bthd,
+        )
+        self.sol_calls += 1
+        self.tau_calls[tau] += 1
+        return output.reshape(batch, tokens, channels)
+
+    def stats(self) -> dict[str, object]:
+        from techniques.sparse_backends.sol_attn_backend import get_sol_attn_stats
+
+        return {
+            "label": self.label,
+            "video_calls": self.video_calls,
+            "sol_calls": self.sol_calls,
+            "dense_video_calls": self.dense_video_calls,
+            "tau_calls": {str(tau): self.tau_calls[tau] for tau in STAGE2_TAUS},
+            "kernel": get_sol_attn_stats(),
+        }

--- a/models/ltx25/RTX5090/build_exact_adaln.py
+++ b/models/ltx25/RTX5090/build_exact_adaln.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Build the compact Exact AdaLN table used by the NVFP4 profile."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+
+from .exact_adaln import MODULE_PREFIXES, TABLE_FORMAT
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--checkpoint", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--tokens", type=int, required=True)
+    parser.add_argument("--sigmas", default="0.909375,0.725,0.421875")
+    return parser.parse_args()
+
+
+def load_prefixed_state(handle, prefix: str) -> dict[str, torch.Tensor]:
+    state_prefix = f"{prefix}."
+    return {
+        key.removeprefix(state_prefix): handle.get_tensor(key)
+        for key in handle.keys()
+        if key.startswith(state_prefix)
+    }
+
+
+def load_module(prefix: str, checkpoint: Path, device: torch.device):
+    from ltx_core.model.transformer.adaln import AdaLayerNormSingle
+
+    with safe_open(checkpoint, framework="pt", device="cpu") as handle:
+        weight = handle.get_tensor(f"{prefix}.linear.weight")
+        embedding_dim = int(weight.shape[1])
+        coefficient = int(weight.shape[0] // embedding_dim)
+        state = load_prefixed_state(handle, prefix)
+    module = AdaLayerNormSingle(embedding_dim, embedding_coefficient=coefficient)
+    module.load_state_dict(state, strict=True)
+    return module.eval().requires_grad_(False).to(device=device, dtype=torch.bfloat16), list(weight.shape)
+
+
+def compact_rows(tensor: torch.Tensor, name: str) -> torch.Tensor:
+    reference = tensor[:1]
+    for chunk in tensor.split(1024, dim=0):
+        if not torch.equal(chunk, reference.expand_as(chunk)):
+            raise RuntimeError(f"{name} is not row-exact")
+    return reference.cpu().clone()
+
+
+def build_module(name, prefix, checkpoint, timesteps, tokens, device):
+    module, weight_shape = load_module(prefix, checkpoint, device)
+    projected_rows = []
+    embedded_rows = []
+    for timestep in timesteps:
+        values = torch.full((tokens,), float(timestep.item()), device=device)
+        with torch.inference_mode():
+            projected, embedded = module(values, hidden_dtype=torch.bfloat16)
+        projected_rows.append(compact_rows(projected, f"{name}.projected"))
+        embedded_rows.append(compact_rows(embedded, f"{name}.embedded"))
+        del values, projected, embedded
+    del module
+    gc.collect()
+    torch.cuda.empty_cache()
+    return {
+        "linear_weight_shape": weight_shape,
+        "projected": torch.stack(projected_rows),
+        "embedded": torch.stack(embedded_rows),
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    device = torch.device("cuda")
+    sigmas = [float(value) for value in args.sigmas.split(",")]
+    scaled_timesteps = torch.tensor(sigmas, dtype=torch.float32) * 1000.0
+    modules = {
+        name: build_module(
+            name,
+            prefix,
+            args.checkpoint,
+            scaled_timesteps,
+            args.tokens,
+            device,
+        )
+        for name, prefix in MODULE_PREFIXES.items()
+    }
+    payload = {
+        "format": TABLE_FORMAT,
+        "source_size": args.checkpoint.stat().st_size,
+        "token_count": args.tokens,
+        "sigmas": sigmas,
+        "scaled_timesteps": scaled_timesteps,
+        "modules": modules,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(payload, args.output)
+    print(json.dumps({"table": str(args.output), "tokens": args.tokens, "sigmas": sigmas}))
+
+
+if __name__ == "__main__":
+    main()

--- a/models/ltx25/RTX5090/exact_adaln.py
+++ b/models/ltx25/RTX5090/exact_adaln.py
@@ -1,0 +1,147 @@
+"""Exact Stage-2 AdaLN tables for the NVFP4 LTX-2.5 profile."""
+
+from __future__ import annotations
+
+import gc
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import torch
+
+TABLE_FORMAT = "ltx25_exact_adaln_v1"
+MODULE_PREFIXES = {
+    "video_base": "model.diffusion_model.adaln_single",
+    "video_cross": "model.diffusion_model.av_ca_video_scale_shift_adaln_single",
+}
+
+
+class ExactScheduleAdaLN(torch.nn.Module):
+    def __init__(
+        self,
+        name: str,
+        projected: torch.Tensor,
+        embedded: torch.Tensor,
+        scaled_timesteps: torch.Tensor,
+        token_count: int,
+        call_counts: Counter[tuple[str, int]],
+    ) -> None:
+        super().__init__()
+        self.name = name
+        self.token_count = token_count
+        self.call_counts = call_counts
+        self.register_buffer("projected", projected.contiguous(), persistent=False)
+        self.register_buffer("embedded", embedded.contiguous(), persistent=False)
+        self.register_buffer("scaled_timesteps", scaled_timesteps.float().contiguous(), persistent=False)
+
+    def forward(
+        self,
+        timestep: torch.Tensor,
+        hidden_dtype: torch.dtype | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        flattened = timestep.flatten()
+        if flattened.numel() != self.token_count:
+            raise RuntimeError(
+                f"{self.name} table expects {self.token_count} tokens, got {flattened.numel()}"
+            )
+        if not torch.equal(flattened, flattened[:1].expand_as(flattened)):
+            raise RuntimeError(f"{self.name} exact table requires a uniform timestep")
+        matches = torch.nonzero(flattened[0] == self.scaled_timesteps, as_tuple=False).flatten()
+        if matches.numel() != 1:
+            raise RuntimeError(f"{self.name} has no table row for timestep {flattened[0].item()}")
+        step = int(matches.item())
+        if hidden_dtype is not None and hidden_dtype != self.projected.dtype:
+            raise RuntimeError(f"{self.name} table dtype does not match {hidden_dtype}")
+        self.call_counts[(self.name, step)] += 1
+        return self.projected[step], self.embedded[step]
+
+
+def _velocity_model(transformer: Any) -> Any:
+    current = transformer
+    while not hasattr(current, "adaln_single"):
+        if hasattr(current, "_model"):
+            current = current._model
+        elif hasattr(current, "velocity_model"):
+            current = current.velocity_model
+        else:
+            raise RuntimeError(f"cannot locate the LTX-2.5 velocity model under {type(current)!r}")
+    return current
+
+
+class LTX25ExactAdaLN:
+    def __init__(self, table_path: Path, checkpoint: Path) -> None:
+        self.payload = torch.load(table_path, map_location="cpu", weights_only=True)
+        if self.payload.get("format") != TABLE_FORMAT:
+            raise ValueError("unsupported Exact AdaLN table")
+        if self.payload.get("source_size") != checkpoint.stat().st_size:
+            raise ValueError("Exact AdaLN table was built from a different checkpoint")
+        if self.payload.get("token_count", 0) <= 0:
+            raise ValueError("invalid Exact AdaLN token count")
+        if set(self.payload.get("modules", {})) != set(MODULE_PREFIXES):
+            raise ValueError("Exact AdaLN table is incomplete")
+        self.call_counts: Counter[tuple[str, int]] = Counter()
+        self.binding: dict[str, Any] | None = None
+
+    def install(self, transformer: Any) -> None:
+        model = _velocity_model(transformer)
+        if self.binding is not None:
+            raise RuntimeError("Exact AdaLN is already installed")
+        preprocessor = model.video_args_preprocessor
+        originals = {
+            "video_base": model.adaln_single,
+            "video_cross": model.av_ca_video_scale_shift_adaln_single,
+        }
+        device = originals["video_base"].linear.weight.device
+        dtype = originals["video_base"].linear.weight.dtype
+        replacements = {}
+        for name, original in originals.items():
+            row = self.payload["modules"][name]
+            if tuple(original.linear.weight.shape) != tuple(row["linear_weight_shape"]):
+                raise RuntimeError(f"{name} shape changed since table generation")
+            replacements[name] = ExactScheduleAdaLN(
+                name,
+                row["projected"].to(device=device, dtype=dtype),
+                row["embedded"].to(device=device, dtype=dtype),
+                self.payload["scaled_timesteps"].to(device=device),
+                int(self.payload["token_count"]),
+                self.call_counts,
+            )
+
+        originals["video_base"].to("cpu")
+        originals["video_cross"].to("cpu")
+        model.adaln_single = replacements["video_base"]
+        model.av_ca_video_scale_shift_adaln_single = replacements["video_cross"]
+        preprocessor.simple_preprocessor.adaln = replacements["video_base"]
+        preprocessor.cross_scale_shift_adaln = replacements["video_cross"]
+        self.binding = {
+            "model": model,
+            "preprocessor": preprocessor,
+            "originals": originals,
+            "replacements": replacements,
+        }
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    def uninstall(self, transformer: Any) -> None:
+        model = _velocity_model(transformer)
+        if self.binding is None or self.binding["model"] is not model:
+            raise RuntimeError("Exact AdaLN is not installed on this transformer")
+        preprocessor = self.binding["preprocessor"]
+        originals = self.binding["originals"]
+        model.adaln_single = originals["video_base"]
+        model.av_ca_video_scale_shift_adaln_single = originals["video_cross"]
+        preprocessor.simple_preprocessor.adaln = originals["video_base"]
+        preprocessor.cross_scale_shift_adaln = originals["video_cross"]
+        self.binding = None
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    def stats(self) -> dict[str, object]:
+        steps = len(self.payload["sigmas"])
+        return {
+            "token_count": int(self.payload["token_count"]),
+            "calls": {
+                name: [self.call_counts[(name, step)] for step in range(steps)]
+                for name in MODULE_PREFIXES
+            },
+        }

--- a/models/ltx25/RTX5090/gpu_infer.py
+++ b/models/ltx25/RTX5090/gpu_infer.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Run the distilled LTX-2.5 pipeline with Stage-2 Sol-Attn on RTX 5090."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from collections import defaultdict
+from collections.abc import Iterator
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from .attention import LTX25Stage2SolAttention
+from .exact_adaln import LTX25ExactAdaLN
+from .memory import FeedForwardChunking
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pipeline", choices=("bf16", "nvfp4"), required=True)
+    parser.add_argument("--metrics", type=Path, required=True)
+    parser.add_argument("--nvfp4-embedding-source", type=Path)
+    parser.add_argument("--exact-adaln-table", type=Path)
+    parser.add_argument("official_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    if args.official_args[:1] == ["--"]:
+        args.official_args = args.official_args[1:]
+    if not args.official_args:
+        parser.error("official LTX-2.5 arguments are required after --")
+    if args.pipeline == "nvfp4" and (
+        args.nvfp4_embedding_source is None or args.exact_adaln_table is None
+    ):
+        parser.error("NVFP4 requires --nvfp4-embedding-source and --exact-adaln-table")
+    return args
+
+
+def find_keyframe_embedding_key(checkpoint) -> str:
+    keys = [
+        key
+        for key in checkpoint.keys()
+        if key.endswith("keyframes_abs_pos_embedding")
+    ]
+    if len(keys) != 1:
+        raise RuntimeError("expected one keyframe embedding")
+    return keys[0]
+
+
+def install_nvfp4_embedding(source: Path) -> str:
+    """Inject the BF16 keyframe embedding omitted from the NVFP4 checkpoint."""
+
+    import torch
+    from ltx_core.loader.sd_ops import KeyValueOperationResult, SDOps
+    from ltx_pipelines.utils.quantization_factory import QuantizationKind
+    from safetensors import safe_open
+
+    with safe_open(source, framework="pt", device="cpu") as checkpoint:
+        source_key = find_keyframe_embedding_key(checkpoint)
+        embedding = checkpoint.get_tensor(source_key).clone()
+
+    original_to_policy = QuantizationKind.to_policy
+
+    def repaired_to_policy(self: QuantizationKind, checkpoint_path: str | None = None):
+        policy = original_to_policy(self, checkpoint_path)
+        if self is not QuantizationKind.NVFP4_PREQUANT:
+            return policy
+
+        def inject(key: str, value: torch.Tensor) -> list[KeyValueOperationResult]:
+            results = [KeyValueOperationResult(key, value)]
+            if key == "patchify_proj.bias":
+                results.append(
+                    KeyValueOperationResult(
+                        "keyframes_abs_pos_embedding",
+                        embedding.to(device=value.device, non_blocking=True),
+                    )
+                )
+            return results
+
+        injection = SDOps("LTX25_NVFP4_KEYFRAME_EMBEDDING").with_kv_operation(
+            key_suffix="patchify_proj.bias",
+            operation=inject,
+        )
+        sd_ops = SDOps(
+            name=f"{policy.sd_ops.name}+{injection.name}",
+            mapping=(*policy.sd_ops.mapping, *injection.mapping),
+            allowed_keys=policy.sd_ops.allowed_keys,
+        )
+        return replace(policy, sd_ops=sd_ops)
+
+    QuantizationKind.to_policy = repaired_to_policy
+    return source_key
+
+
+def sync() -> None:
+    import torch
+
+    torch.cuda.synchronize()
+
+
+class Timings:
+    def __init__(self) -> None:
+        self.values: dict[str, list[float]] = defaultdict(list)
+
+    def measure(self, name: str, function, *args, **kwargs):
+        sync()
+        start = time.perf_counter()
+        result = function(*args, **kwargs)
+        sync()
+        self.values[name].append(time.perf_counter() - start)
+        return result
+
+    def total(self, name: str) -> float:
+        return sum(self.values.get(name, ()))
+
+
+class TimedCallable:
+    def __init__(self, name: str, wrapped: Any, timings: Timings) -> None:
+        self.name = name
+        self.wrapped = wrapped
+        self.timings = timings
+
+    def __call__(self, *args, **kwargs):
+        return self.timings.measure(self.name, self.wrapped, *args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.wrapped, name)
+
+
+class TimedVideoDecoder(TimedCallable):
+    def __call__(self, *args, **kwargs) -> Iterator[Any]:
+        iterator = self.timings.measure("video_decoder_build", self.wrapped, *args, **kwargs)
+
+        def measured() -> Iterator[Any]:
+            sync()
+            start = time.perf_counter()
+            try:
+                yield from iterator
+            finally:
+                sync()
+                self.timings.values[self.name].append(time.perf_counter() - start)
+
+        return measured()
+
+
+class TimedStage:
+    def __init__(
+        self,
+        name: str,
+        stage: Any,
+        timings: Timings,
+        attention: LTX25Stage2SolAttention,
+        exact_adaln: LTX25ExactAdaLN | None = None,
+    ) -> None:
+        self.name = name
+        self.stage = stage
+        self.timings = timings
+        self.attention = attention
+        self.exact_adaln = exact_adaln
+        self.call_index = 0
+
+    def __call__(self, *args, **kwargs):
+        from ltx_pipelines.utils.samplers import euler_denoising_loop
+
+        if self.name == "stage":
+            self.call_index += 1
+            stage_index = self.call_index
+            stage_name = f"stage_{stage_index}"
+        else:
+            stage_index = int(self.name.rsplit("_", 1)[1])
+            stage_name = self.name
+        original_loop = kwargs.get("loop") or euler_denoising_loop
+
+        def timed_loop(*loop_args, **loop_kwargs):
+            transformer = loop_kwargs["transformer"]
+            if self.exact_adaln is not None and stage_index == 2:
+                self.exact_adaln.install(transformer)
+            try:
+                return self.timings.measure(
+                    f"{stage_name}_denoise",
+                    original_loop,
+                    *loop_args,
+                    **loop_kwargs,
+                )
+            finally:
+                if self.exact_adaln is not None and stage_index == 2:
+                    self.exact_adaln.uninstall(transformer)
+
+        kwargs["loop"] = timed_loop
+        with self.attention.stage2(stage_index == 2):
+            return self.timings.measure(stage_name, self.stage, *args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.stage, name)
+
+
+def parse_official_args(argv: list[str]) -> argparse.Namespace:
+    from ltx_pipelines.utils.args import (
+        add_generated_keyframes_arg,
+        default_2_stage_distilled_arg_parser,
+        resolve_cli_params,
+    )
+
+    old_argv = sys.argv
+    try:
+        sys.argv = ["ltx25-distilled", *argv]
+        params = resolve_cli_params(distilled=True)
+        parser = default_2_stage_distilled_arg_parser(params=params, supports_auto_duration=True)
+        return add_generated_keyframes_arg(parser).parse_args(argv)
+    finally:
+        sys.argv = old_argv
+
+
+def build_pipeline(args: argparse.Namespace):
+    from ltx_pipelines.distilled import DistilledPipeline
+
+    return DistilledPipeline(
+        model_paths=args.model_paths,
+        spatial_upsampler_path=args.spatial_upsampler_path,
+        loras=tuple(args.lora) if args.lora else (),
+        quantization=args.quantization,
+        compilation_config=args.compile,
+        offload_mode=args.offload_mode,
+        prompt_enhancer_gemma_root=args.prompt_enhancer_gemma_root,
+        diffvae_optimization=args.diffvae_optimization,
+    )
+
+
+def instrument_pipeline(
+    pipeline: Any,
+    attention: LTX25Stage2SolAttention,
+    exact_adaln: LTX25ExactAdaLN | None,
+    timings: Timings,
+) -> None:
+    pipeline.stage = TimedStage(
+        "stage",
+        pipeline.stage.with_attention(attention),
+        timings,
+        attention,
+        exact_adaln,
+    )
+    pipeline.prompt_encoder = TimedCallable("prompt_encode", pipeline.prompt_encoder, timings)
+    pipeline.upsampler = TimedCallable("video_upsample", pipeline.upsampler, timings)
+    pipeline.video_decoder = TimedVideoDecoder("video_decode", pipeline.video_decoder, timings)
+    pipeline.audio_decoder = TimedCallable("audio_decode", pipeline.audio_decoder, timings)
+
+
+def run_pipeline(pipeline: Any, args: argparse.Namespace) -> None:
+    import torch
+    from ltx_core.model.video_vae import AUTO_TILING, get_video_chunks_number
+    from ltx_pipelines.utils.media_io import (
+        encode_video,
+        resolve_hdr_color_space,
+        vae_dtype_for_hdr,
+    )
+
+    hdr = resolve_hdr_color_space(images=args.images, hdr=args.hdr)
+    video, audio, num_frames, tiling_config = pipeline(
+        prompt=args.prompt,
+        seed=args.seed,
+        height=args.height,
+        width=args.width,
+        num_frames=args.num_frames,
+        frame_rate=args.frame_rate,
+        images=args.images,
+        vae_dtype=vae_dtype_for_hdr(hdr, torch.bfloat16),
+        color_space=hdr,
+        enhance_prompt=args.enhance_prompt,
+        enhance_static_cache=args.enhance_static_cache,
+        tiling_config=AUTO_TILING,
+        generated_keyframes=args.num_generated_keyframes,
+    )
+    encode_video(
+        video=video,
+        fps=args.frame_rate,
+        audio=audio,
+        output_path=args.output_path,
+        video_chunks_number=get_video_chunks_number(num_frames, tiling_config),
+        color_space=hdr,
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    os.environ["SOL_ATTN_STRICT"] = "1"
+
+    import torch
+
+    embedding_key = None
+    if args.pipeline == "nvfp4":
+        embedding_key = install_nvfp4_embedding(args.nvfp4_embedding_source)
+    official = parse_official_args(args.official_args)
+    exact_adaln = (
+        LTX25ExactAdaLN(args.exact_adaln_table, Path(official.transformer_path))
+        if args.pipeline == "nvfp4"
+        else None
+    )
+    ffn_chunking = FeedForwardChunking() if args.pipeline == "bf16" else None
+    if ffn_chunking is not None:
+        ffn_chunking.install()
+
+    timings = Timings()
+    attention = LTX25Stage2SolAttention()
+    try:
+        pipeline = build_pipeline(official)
+        instrument_pipeline(pipeline, attention, exact_adaln, timings)
+        torch.cuda.reset_peak_memory_stats()
+        sync()
+        start = time.perf_counter()
+        with torch.inference_mode():
+            run_pipeline(pipeline, official)
+        sync()
+        e2e_seconds = time.perf_counter() - start
+    finally:
+        if ffn_chunking is not None:
+            ffn_chunking.uninstall()
+
+    metrics = {
+        "pipeline": args.pipeline,
+        "stage_1_seconds": timings.total("stage_1"),
+        "stage_2_seconds": timings.total("stage_2"),
+        "video_vae_seconds": timings.total("video_decoder_build") + timings.total("video_decode"),
+        "e2e_seconds": e2e_seconds,
+        "peak_allocated_gib": torch.cuda.max_memory_allocated() / 1024**3,
+        "peak_reserved_gib": torch.cuda.max_memory_reserved() / 1024**3,
+        "attention": attention.stats(),
+        "exact_adaln": exact_adaln.stats() if exact_adaln is not None else None,
+        "nvfp4_embedding_key": embedding_key,
+        "torch_version": torch.__version__,
+        "gpu": torch.cuda.get_device_name(),
+    }
+    args.metrics.parent.mkdir(parents=True, exist_ok=True)
+    args.metrics.write_text(json.dumps(metrics, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(metrics, sort_keys=True), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/ltx25/RTX5090/ltx25_rtx5090_distill_bf16.toml
+++ b/models/ltx25/RTX5090/ltx25_rtx5090_distill_bf16.toml
@@ -1,0 +1,9 @@
+name = "ltx25_rtx5090_distill_bf16"
+runtime = "."
+entry = "run_ltx25_gpu.sh"
+gpus = 1
+
+LTX25_PIPELINE = "bf16"
+LTX25_WORKLOAD = "4k5s"
+LTX25_PROMPT_FILE = "models/ltx25/prompts/p01_multishot.txt"
+LTX25_SEED = "42"

--- a/models/ltx25/RTX5090/ltx25_rtx5090_distill_nvfp4.toml
+++ b/models/ltx25/RTX5090/ltx25_rtx5090_distill_nvfp4.toml
@@ -1,0 +1,9 @@
+name = "ltx25_rtx5090_distill_nvfp4"
+runtime = "."
+entry = "run_ltx25_gpu.sh"
+gpus = 1
+
+LTX25_PIPELINE = "nvfp4"
+LTX25_WORKLOAD = "4k5s"
+LTX25_PROMPT_FILE = "models/ltx25/prompts/p01_multishot.txt"
+LTX25_SEED = "42"

--- a/models/ltx25/RTX5090/memory.py
+++ b/models/ltx25/RTX5090/memory.py
@@ -1,0 +1,37 @@
+"""Exact FFN chunking used by the BF16 RTX 5090 profile."""
+
+from __future__ import annotations
+
+
+class FeedForwardChunking:
+    def __init__(self, chunk_tokens: int = 16384, min_tokens: int = 65536) -> None:
+        self.chunk_tokens = chunk_tokens
+        self.min_tokens = min_tokens
+        self.original_forward = None
+        self.feed_forward_class = None
+
+    def install(self) -> None:
+        import torch
+        from ltx_core.model.transformer.feed_forward import FeedForward
+
+        original_forward = FeedForward.forward
+        owner = self
+
+        def chunked_forward(module, x):
+            if x.shape[-2] < owner.min_tokens:
+                return original_forward(module, x)
+            outputs = [
+                original_forward(module, chunk)
+                for chunk in torch.split(x, owner.chunk_tokens, dim=-2)
+            ]
+            return torch.cat(outputs, dim=-2)
+
+        self.original_forward = original_forward
+        self.feed_forward_class = FeedForward
+        FeedForward.forward = chunked_forward
+
+    def uninstall(self) -> None:
+        if self.original_forward is not None:
+            self.feed_forward_class.forward = self.original_forward
+            self.original_forward = None
+            self.feed_forward_class = None

--- a/models/ltx25/RTX5090/run_ltx25_gpu.sh
+++ b/models/ltx25/RTX5090/run_ltx25_gpu.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${OUT_DIR:?OUT_DIR must be set by scripts/run.py}"
+: "${LTX25_PIPELINE:?LTX25_PIPELINE must be bf16 or nvfp4}"
+: "${LTX25_LTX_ROOT:?Set LTX25_LTX_ROOT to the pinned LTX-2 checkout}"
+: "${LTX25_WEIGHTS_ROOT:?Set LTX25_WEIGHTS_ROOT to the LTX-2.5 model snapshot}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-$LTX25_LTX_ROOT/.venv/bin/python}"
+PROMPT_FILE="${LTX25_PROMPT_FILE:-$REPO_ROOT/models/ltx25/prompts/p01_multishot.txt}"
+
+case "${LTX25_WORKLOAD:-4k5s}" in
+  4k5s)
+    WIDTH=3840; HEIGHT=2176; FRAMES=121; TOKENS=130560
+    ;;
+  1080p20s)
+    WIDTH=1920; HEIGHT=1088; FRAMES=481; TOKENS=124440
+    ;;
+  *)
+    echo "unknown LTX25_WORKLOAD=${LTX25_WORKLOAD:-}" >&2
+    exit 2
+    ;;
+esac
+
+BF16="$LTX25_WEIGHTS_ROOT/diffusion_models/ltx-2.5-22b-distilled-transformer-bf16.safetensors"
+NVFP4="$LTX25_WEIGHTS_ROOT/diffusion_models/ltx-2.5-22b-distilled-transformer-nvfp4.safetensors"
+TEXT="$LTX25_WEIGHTS_ROOT/text_encoders/gemma4-12b-with-proj-ltx-2.5-bf16.safetensors"
+VIDEO_VAE="$LTX25_WEIGHTS_ROOT/vae/ltx-2.5-video-vae-conv-bf16.safetensors"
+AUDIO_VAE="$LTX25_WEIGHTS_ROOT/vae/ltx-2.5-audio-vae-bf16.safetensors"
+UPSCALER="$LTX25_WEIGHTS_ROOT/latent_upscale_models/ltx-2.5-latent-spatial-upscaler-x2-bf16-1.0.safetensors"
+
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"
+export OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 NUMEXPR_NUM_THREADS=1
+export TOKENIZERS_PARALLELISM=false
+export PYTHONUNBUFFERED=1
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export PYTHONPATH="$REPO_ROOT${LTX25_EXTRA_PYTHONPATH:+:$LTX25_EXTRA_PYTHONPATH}${PYTHONPATH:+:$PYTHONPATH}"
+
+mkdir -p "$OUT_DIR"
+RUNNER_ARGS=(--pipeline "$LTX25_PIPELINE" --metrics "$OUT_DIR/benchmark.json")
+OFFICIAL_ARGS=()
+TRANSFORMER="$BF16"
+
+case "$LTX25_PIPELINE" in
+  bf16)
+    OFFICIAL_ARGS+=(--offload cpu)
+    ;;
+  nvfp4)
+    TRANSFORMER="$NVFP4"
+    OFFICIAL_ARGS+=(--quantization nvfp4-prequant)
+    TABLE="${LTX25_ADALN_TABLE:-$REPO_ROOT/.cache/ltx25/rtx5090/${LTX25_WORKLOAD:-4k5s}/exact_adaln.pt}"
+    if [[ ! -s "$TABLE" ]]; then
+      "$PYTHON_BIN" -m models.ltx25.RTX5090.build_exact_adaln \
+        --checkpoint "$NVFP4" --tokens "$TOKENS" --output "$TABLE"
+    fi
+    RUNNER_ARGS+=(--nvfp4-embedding-source "$BF16" --exact-adaln-table "$TABLE")
+    ;;
+  *)
+    echo "unknown LTX25_PIPELINE=$LTX25_PIPELINE" >&2
+    exit 2
+    ;;
+esac
+
+cd "$REPO_ROOT"
+exec "$PYTHON_BIN" -m models.ltx25.RTX5090.gpu_infer \
+  "${RUNNER_ARGS[@]}" -- \
+  --transformer-path "$TRANSFORMER" \
+  --text-encoder-path "$TEXT" \
+  --video-vae-path "$VIDEO_VAE" \
+  --audio-vae-path "$AUDIO_VAE" \
+  --spatial-upsampler-path "$UPSCALER" \
+  "${OFFICIAL_ARGS[@]}" \
+  --width "$WIDTH" --height "$HEIGHT" --num-frames "$FRAMES" \
+  --frame-rate 24 --seed "${LTX25_SEED:-42}" \
+  --prompt "$(< "$PROMPT_FILE")" --output-path "$OUT_DIR/out.mp4"

--- a/models/ltx25/RTX5090/tests/test_attention.py
+++ b/models/ltx25/RTX5090/tests/test_attention.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from models.ltx25.RTX5090.attention import (
+    LAYERS_PER_FORWARD,
+    STAGE2_TAUS,
+    LTX25Stage2SolAttention,
+    route_for_call,
+)
+
+
+def test_stage2_policy_routes_141_sol_calls_and_three_dense_layers() -> None:
+    routes = [route_for_call(index) for index in range(3 * LAYERS_PER_FORWARD)]
+
+    assert sum(tau is None for tau, _, _ in routes) == 3
+    assert sum(tau is not None for tau, _, _ in routes) == 141
+    for forward_index, expected_tau in enumerate(STAGE2_TAUS):
+        forward = routes[
+            forward_index * LAYERS_PER_FORWARD : (forward_index + 1) * LAYERS_PER_FORWARD
+        ]
+        assert forward[0] == (None, forward_index, 0)
+        assert all(tau == expected_tau for tau, _, _ in forward[1:])
+
+
+def test_stage2_policy_rejects_an_unexpected_fourth_forward() -> None:
+    with pytest.raises(RuntimeError, match="unexpected Stage-2"):
+        route_for_call(3 * LAYERS_PER_FORWARD)
+
+
+def test_attention_dispatch_is_excluded_from_torch_compile() -> None:
+    assert getattr(LTX25Stage2SolAttention.__call__, "_torchdynamo_disable", False)

--- a/models/ltx25/RTX5090/tests/test_exact_adaln.py
+++ b/models/ltx25/RTX5090/tests/test_exact_adaln.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+import torch
+
+from models.ltx25.RTX5090.build_exact_adaln import load_prefixed_state
+from models.ltx25.RTX5090.exact_adaln import ExactScheduleAdaLN
+
+
+class KeysOnlyCheckpoint:
+    def __init__(self) -> None:
+        self.tensors = {
+            "video.linear.weight": torch.tensor([1.0]),
+            "video.linear.bias": torch.tensor([2.0]),
+            "audio.linear.weight": torch.tensor([3.0]),
+        }
+
+    def keys(self):
+        return self.tensors.keys()
+
+    def get_tensor(self, key: str) -> torch.Tensor:
+        return self.tensors[key]
+
+
+def test_prefixed_state_accepts_noniterable_safe_open_handle() -> None:
+    state = load_prefixed_state(KeysOnlyCheckpoint(), "video")
+
+    assert set(state) == {"linear.weight", "linear.bias"}
+    torch.testing.assert_close(state["linear.weight"], torch.tensor([1.0]))
+
+
+def test_exact_schedule_selects_the_matching_row() -> None:
+    calls = Counter()
+    module = ExactScheduleAdaLN(
+        "video_base",
+        torch.tensor([[[1.0, 2.0]], [[3.0, 4.0]]]),
+        torch.tensor([[[5.0]], [[6.0]]]),
+        torch.tensor([100.0, 200.0]),
+        4,
+        calls,
+    )
+
+    projected, embedded = module(torch.full((4,), 200.0))
+
+    torch.testing.assert_close(projected, torch.tensor([[3.0, 4.0]]))
+    torch.testing.assert_close(embedded, torch.tensor([[6.0]]))
+    assert calls[("video_base", 1)] == 1
+
+
+def test_exact_schedule_rejects_wrong_tokens_and_nonuniform_steps() -> None:
+    module = ExactScheduleAdaLN(
+        "video_base",
+        torch.zeros(2, 1, 2),
+        torch.zeros(2, 1, 1),
+        torch.tensor([100.0, 200.0]),
+        4,
+        Counter(),
+    )
+    with pytest.raises(RuntimeError, match="expects 4 tokens"):
+        module(torch.full((3,), 100.0))
+    with pytest.raises(RuntimeError, match="uniform timestep"):
+        module(torch.tensor([100.0, 100.0, 200.0, 100.0]))

--- a/models/ltx25/RTX5090/tests/test_gpu_infer.py
+++ b/models/ltx25/RTX5090/tests/test_gpu_infer.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from models.ltx25.RTX5090 import gpu_infer
+
+
+class FakeAttention:
+    def __init__(self) -> None:
+        self.contexts = []
+
+    @contextmanager
+    def stage2(self, enabled: bool):
+        self.contexts.append(enabled)
+        yield
+
+
+class FakeStage:
+    def __call__(self, *args, **kwargs):
+        return kwargs["loop"](transformer=object())
+
+
+class KeysOnlyCheckpoint:
+    def keys(self):
+        return (
+            "transformer.keyframes_abs_pos_embedding",
+            "transformer.patchify_proj.bias",
+        )
+
+
+def test_keyframe_lookup_accepts_noniterable_safe_open_handle() -> None:
+    assert (
+        gpu_infer.find_keyframe_embedding_key(KeysOnlyCheckpoint())
+        == "transformer.keyframes_abs_pos_embedding"
+    )
+
+
+def test_shared_stage_marks_only_the_second_call_as_stage2(monkeypatch) -> None:
+    monkeypatch.setattr(gpu_infer, "sync", lambda: None)
+    attention = FakeAttention()
+    timings = gpu_infer.Timings()
+    stage = gpu_infer.TimedStage("stage", FakeStage(), timings, attention)
+
+    stage(loop=lambda **_kwargs: None)
+    stage(loop=lambda **_kwargs: None)
+
+    assert attention.contexts == [False, True]
+    assert timings.total("stage_1") >= 0.0
+    assert timings.total("stage_2") >= 0.0

--- a/models/ltx25/RTX5090/tests/test_memory.py
+++ b/models/ltx25/RTX5090/tests/test_memory.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import torch
+from ltx_core.model.transformer.feed_forward import FeedForward
+
+from models.ltx25.RTX5090.memory import FeedForwardChunking
+
+
+def test_feed_forward_chunking_is_exact() -> None:
+    torch.manual_seed(7)
+    module = FeedForward(dim=16, dim_out=16, mult=2)
+    inputs = torch.randn(2, 13, 16)
+    expected = module(inputs)
+    chunking = FeedForwardChunking(chunk_tokens=5, min_tokens=10)
+    try:
+        chunking.install()
+        actual = module(inputs)
+    finally:
+        chunking.uninstall()
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-6)

--- a/models/ltx25/model.toml
+++ b/models/ltx25/model.toml
@@ -1,6 +1,6 @@
 schema_version = 1
 id = "ltx25"
-display_name = "LTX-2.5 public 22B two-stage T2V on 4xGB200"
+display_name = "LTX-2.5 public 22B two-stage video generation"
 contract_kind = "model_baseline_minimal_copy"
 
 [baseline]


### PR DESCRIPTION
## Summary

- add single-GPU RTX 5090 profiles for the LTX-2.5 distilled BF16 and NVFP4 pipelines with Conv VAE
- apply Sol-Attn to Stage 2 video self-attention with per-step taus and a dense first layer
- add exact NVFP4 AdaLN tables, BF16 FFN chunking, concise usage, and measured 4K/1080p results

## Validation

- B200/GB200 4K 5s NVFP4 E2E smoke: Slurm `6180488`, 141 Sol calls and 3 dense video calls, output decoded successfully
- B200 CPU regression suite: 9 tests passed in Slurm `6180236`
- Python compilation, shell syntax, JSON/TOML parsing, config rendering, and staged diff checks passed
