### PR TITLE
Add MiniMax-H3 RTX 4090 fullopt runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ support a wider range of models.
 
 ## 📰 News
 
+- **[2026/08/17]** 🔥 **[MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3) on GeForce RTX 4090** [[Code](models/minimax_h3/RTX4090/)] — reaches **4.44×** end-to-end with TeaCache, regional compile, and the SM89 Sol-Attn kernel.
 - **[2026/08/13]** 🔥 **[LTX-2.5](https://github.com/Lightricks/LTX-2) across B200, GeForce RTX 5090, and DGX Spark** [[Code](models/ltx25/) | [Blog](https://nvlabs.github.io/Sana/Sol-Engine/LTX25/)] — reaches up to **4.68×** multi-step pipeline speedup and **1.90×** distilled pipeline speedup.
 - **[2026/08/09]** 🔥 **[MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3) on H100 and A100** [[Code](models/minimax_h3/) | [Blog](https://nvlabs.github.io/Sana/Sol-Engine/H3-DataCenter/)] — reaches **3.56×** end-to-end on 4×H100 and **3.55×** on 4×A100.
 - **[2026/08/06]** 🔥 **[MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3) on GB10 and RTX 5090** [[Code](models/minimax_h3/) | [Blog](https://nvlabs.github.io/Sana/Sol-Engine/H3-OnDevice/)] — reaches **3.92×** end-to-end on DGX Spark (GB10) and **4.52×** on RTX 5090.
@@ -151,7 +152,7 @@ your specific machine.
 - [x] **Wan2.2 TI2V-5B, Wan2.2-A14B, and LingBot-Video** acceleration lines — kernel fusion + cache + PISA/compile
 - [x] **HunyuanVideo-13B and Wan2.1-T2V-14B** acceleration lines — kernel fusion + cache + Sol-Attn
 - [x] **Sol-Attn** sparse-attention release — optimized SM89/SM90/SM100/SM120 kernels + portable Triton backend
-- [x] **MiniMax-H3** across GB200, H100, A100, GB10, and RTX 5090 — context parallel + kernel fusion + Sol-Attn + FirstBlockCache
+- [x] **MiniMax-H3** across GB200, H100, A100, GB10, RTX 4090, and RTX 5090 — context parallel + kernel fusion + Sol-Attn + FirstBlockCache/TeaCache
 - [x] **LTX-2.5** across B200, GeForce RTX 5090, and DGX Spark — parallel optimization + FBCache + kernel fusion + Sol-Attn
 - [ ] More backends for each acceleration method
 - [ ] Agent-native workflow without human-in-the-loop

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ support a wider range of models.
 
 ## 📰 News
 
-- **[2026/08/17]** 🔥 **[MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3) on GeForce RTX 4090** [[Code](models/minimax_h3/RTX4090/)] — reaches **4.44×** end-to-end with TeaCache, regional compile, and the SM89 Sol-Attn kernel.
+- **[2026/08/17]** 🔥 **[MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3) on GeForce RTX 4090** [[Code](models/minimax_h3/)] — reaches **4.44×** end-to-end on RTX 4090. Sol-Attn now includes an optimized SM89 CuTe DSL kernel for RTX 4090.
 - **[2026/08/13]** 🔥 **[LTX-2.5](https://github.com/Lightricks/LTX-2) across B200, GeForce RTX 5090, and DGX Spark** [[Code](models/ltx25/) | [Blog](https://nvlabs.github.io/Sana/Sol-Engine/LTX25/)] — reaches up to **4.68×** multi-step pipeline speedup and **1.90×** distilled pipeline speedup.
 - **[2026/08/09]** 🔥 **[MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3) on H100 and A100** [[Code](models/minimax_h3/) | [Blog](https://nvlabs.github.io/Sana/Sol-Engine/H3-DataCenter/)] — reaches **3.56×** end-to-end on 4×H100 and **3.55×** on 4×A100.
 - **[2026/08/06]** 🔥 **[MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3) on GB10 and RTX 5090** [[Code](models/minimax_h3/) | [Blog](https://nvlabs.github.io/Sana/Sol-Engine/H3-OnDevice/)] — reaches **3.92×** end-to-end on DGX Spark (GB10) and **4.52×** on RTX 5090.

--- a/config/minimax_h3/rtx4090_fullopt.toml
+++ b/config/minimax_h3/rtx4090_fullopt.toml
@@ -1,0 +1,60 @@
+id = "minimax_h3_rtx4090_fullopt"
+kind = "optimized"
+purpose = "stacked"
+description = "RTX 4090 BF16 stack: SM89 Sol-Attn, TeaCache, regional torch.compile, and a full BF16 video VAE resident after denoising."
+model_profile = "minimax_h3"
+submodule = "models/minimax_h3/RTX4090"
+run_script = "run_minimax_h3_gpu.sh"
+
+[runtime]
+root = "models/minimax_h3/RTX4090"
+
+[official_config]
+model = "MiniMaxAI/MiniMax-H3"
+task = "t2va"
+width = 1344
+height = 768
+duration_s = 5
+steps = 50
+seed = 0
+num_gpus = 1
+transformer_dtype = "bf16"
+vae_dtype = "bf16"
+
+[env]
+# The shim requires H3_MODEL_PATH; stated here because the model profile no
+# longer carries one machine's checkout path. A repo id, resolved against
+# HF_HOME, is what the H100 and A100 cells use and what this cell was verified
+# with. Point it at a local directory to run offline.
+H3_MODEL_PATH = "MiniMaxAI/MiniMax-H3"
+H3_MODEL_REVISION = "bfc8ed0353f5a9733be73e6b2c98ec0948195b86"
+HF_HUB_OFFLINE = "0"
+H3_RTX4090_PROFILE = "fullopt"
+H3_CUDA_VISIBLE_DEVICES = "0"
+TORCH_CUDA_ARCH_LIST = "8.9"
+H3_PROMPT_FILE = "models/minimax_h3/demo_prompt.json"
+H3_WARMUP_NUM_STEPS = "50"
+H3_MEASURED_NUM_STEPS = "50"
+H3_DURATION_SECONDS = "5"
+H3_SEED = "0"
+SOL_ATTN_TAU = "1.0"
+SOL_ATTN_THRESH_TYPE = "diag"
+SOL_ATTN_FORCE_DENSE = "0"
+SOL_ATTN_FIRST_DENSE_STEPS = "10"
+SOL_ATTN_FIRST_DENSE_LAYERS = "2"
+SOL_ATTN_CORRECTNESS_GATE = "1"
+H3_TEACACHE_ENABLED = "1"
+H3_TEACACHE_THRESHOLD = "0.10"
+H3_TEACACHE_RETAIN_STEPS = "5"
+H3_TEACACHE_COOLDOWN_STEPS = "1"
+H3_TEACACHE_NUM_FORWARDS = "49"
+H3_TEACACHE_COEFFICIENTS = "1.0,0.0"
+H3_FULL_VAE_AFTER_DENOISE = "1"
+H3_FULL_VAE_DTYPE = "bfloat16"
+H3_FULL_VAE_TILE_BATCH_SIZE = "0"
+
+[artifacts]
+output_dir = "outputs"
+video = "out.mp4"
+log = "run.log"
+benchmark = "benchmark.json"

--- a/models/minimax_h3.toml
+++ b/models/minimax_h3.toml
@@ -130,6 +130,31 @@ upstream_pull_request = "https://github.com/huggingface/diffusers/pull/14355"
 upstream_commit = "abc5e9bf71fd38f53cd471bc3acaa84bc5ecbfdc"
 source_snapshot = "models/minimax_h3/GB200/diffusers_src"
 
+[rtx4090]
+variant = "sglang_registered_bf16_single_rtx4090"
+status = "measured_rtx4090"
+runtime_root = "models/minimax_h3/RTX4090"
+run_script = "models/minimax_h3/RTX4090/run_minimax_h3_gpu.sh"
+config = ["config/minimax_h3/rtx4090_fullopt.toml"]
+hardware = "1x NVIDIA GeForce RTX 4090, 24 GiB GDDR6X, SM89"
+cell = "1344x768, 124 frames, 5 seconds, 50 steps, released BF16 FL2VA"
+timing_scope = "benchmark.json measured.inference_time_s after a 50-step warmup"
+memory_scope = "benchmark.json measured.peak_memory_mb"
+source_snapshot = "models/minimax_h3/RTX4090/SOURCE_SNAPSHOT.json"
+note = "The single released config composes the SM89 Sol-Attn kernel, TeaCache, regional compile, full BF16 VAE decode, and SGLang layerwise offload."
+
+[rtx4090.policy]
+tau = 1.0
+threshold = "diag"
+first_dense_steps = 10
+first_dense_layers = 2
+reorder = false
+text_kv_sink = "exact"
+text_query_rows = "dense"
+teacache_threshold = 0.10
+teacache_retain_steps = 5
+teacache_cooldown_steps = 1
+
 [rtx5090]
 variant = "sglang_registered_bf16_single_rtx5090"
 status = "single_gpu_layerwise_offload"

--- a/models/minimax_h3/README.md
+++ b/models/minimax_h3/README.md
@@ -10,8 +10,8 @@ Sol-Attn, caching, and memory-efficient decoding.
 |---|---:|---:|---:|---:|---:|---|
 | GB200 | 8 | 768p@5s | 27.21 | 6.88 | **3.95x** | [`minimax_h3_fullopt.toml`](../../config/minimax_h3/fullopt.toml) |
 | GB10 (DGX Spark) | 1 | 480p@5s | 710.6 | 181.3 | **3.92x** | [`minimax_h3_gb10_fullopt.toml`](../../config/minimax_h3/gb10_fullopt.toml) |
-| RTX 4090 | 1 | 768p@5s | 2239.22 | 504.33 | **4.44x** | [`rtx4090_fullopt.toml`](../../config/minimax_h3/rtx4090_fullopt.toml) |
-| RTX 5090 | 1 | 768p@5s | 1045.4 | 231.2 | **4.52x** | [`minimax_h3_rtx5090_fullopt.toml`](../../config/minimax_h3/rtx5090_fullopt.toml) |
+| RTX 4090 | 1 | 768p@5s | 2239.22 | 504.33 | **4.44x** | [`minimax_h3/rtx4090_fullopt.toml`](../../config/minimax_h3/rtx4090_fullopt.toml) |
+| RTX 5090 | 1 | 768p@5s | 1045.4 | 231.2 | **4.52x** | [`minimax_h3/rtx5090_fullopt.toml`](../../config/minimax_h3/rtx5090_fullopt.toml) |
 | H100 | 4 | 768p@5s | 81.47 | 22.89 | **3.56x** | [`minimax_h3_h100_fullopt.toml`](../../config/minimax_h3/minimax_h3_h100_fullopt.toml) |
 | A100 | 4 | 768p@5s | 217.32 | 61.28 | **3.55x** | [`minimax_h3_a100_fullopt.toml`](../../config/minimax_h3/minimax_h3_a100_fullopt.toml) |
 

--- a/models/minimax_h3/README.md
+++ b/models/minimax_h3/README.md
@@ -10,6 +10,7 @@ Sol-Attn, caching, and memory-efficient decoding.
 |---|---:|---:|---:|---:|---:|---|
 | GB200 | 8 | 768p@5s | 27.21 | 6.88 | **3.95x** | [`minimax_h3_fullopt.toml`](../../config/minimax_h3/fullopt.toml) |
 | GB10 (DGX Spark) | 1 | 480p@5s | 710.6 | 181.3 | **3.92x** | [`minimax_h3_gb10_fullopt.toml`](../../config/minimax_h3/gb10_fullopt.toml) |
+| RTX 4090 | 1 | 768p@5s | 2239.22 | 504.33 | **4.44x** | [`rtx4090_fullopt.toml`](../../config/minimax_h3/rtx4090_fullopt.toml) |
 | RTX 5090 | 1 | 768p@5s | 1045.4 | 231.2 | **4.52x** | [`minimax_h3_rtx5090_fullopt.toml`](../../config/minimax_h3/rtx5090_fullopt.toml) |
 | H100 | 4 | 768p@5s | 81.47 | 22.89 | **3.56x** | [`minimax_h3_h100_fullopt.toml`](../../config/minimax_h3/minimax_h3_h100_fullopt.toml) |
 | A100 | 4 | 768p@5s | 217.32 | 61.28 | **3.55x** | [`minimax_h3_a100_fullopt.toml`](../../config/minimax_h3/minimax_h3_a100_fullopt.toml) |
@@ -52,6 +53,7 @@ Each run is stored under `runs/` with the generated video, `benchmark.json`, and
 ## Runtime Notes
 
 Platform-specific environment and implementation notes are available for
-[GB200](GB200/), [GB10](GB10/), [RTX 5090](RTX5090/), [H100](H100/), and [A100](A100/).
+[GB200](GB200/), [GB10](GB10/), [RTX 4090](RTX4090/), [RTX 5090](RTX5090/),
+[H100](H100/), and [A100](A100/).
 Full-opt uses approximate caching and sparse attention; keep the released config unchanged when
 reproducing the reported performance and quality.

--- a/models/minimax_h3/RTX4090/README.md
+++ b/models/minimax_h3/RTX4090/README.md
@@ -15,7 +15,7 @@ the 24 GiB GPU.
 The speedup is one warm end-to-end timing sample against the matching dense runtime on the same
 GPU. Both arms use the released BF16 FL2VA weights, prompt, seed, 50 measured denoising steps, and
 layerwise component offload. The released full-opt configuration is pinned by
-[`rtx4090_fullopt.toml`](../../../config/minimax_h3/rtx4090_fullopt.toml).
+[`minimax_h3/rtx4090_fullopt.toml`](../../../config/minimax_h3/rtx4090_fullopt.toml).
 
 The controlled attribution experiment held the optimized runtime, 50-step warmup, prompt, seed,
 and measured workload fixed:

--- a/models/minimax_h3/RTX4090/README.md
+++ b/models/minimax_h3/RTX4090/README.md
@@ -1,0 +1,95 @@
+# MiniMax-H3 on RTX 4090
+
+## Overview
+
+This runtime runs the released BF16 FL2VA checkpoint on one RTX 4090. The 33B DiT, Qwen3-VL
+conditioner, and VAEs use SGLang layerwise component offload so only the active component resides on
+the 24 GiB GPU.
+
+## Performance
+
+| GPUs | Workload | Baseline (s) | Optimized (s) | Speedup |
+|---:|---|---:|---:|---:|
+| 1 | 768p@5s | 2239.22 | 504.33 | **4.44x** |
+
+The speedup is one warm end-to-end timing sample against the matching dense runtime on the same
+GPU. Both arms use the released BF16 FL2VA weights, prompt, seed, 50 measured denoising steps, and
+layerwise component offload. The released full-opt configuration is pinned by
+[`rtx4090_fullopt.toml`](../../../config/minimax_h3/rtx4090_fullopt.toml).
+
+The controlled attribution experiment held the optimized runtime, 50-step warmup, prompt, seed,
+and measured workload fixed:
+
+| Controlled arm | TeaCache | Sol-Attn | E2E time (s) | Incremental speedup | Cumulative speedup |
+|---|---:|---:|---:|---:|---:|
+| lossless opt | off | off | 1951.27 | 1.00x | 1.00x |
+| + Cache | on | off | 613.71 | **3.18x** | **3.18x** |
+| + Cache + Sol-Attn | on | on | 504.33 | **1.22x** | **3.87x** |
+
+Here, **lossless opt** means that neither TeaCache reuse nor Sol-Attn sparsification is enabled. It
+does not claim bitwise or video-quality equivalence. No perceptual or embedding similarity metric
+was measured, and the timings have not been repeated to characterize variance.
+
+## Full-Opt
+
+- **Parallelism:** single-GPU execution with layerwise component offload.
+- **Attention:** SM89 Sol-Attn with `tau=1.0`, diagonal thresholding, an exact prefix KV sink, dense
+  prefix queries, and the first 10 steps and first two blocks dense.
+- **Cache:** TeaCache with threshold `0.10`, five retained steps, and one cooldown step.
+- **Runtime:** regional `torch.compile`; the complete BF16 video VAE becomes resident only for
+  decoding and returns to offload afterward.
+
+## Usage
+
+The released config reproduces the [`demo_prompt`](../demo_prompt.json) full-opt benchmark with
+seed `0`, 50 denoising steps, and the workload above. Run it from the repository root:
+
+```bash
+python3 scripts/run.py config/minimax_h3/rtx4090_fullopt.toml
+```
+
+`scripts/run.py` takes either config dialect -- a flat single-file config or a
+config manifest -- and renders the same run bundle under `runs/`:
+`launch.sh`, `job.sbatch`, `manifest.resolved.toml`, `metadata.json` and
+`outputs/`. Add `--print` to resolve without running, or `--set KEY=VALUE` to
+override one value for a single run without editing the config:
+
+```bash
+python3 scripts/run.py config/minimax_h3/rtx4090_fullopt.toml \
+  --set PYTHON_BIN=/path/to/venv/bin/python
+```
+
+It contains no scheduler. To run under Slurm either put that same command in
+your own job script, or call the renderer directly, which is the one thing
+`run.py` does not do:
+
+```bash
+python3 scripts/launch_config.py config/minimax_h3/rtx4090_fullopt.toml --mode sbatch --confirm-submit
+```
+
+## Environment
+
+- **Runtime:** PyTorch 2.11 with CUDA 12.8, Triton 3.6, and the pinned SGLang checkout.
+- **Weights:** released BF16 FL2VA checkpoint supplied through `H3_MODEL_PATH`.
+- **Placement:** one RTX 4090 with 24 GiB GPU memory and sufficient host memory for layerwise offload.
+
+The selected environment must provide `ffmpeg` and `ffprobe`. Runtime registration is process-local
+and does not modify the installed SGLang checkout.
+
+## Validation
+
+- Sana commit: `6fb7eb11c3435555ec6d6adf0d5572d339d2c6eb`.
+- SGLang commit: `6fa3f9df11c8bdbc0e3b4ddc87a3d873343aca72`.
+- First sparse forward: `[1, 38247, 56, 128]` at 19.65% effective block density.
+- Real-QKV gate: maximum absolute error `0.0625`, mean absolute error `0.000289`, and relative L2
+  `0.000609`; all passed their declared limits.
+- TeaCache measured 14 block-stack computations and 35 reuses over 49 decisions.
+
+The timing and correctness evidence was collected with the same runtime stack before it was split
+into this RTX4090-named package. The hardware-specific package fixes the profile name, SM89 cache
+paths, capability check, and benchmark device metadata without changing the attention or TeaCache
+implementations.
+
+## Outputs
+
+The run bundle stores `out.mp4`, `benchmark.json`, and launch logs under `runs/`.

--- a/models/minimax_h3/RTX4090/SOURCE_SNAPSHOT.json
+++ b/models/minimax_h3/RTX4090/SOURCE_SNAPSHOT.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "variant": "rtx4090",
+  "source_root": ".",
+  "core_sha256": {
+    "adapter.py": "6367e8ffb3676996e987cd4a7cf0279d41fb82336d2a62ca48b340d4be96d7ac",
+    "teacache.py": "878bb72a38677fbf39cb4b041588f38990579d3eb9f49cdf7c6e31e71853bf99",
+    "model.py": "455af1bf82a7e91efddeb120db5a2229210985b417efc3c659c997c451a39255",
+    "pipeline.py": "3f7304a392d85616a7ace515165f6b3fe98d2228ec8c5dca2d864cd64b6eb97b",
+    "registration.py": "b03a726160a6d8a1e8da6a1922f212079e38c3996aff380cc4cf44ca582e9b04",
+    "gpu_infer.py": "dfd1ad439bb72f1d7c0cda782147972132553b86d929a78d1aa54eede8bd0f9f",
+    "run_minimax_h3_gpu.sh": "2ebefaafa3363cd09ba54da20c30088ae20336e1461b57a1bef3f10eb0d44c68"
+  },
+  "sglang": {
+    "repo": "https://github.com/sgl-project/sglang.git",
+    "commit": "6fa3f9df11c8bdbc0e3b4ddc87a3d873343aca72",
+    "source_sha256": {
+      "runtime/models/dits/minimax_h3.py": "5f87319969c446685ee93d422fc34a7c040defb238eff2274d664f2f8310e997",
+      "pipelines_core/stages/denoising.py": "2325b039c055d2db8c320a00f65e2880816888fd5fa107b72cfd6a85be104399",
+      "minimax_h3/stages/decoding.py": "5e2cf87da11e0c744d6c7703d8151abd7da7937e1ad67d576fdbf6c678380954"
+    }
+  },
+  "weights": {
+    "repo": "MiniMaxAI/MiniMax-H3",
+    "partition": "FL2VA",
+    "dtype": "bfloat16"
+  },
+  "environment": {
+    "python": "3.13.9",
+    "validation_runtime_bundle": "torch211-cu128"
+  },
+  "hardware": {
+    "device": "NVIDIA GeForce RTX 4090",
+    "sm": "89",
+    "memory_gib": 24
+  }
+}

--- a/models/minimax_h3/RTX4090/__init__.py
+++ b/models/minimax_h3/RTX4090/__init__.py
@@ -1,0 +1,1 @@
+"""Single-card RTX 4090 runtime for MiniMax-H3."""

--- a/models/minimax_h3/RTX4090/adapter.py
+++ b/models/minimax_h3/RTX4090/adapter.py
@@ -1,0 +1,627 @@
+"""Sol-Attn adapter for MiniMax-H3 packed multimodal attention."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import math
+import os
+from pathlib import Path
+import re
+import time
+from typing import Any, Iterable
+
+import torch
+import torch.nn.functional as F
+
+
+_LAYER_PATTERN = re.compile(r"(?:^|\.)blocks\.(\d+)\.attn$")
+_LOG_PREFIX = "MINIMAX_H3_SOL_ATTN "
+_MAIN_DIT_LAYER_INDICES: set[int] = set()
+
+
+@dataclass(frozen=True)
+class StepContext:
+    request_epoch: str
+    request_index: int
+    step_index: int
+    total_tokens: int
+    live_tokens: int
+    text_start: int
+    text_tokens: int
+    cu_seqlens_host: tuple[int, ...]
+    num_layers: int
+    timestep_max: float | None
+
+
+@dataclass
+class _RuntimeState:
+    context: StepContext | None = None
+    request_index: int = -1
+    previous_epoch: str | None = None
+    previous_timestep_max: float | None = None
+    density_logged_shapes: set[tuple[int, int, int]] = field(default_factory=set)
+    gate_shapes: set[tuple[int, int, int]] = field(default_factory=set)
+    first_sparse_logged_shapes: set[tuple[int, int, int]] = field(default_factory=set)
+    dense_backend_logged: bool = False
+
+
+_STATE = _RuntimeState()
+
+
+def parse_layer_index(prefix: str) -> int | None:
+    """Return the main DiT block index, excluding token-refiner blocks."""
+
+    if "token_refiner" in prefix:
+        return None
+    match = _LAYER_PATTERN.search(prefix)
+    if match is None:
+        return None
+    layer_index = int(match.group(1))
+    _MAIN_DIT_LAYER_INDICES.add(layer_index)
+    return layer_index
+
+
+def _host_positions(values: torch.Tensor | Iterable[int]) -> tuple[int, ...]:
+    if torch.is_tensor(values):
+        values = values.detach().reshape(-1).to(device="cpu").tolist()
+    return tuple(int(value) for value in values if int(value) >= 0)
+
+
+def _contiguous_range(values: tuple[int, ...], name: str) -> tuple[int, int]:
+    if not values:
+        return 0, 0
+    ordered = tuple(sorted(set(values)))
+    start = ordered[0]
+    if ordered != tuple(range(start, start + len(ordered))):
+        raise ValueError(f"MiniMax-H3 {name} positions must be contiguous")
+    return start, len(ordered)
+
+
+def _normalize_boundaries(
+    boundaries: Iterable[int] | None,
+    total_tokens: int,
+) -> tuple[int, ...]:
+    if boundaries is None:
+        return (0, total_tokens)
+    result = tuple(int(value) for value in boundaries)
+    if not result or result[0] != 0:
+        raise ValueError(f"cu_seqlens_host must start at 0, got {result}")
+    if any(left > right for left, right in zip(result, result[1:])):
+        raise ValueError(f"cu_seqlens_host must be nondecreasing, got {result}")
+    if result[-1] > total_tokens:
+        raise ValueError(
+            f"cu_seqlens_host ends at {result[-1]}, beyond T={total_tokens}"
+        )
+    if result[-1] < total_tokens:
+        result = (*result, total_tokens)
+    return result
+
+
+def _request_epoch() -> str | None:
+    path = os.getenv("SOL_ATTN_REQUEST_EPOCH_FILE")
+    if not path:
+        return None
+    try:
+        return Path(path).read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+
+
+def _timestep_max(unique_timesteps: torch.Tensor) -> float | None:
+    if not torch.is_tensor(unique_timesteps) or not unique_timesteps.numel():
+        return None
+    return float(unique_timesteps.detach().float().max().to(device="cpu").item())
+
+
+def _rank() -> int:
+    return int(os.getenv("RANK", os.getenv("LOCAL_RANK", "0")))
+
+
+def _emit(event: str, **payload: Any) -> None:
+    record = {"event": event, "rank": _rank(), **payload}
+    line = json.dumps(record, sort_keys=True)
+    print(_LOG_PREFIX + line, flush=True)
+    path_template = os.getenv("SOL_ATTN_EVENT_LOG")
+    if path_template:
+        path = Path(path_template.format(rank=_rank()))
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+
+
+def emit_event(event: str, **payload: Any) -> None:
+    """Write an integration event to the shared per-rank log."""
+
+    _emit(event, **payload)
+
+
+@torch.no_grad()
+def begin_model_forward(
+    *,
+    unique_timesteps: torch.Tensor,
+    text_positions: torch.Tensor | Iterable[int],
+    image_positions: torch.Tensor | Iterable[int],
+    audio_positions: torch.Tensor | Iterable[int],
+    cu_seqlens_host: Iterable[int] | None,
+    total_tokens: int,
+    num_layers: int,
+) -> StepContext:
+    """Record request-static layout and advance the denoise-step counter."""
+
+    registered_num_layers = max(_MAIN_DIT_LAYER_INDICES, default=-1) + 1
+    num_layers = max(int(num_layers), registered_num_layers)
+
+    text = _host_positions(text_positions)
+    image = _host_positions(image_positions)
+    audio = _host_positions(audio_positions)
+    text_start, text_tokens = _contiguous_range(text, "text")
+    live_positions = text + image + audio
+    live_tokens = max(live_positions, default=-1) + 1
+    if live_tokens <= 0 or live_tokens > total_tokens:
+        raise ValueError(
+            f"invalid MiniMax-H3 live token count {live_tokens} for T={total_tokens}"
+        )
+    if len(set(live_positions)) != len(live_positions):
+        raise ValueError("MiniMax-H3 text/video/audio token positions overlap")
+
+    boundaries = _normalize_boundaries(cu_seqlens_host, total_tokens)
+    timestep_max = _timestep_max(unique_timesteps)
+    epoch = _request_epoch()
+    layout_key = (total_tokens, live_tokens, text_start, text_tokens, boundaries)
+    previous = _STATE.context
+    layout_changed = previous is None or (
+        previous.total_tokens,
+        previous.live_tokens,
+        previous.text_start,
+        previous.text_tokens,
+        previous.cu_seqlens_host,
+    ) != layout_key
+    epoch_changed = epoch is not None and epoch != _STATE.previous_epoch
+    # MiniMax-H3 traverses its denoise schedule in increasing timestep order.
+    # A decrease therefore marks the next request; treating an increase as a
+    # reset would keep every denoise iteration at step zero and force dense.
+    timestep_reset = (
+        epoch is None
+        and previous is not None
+        and timestep_max is not None
+        and _STATE.previous_timestep_max is not None
+        and timestep_max < _STATE.previous_timestep_max - 1.0e-6
+    )
+    new_request = layout_changed or epoch_changed or timestep_reset
+    if new_request:
+        _STATE.request_index += 1
+        step_index = 0
+    else:
+        step_index = previous.step_index + 1 if previous is not None else 0
+
+    request_epoch = epoch if epoch is not None else f"auto-{_STATE.request_index}"
+    _STATE.context = StepContext(
+        request_epoch=request_epoch,
+        request_index=_STATE.request_index,
+        step_index=step_index,
+        total_tokens=total_tokens,
+        live_tokens=live_tokens,
+        text_start=text_start,
+        text_tokens=text_tokens,
+        cu_seqlens_host=boundaries,
+        num_layers=num_layers,
+        timestep_max=timestep_max,
+    )
+    _STATE.previous_epoch = epoch
+    _STATE.previous_timestep_max = timestep_max
+
+    if new_request or step_index < 2:
+        _emit(
+            "step_context",
+            request_epoch=request_epoch,
+            request_index=_STATE.request_index,
+            step_index=step_index,
+            timestep_max=timestep_max,
+            total_tokens=total_tokens,
+            live_tokens=live_tokens,
+            padding_tokens=total_tokens - live_tokens,
+            text_start=text_start,
+            text_tokens=text_tokens,
+            image_tokens=len(image),
+            audio_tokens=len(audio),
+            cu_seqlens_host=list(boundaries),
+            num_layers=num_layers,
+        )
+    return _STATE.context
+
+
+def _set_dense_backend(attention: Any, q: torch.Tensor) -> None:
+    if attention._attention_impl is not None:
+        return
+    from sglang.multimodal_gen.runtime.layers.attention.selector import (
+        get_attn_backend,
+    )
+
+    attention._set_attention_backend(
+        get_attn_backend(
+            attention.head_dim,
+            q.dtype,
+            supported_attention_backends=attention._supported_attention_backends,
+        )
+    )
+
+
+def _dense_varlen(
+    attention: Any,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor,
+    cu_seqlens_host: tuple[int, ...] | None,
+    max_seqlen: int,
+) -> torch.Tensor:
+    global _STATE
+    _set_dense_backend(attention, q)
+    if not _STATE.dense_backend_logged:
+        _emit(
+            "dense_backend",
+            backend=type(attention._attention_impl).__name__,
+            q_shape=list(q.shape),
+        )
+        _STATE.dense_backend_logged = True
+    return attention._attention_impl.forward_varlen(
+        q,
+        k,
+        v,
+        cu_seqlens=cu_seqlens,
+        max_seqlen=max_seqlen,
+        cu_seqlens_host=cu_seqlens_host,
+    )
+
+
+def _dense_text_queries(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    start: int,
+    tokens: int,
+    scale: float,
+) -> torch.Tensor:
+    q_text = q[:, start : start + tokens].transpose(1, 2)
+    k_heads = k.transpose(1, 2)
+    v_heads = v.transpose(1, 2)
+    output = F.scaled_dot_product_attention(
+        q_text,
+        k_heads,
+        v_heads,
+        dropout_p=0.0,
+        is_causal=False,
+        scale=scale,
+    )
+    return output.transpose(1, 2)
+
+
+def _error_stats(
+    actual: torch.Tensor, expected: torch.Tensor
+) -> dict[str, float | int]:
+    difference = actual.float() - expected.float()
+    absolute = difference.abs()
+    denominator = torch.linalg.vector_norm(expected.float()).clamp_min(1.0e-12)
+    flat_index = int(absolute.argmax().item())
+    actual_flat = actual.float().reshape(-1)
+    expected_flat = expected.float().reshape(-1)
+    return {
+        "max_abs": float(absolute.reshape(-1)[flat_index].item()),
+        "mean_abs": float(absolute.mean().item()),
+        "rel_l2": float(
+            (torch.linalg.vector_norm(difference) / denominator).item()
+        ),
+        "max_error_flat_index": flat_index,
+        "actual_at_max_error": float(actual_flat[flat_index].item()),
+        "expected_at_max_error": float(expected_flat[flat_index].item()),
+    }
+
+
+@torch.no_grad()
+def _real_qkv_gate(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    scale: float,
+) -> None:
+    shape_key = (int(q.shape[1]), int(q.shape[2]), int(q.shape[3]))
+    if (
+        shape_key in _STATE.gate_shapes
+        or os.getenv("SOL_ATTN_CORRECTNESS_GATE", "1") != "1"
+    ):
+        return
+    from sol_attn import sol_attn
+
+    gate_heads = min(int(os.getenv("SOL_ATTN_GATE_HEADS", "1")), q.shape[2])
+    q_gate = q[:, :, :gate_heads].contiguous()
+    k_gate = k[:, :, :gate_heads].contiguous()
+    v_gate = v[:, :, :gate_heads].contiguous()
+    # This one-shot validation follows component loading and dense warmup.
+    # Release inactive allocator blocks before Triton's first autotune sweep.
+    torch.cuda.synchronize(q.device)
+    torch.cuda.empty_cache()
+    config = sol_attn(
+        q_gate,
+        k_gate,
+        v_gate,
+        scale=scale,
+        tau=-1000.0,
+        thresh_type="diag",
+    )
+    reference = F.scaled_dot_product_attention(
+        q_gate.transpose(1, 2),
+        k_gate.transpose(1, 2),
+        v_gate.transpose(1, 2),
+        dropout_p=0.0,
+        is_causal=False,
+        scale=scale,
+    ).transpose(1, 2)
+    torch.cuda.synchronize(q.device)
+    stats = _error_stats(config, reference)
+    limits = {
+        "max_abs": float(
+            os.getenv(
+                "SOL_ATTN_GATE_MAX_ABS",
+                "0.15" if q.shape[1] >= 32768 else "0.08",
+            )
+        ),
+        "mean_abs": float(os.getenv("SOL_ATTN_GATE_MEAN_ABS", "0.002")),
+        "rel_l2": float(os.getenv("SOL_ATTN_GATE_REL_L2", "0.005")),
+    }
+    passed = all(stats[name] <= limit for name, limit in limits.items())
+    _emit(
+        "real_qkv_correctness_gate",
+        passed=passed,
+        shape=list(q_gate.shape),
+        stats=stats,
+        limits=limits,
+    )
+    if not passed:
+        raise RuntimeError(f"MiniMax-H3 Sol-Attn correctness gate failed: {stats}")
+    _STATE.gate_shapes.add(shape_key)
+
+
+@torch.no_grad()
+def _estimate_density(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    scale: float,
+    tau: float,
+    thresh_type: str,
+    sink_start: int,
+    sink_tokens: int,
+) -> dict[str, float | int]:
+    from sol_attn.preprocess import BLOCK_SIZE, prepare
+
+    sample_heads = min(int(os.getenv("SOL_ATTN_DENSITY_SAMPLE_HEADS", "1")), q.shape[2])
+    q_sample = q[:, :, :sample_heads].contiguous()
+    k_sample = k[:, :, :sample_heads].contiguous()
+    v_sample = v[:, :, :sample_heads].contiguous()
+    kc, _, threshold = prepare(
+        q_sample,
+        k_sample,
+        v_sample,
+        scale=scale,
+        tau=tau,
+        thresh_type=thresh_type,
+    )
+    tokens = q_sample.shape[1]
+    blocks = math.ceil(tokens / BLOCK_SIZE)
+    pad = blocks * BLOCK_SIZE - tokens
+    q_padded = F.pad(q_sample, (0, 0, 0, 0, 0, pad))
+    q_sum = q_padded.view(
+        q_sample.shape[0], blocks, BLOCK_SIZE, sample_heads, q_sample.shape[3]
+    ).float().sum(dim=2)
+    counts = torch.full(
+        (blocks,),
+        BLOCK_SIZE,
+        device=q.device,
+        dtype=torch.float32,
+    )
+    counts[-1] = tokens - (blocks - 1) * BLOCK_SIZE
+    q_bar = q_sum / counts.view(1, blocks, 1, 1)
+    scores = torch.einsum("bqhd,bkhd->bqkh", q_bar, kc.float())
+    scores.mul_(scale * math.log2(math.e))
+    routed = scores > threshold[:, :, None, :]
+    threshold_density = float(routed.float().mean().item())
+
+    block_ids = torch.arange(blocks, device=q.device)
+    local_band = (block_ids[:, None] - block_ids[None, :]).abs() <= 1
+    routed |= local_band[None, :, :, None]
+    sink_blocks = 0
+    if sink_tokens:
+        sink_first = sink_start // BLOCK_SIZE
+        sink_last = math.ceil((sink_start + sink_tokens) / BLOCK_SIZE)
+        routed[:, :, sink_first:sink_last, :] = True
+        sink_blocks = sink_last - sink_first
+    return {
+        "sample_heads": sample_heads,
+        "blocks": blocks,
+        "sink_blocks": sink_blocks,
+        "threshold_density": threshold_density,
+        "effective_density": float(routed.float().mean().item()),
+    }
+
+
+def _dense_policy(layer_index: int | None, context: StepContext | None) -> bool:
+    if layer_index is None or context is None:
+        return True
+    if os.getenv("SOL_ATTN_FORCE_DENSE", "0") == "1":
+        return True
+    first_steps = int(os.getenv("SOL_ATTN_FIRST_DENSE_STEPS", "10"))
+    layer_ratio = float(os.getenv("SOL_ATTN_FIRST_DENSE_LAYER_RATIO", "0.03"))
+    default_layers = max(1, math.ceil(context.num_layers * layer_ratio))
+    first_layers = int(os.getenv("SOL_ATTN_FIRST_DENSE_LAYERS", str(default_layers)))
+    return context.step_index < first_steps or layer_index < first_layers
+
+
+@torch.no_grad()
+def _sol_varlen(
+    attention: Any,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    boundaries: tuple[int, ...],
+    context: StepContext,
+) -> torch.Tensor:
+    from sol_attn import sol_attn
+
+    tau = float(os.getenv("SOL_ATTN_TAU", "1.0"))
+    thresh_type = os.getenv("SOL_ATTN_THRESH_TYPE", "diag")
+    output = torch.zeros_like(q)
+    for raw_start, raw_end in zip(boundaries, boundaries[1:]):
+        start = min(raw_start, context.live_tokens)
+        end = min(raw_end, context.live_tokens)
+        if end <= start:
+            continue
+        q_segment = q[start:end].unsqueeze(0).contiguous()
+        k_segment = k[start:end].unsqueeze(0).contiguous()
+        v_segment = v[start:end].unsqueeze(0).contiguous()
+        text_global_start = context.text_start
+        text_global_end = context.text_start + context.text_tokens
+        sink_global_start = max(start, text_global_start)
+        sink_global_end = min(end, text_global_end)
+        sink_tokens = max(0, sink_global_end - sink_global_start)
+        sink_start = sink_global_start - start if sink_tokens else 0
+
+        _real_qkv_gate(
+            q_segment,
+            k_segment,
+            v_segment,
+            scale=attention.softmax_scale,
+        )
+        shape_key = (
+            int(q_segment.shape[1]),
+            int(q_segment.shape[2]),
+            int(q_segment.shape[3]),
+        )
+        if shape_key not in _STATE.density_logged_shapes:
+            density = _estimate_density(
+                q_segment,
+                k_segment,
+                v_segment,
+                scale=attention.softmax_scale,
+                tau=tau,
+                thresh_type=thresh_type,
+                sink_start=sink_start,
+                sink_tokens=sink_tokens,
+            )
+            _emit(
+                "route_density",
+                tau=tau,
+                thresh_type=thresh_type,
+                sequence_tokens=end - start,
+                sink_start=sink_start,
+                sink_tokens=sink_tokens,
+                **density,
+            )
+            _STATE.density_logged_shapes.add(shape_key)
+
+        started = time.perf_counter()
+        segment_output = sol_attn(
+            q_segment,
+            k_segment,
+            v_segment,
+            scale=attention.softmax_scale,
+            tau=tau,
+            thresh_type=thresh_type,
+            sink_start=sink_start,
+            sink_tokens=sink_tokens,
+        )
+        if sink_tokens:
+            segment_output[:, sink_start : sink_start + sink_tokens] = (
+                _dense_text_queries(
+                    q_segment,
+                    k_segment,
+                    v_segment,
+                    start=sink_start,
+                    tokens=sink_tokens,
+                    scale=attention.softmax_scale,
+                )
+            )
+        output[start:end].copy_(segment_output[0])
+
+        if shape_key not in _STATE.first_sparse_logged_shapes:
+            torch.cuda.synchronize(q.device)
+            _emit(
+                "first_sparse_forward",
+                q_shape=list(q_segment.shape),
+                elapsed_s=time.perf_counter() - started,
+                tau=tau,
+                thresh_type=thresh_type,
+                sink_start=sink_start,
+                sink_tokens=sink_tokens,
+            )
+            _STATE.first_sparse_logged_shapes.add(shape_key)
+    return output
+
+
+@torch.no_grad()
+def forward_attention(
+    attention: Any,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor,
+    cu_seqlens_host: tuple[int, ...] | None,
+    max_seqlen: int,
+    ulysses_active: bool,
+) -> torch.Tensor:
+    """Replace only the H3 main DiT attention core."""
+
+    if ulysses_active:
+        from sglang.multimodal_gen.runtime.layers.usp import (
+            _usp_input_all_to_all_packed_qkv,
+            _usp_output_all_to_all,
+        )
+
+        q, k, v = _usp_input_all_to_all_packed_qkv(q, k, v)
+
+    layer_index = getattr(attention, "_sol_attn_layer_index", None)
+    context = _STATE.context
+    if _dense_policy(layer_index, context):
+        output = _dense_varlen(
+            attention,
+            q,
+            k,
+            v,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_host=cu_seqlens_host,
+            max_seqlen=max_seqlen,
+        )
+    else:
+        if context is None:
+            raise RuntimeError("MiniMax-H3 Sol-Attn context was not initialized")
+        boundaries = _normalize_boundaries(
+            cu_seqlens_host or context.cu_seqlens_host,
+            q.shape[0],
+        )
+        output = _sol_varlen(
+            attention,
+            q,
+            k,
+            v,
+            boundaries=boundaries,
+            context=context,
+        )
+
+    if ulysses_active:
+        output = _usp_output_all_to_all(output[None], head_dim=2)[0]
+    return output
+
+
+__all__ = [
+    "StepContext",
+    "begin_model_forward",
+    "emit_event",
+    "forward_attention",
+    "parse_layer_index",
+]

--- a/models/minimax_h3/RTX4090/gpu_infer.py
+++ b/models/minimax_h3/RTX4090/gpu_infer.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Run the registered single-RTX-4090 MiniMax-H3 profile."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+import torch
+
+
+RUNTIME_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = RUNTIME_ROOT.parents[2]
+sys.path.insert(0, str(RUNTIME_ROOT))
+
+from registration import register_runtime  # noqa: E402
+
+
+# Multiprocessing uses spawn. Keeping registration at module scope makes the
+# same local model/pipeline entries available in every SGLang worker process.
+PROFILE = register_runtime()
+
+from sglang.multimodal_gen.runtime.entrypoints.diffusion_generator import (  # noqa: E402
+    DiffGenerator,
+)
+
+
+DEFAULT_PROMPT_FILE = REPO_ROOT / "models/minimax_h3/demo_prompt.json"
+
+
+def _device_metadata() -> tuple[str, str]:
+    if not torch.cuda.is_available():
+        raise RuntimeError("The RTX 4090 runtime requires a CUDA device")
+    device_index = torch.cuda.current_device()
+    capability = torch.cuda.get_device_capability(device_index)
+    if capability != (8, 9):
+        raise RuntimeError(
+            "The RTX 4090 runtime requires SM89, got "
+            f"SM{capability[0]}{capability[1]} on "
+            f"{torch.cuda.get_device_name(device_index)}"
+        )
+    return torch.cuda.get_device_name(device_index), "sm89"
+
+
+def _load_prompt() -> tuple[str, str]:
+    direct = os.environ.get("H3_PROMPT")
+    if direct:
+        return direct, "H3_PROMPT"
+
+    prompt_file = Path(os.environ.get("H3_PROMPT_FILE", str(DEFAULT_PROMPT_FILE)))
+    payload = json.loads(prompt_file.read_text(encoding="utf-8"))
+    prompt = payload.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        raise ValueError(f"Prompt file has no non-empty prompt: {prompt_file}")
+    return prompt, str(prompt_file)
+
+
+def _metric_seconds(metrics: dict[str, Any], fallback: float) -> float:
+    if "total_duration_s" in metrics:
+        return float(metrics["total_duration_s"])
+    if "total_duration_ms" in metrics:
+        return float(metrics["total_duration_ms"]) / 1000.0
+    return float(fallback)
+
+
+def _result_record(result) -> dict[str, Any]:
+    metrics = dict(result.metrics or {})
+    peak_memory_mb = result.peak_memory_mb
+    return {
+        "inference_time_s": _metric_seconds(metrics, result.generation_time),
+        "generation_wall_s": float(result.generation_time),
+        "peak_memory_mb": (
+            None if peak_memory_mb is None else float(peak_memory_mb)
+        ),
+        "output_file": result.output_file_path,
+        "metrics": metrics,
+    }
+
+
+def _sampling_params(
+    *,
+    prompt: str,
+    output_path: Path,
+    output_file_name: str,
+    steps: int,
+    duration_s: int,
+    seed: int,
+) -> dict[str, Any]:
+    return {
+        "prompt": prompt,
+        "task": "t2va",
+        "conditions": [],
+        "target": {
+            "short_edge": 768,
+            "aspect_ratio": "16:9",
+            "duration_seconds": float(duration_s),
+        },
+        "num_outputs_per_prompt": 1,
+        "num_inference_steps": steps,
+        "flow_shift": 12.0,
+        "audio_flow_shift": 3.0,
+        "seed": seed,
+        "output_path": str(output_path),
+        "output_file_name": output_file_name,
+        "save_output": True,
+        "return_file_paths_only": True,
+    }
+
+
+def _run_request(
+    generator: DiffGenerator,
+    *,
+    label: str,
+    epoch_file: Path,
+    **sampling_params: Any,
+) -> dict[str, Any]:
+    epoch_file.write_text(label + "\n", encoding="utf-8")
+    result = generator.generate(sampling_params_kwargs=sampling_params)
+    if result is None or isinstance(result, list):
+        raise RuntimeError(f"Expected one MiniMax-H3 result, got {result!r}")
+    return _result_record(result)
+
+
+def main() -> int:
+    device_name, compute_capability = _device_metadata()
+    model_path = os.environ.get("H3_MODEL_PATH", "MiniMaxAI/MiniMax-H3")
+    # The FL2VA weights sit in a subfolder of the MiniMax-H3 repository, so the
+    # subfolder depends on whether H3_MODEL_PATH already points inside it. Same
+    # rule as the H100 and A100 cells; this one hardcoded ".", which meant a
+    # repository id resolved to the repo root and the loader stopped on
+    # "does not contain model_index.json" -- only a path that already ended in
+    # FL2VA worked, and nothing said so outside the README.
+    model_subfolder = os.environ.get("H3_MODEL_SUBFOLDER")
+    if not model_subfolder:
+        model_subfolder = "." if Path(model_path).name.lower() == "fl2va" else "FL2VA"
+
+    output_dir = Path(os.environ.get("OUT_DIR", str(RUNTIME_ROOT / "outputs")))
+    output_dir.mkdir(parents=True, exist_ok=True)
+    warmup_dir = output_dir / "warmup"
+    warmup_dir.mkdir(exist_ok=True)
+
+    prompt, prompt_source = _load_prompt()
+    prompt_sha256 = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+    measured_steps = int(os.environ.get("H3_MEASURED_NUM_STEPS", "50"))
+    warmup_default = "5" if PROFILE == "dense" else str(measured_steps)
+    warmup_steps = int(os.environ.get("H3_WARMUP_NUM_STEPS", warmup_default))
+    duration_s = int(os.environ.get("H3_DURATION_SECONDS", "5"))
+    seed = int(os.environ.get("H3_SEED", "0"))
+    warmup_seed = int(os.environ.get("H3_WARMUP_SEED", str(seed + 1)))
+    master_port = int(os.environ.get("H3_MASTER_PORT", "30005"))
+    epoch_file = Path(
+        os.environ.get("SOL_ATTN_REQUEST_EPOCH_FILE", output_dir / "request_epoch.txt")
+    )
+
+    compile_enabled = PROFILE == "fullopt"
+    generator = DiffGenerator.from_pretrained(
+        local_mode=True,
+        model_path=model_path,
+        model_subfolder=model_subfolder,
+        num_gpus=1,
+        tp_size=1,
+        ulysses_degree=1,
+        performance_mode="memory",
+        layerwise_offload_components=["dit", "text_encoder", "vae"],
+        dit_offload_prefetch_size=int(
+            os.environ.get("H3_DIT_OFFLOAD_PREFETCH_SIZE", "1")
+        ),
+        dit_layerwise_resident_layers=int(
+            os.environ.get("H3_DIT_RESIDENT_LAYERS", "0")
+        ),
+        pin_cpu_memory=False,
+        enable_torch_compile=compile_enabled,
+        regional_compile=compile_enabled,
+        server_warmup=False,
+        master_port=master_port,
+    )
+    try:
+        warmup = _run_request(
+            generator,
+            label=f"warmup-{PROFILE}",
+            epoch_file=epoch_file,
+            **_sampling_params(
+                prompt=prompt,
+                output_path=warmup_dir,
+                output_file_name="warmup.mp4",
+                steps=warmup_steps,
+                duration_s=duration_s,
+                seed=warmup_seed,
+            ),
+        )
+        measured = _run_request(
+            generator,
+            label=f"measured-{PROFILE}",
+            epoch_file=epoch_file,
+            **_sampling_params(
+                prompt=prompt,
+                output_path=output_dir,
+                output_file_name="out.mp4",
+                steps=measured_steps,
+                duration_s=duration_s,
+                seed=seed,
+            ),
+        )
+    finally:
+        generator.shutdown()
+
+    benchmark = {
+        "profile": PROFILE,
+        "model": "MiniMaxAI/MiniMax-H3",
+        "partition": "FL2VA",
+        "dtype": "bfloat16",
+        "hardware": f"1x {device_name}",
+        "compute_capability": compute_capability,
+        "workload": {
+            "task": "t2va",
+            "width": 1344,
+            "height": 768,
+            "duration_s": duration_s,
+            "measured_steps": measured_steps,
+            "seed": seed,
+            "prompt_source": prompt_source,
+            "prompt_sha256": prompt_sha256,
+        },
+        "warmup": warmup,
+        "measured": measured,
+    }
+    benchmark_path = output_dir / "benchmark.json"
+    benchmark_path.write_text(
+        json.dumps(benchmark, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(benchmark, indent=2, sort_keys=True), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/models/minimax_h3/RTX4090/model.py
+++ b/models/minimax_h3/RTX4090/model.py
@@ -1,0 +1,1721 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MiniMax-H3 DiT registered by the single-RTX-4090 runtime.
+
+This is the pinned SGLang model implementation with the Sol-Attn dispatch and
+TeaCache block-stack policy integrated at their natural model boundaries.  It
+is loaded through SGLang's model registry; no installed SGLang file is edited
+or shadowed at runtime.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from adapter import (
+    begin_model_forward as _sol_attn_begin_model_forward,
+    forward_attention as _sol_attn_forward_attention,
+    parse_layer_index as _sol_attn_parse_layer_index,
+)
+from teacache import (
+    after_blocks as _sol_engine_teacache_after_blocks,
+    before_blocks as _sol_engine_teacache_before_blocks,
+    enabled as _sol_engine_teacache_enabled,
+)
+from sglang.kernels.ops.activation.activation import (
+    silu_and_mul_with_activation_rounding_,
+)
+from sglang.kernels.ops.diffusion.qknorm_rope import (
+    can_use_fused_inplace_qknorm_rope,
+    fused_inplace_qknorm_rope,
+)
+from sglang.kernels.ops.diffusion.triton.indexed_modulation import (
+    indexed_gate_bf16_,
+    indexed_scale_shift_bf16_,
+)
+from sglang.kernels.ops.layernorm.norm import fused_inplace_qknorm
+from sglang.multimodal_gen import envs
+from sglang.multimodal_gen.configs.models.dits.minimax_h3 import (
+    MINIMAX_H3_ADALN_MODALITY_NUM,
+    MINIMAX_H3_PACKED_SEQUENCE_ALIGNMENT,
+    MiniMaxH3DiTArchConfig,
+    MiniMaxH3DiTConfig,
+)
+from sglang.multimodal_gen.runtime.distributed import (
+    get_tp_world_size,
+    tensor_model_parallel_all_gather,
+)
+from sglang.multimodal_gen.runtime.layers.attention.selector import get_attn_backend
+from sglang.multimodal_gen.runtime.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    RowParallelLinear,
+)
+from sglang.multimodal_gen.runtime.layers.quantization.configs.base_config import (
+    QuantizationConfig,
+)
+from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload import (
+    LayerwiseOffloadableModuleMixin,
+    is_layerwise_offloaded_module,
+)
+from sglang.multimodal_gen.runtime.models.dits.base import BaseDiT
+from sglang.multimodal_gen.runtime.platforms import (
+    AttentionBackendEnum,
+    current_platform,
+)
+from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
+    eager_on_graph,
+)
+
+_ARCH_DEFAULTS = MiniMaxH3DiTArchConfig()
+_BF16_DTYPE = torch.bfloat16
+_FP32_DTYPE = torch.float32
+
+_MINIMAX_H3_FP32_PARAM_NAMES_IN_MODEL_ORDER = (
+    "video_patch_proj.weight",
+    "video_patch_proj.bias",
+    "audio_patch_proj.weight",
+    "audio_patch_proj.bias",
+    "time_embedder.proj_in.weight",
+    "time_embedder.proj_in.bias",
+    "time_embedder.proj_out.weight",
+    "time_embedder.proj_out.bias",
+    "final_layer.video_out.weight",
+    "final_layer.video_out.bias",
+    "final_layer.audio_out.weight",
+    "final_layer.audio_out.bias",
+)
+MINIMAX_H3_FP32_PARAM_NAMES = frozenset(_MINIMAX_H3_FP32_PARAM_NAMES_IN_MODEL_ORDER)
+MINIMAX_H3_FP32_BUFFER_NAMES = frozenset({"rope.inv_freq"})
+
+
+def _required_kwarg(kwargs: dict[str, Any], key: str) -> Any:
+    if key not in kwargs or kwargs[key] is None:
+        raise ValueError(f"MiniMaxH3DiTModel.forward requires kwarg {key!r}")
+    return kwargs[key]
+
+
+# The exhaustive keyword contract of MiniMaxH3DiTModel.forward. Anything not
+# listed here is rejected with a TypeError before any tensor work starts.
+_FORWARD_SUPPORTED_KWARGS = frozenset(
+    {
+        "x",
+        "audio_x",
+        "img_position_ids",
+        "rope_cache",
+        "unique_timesteps",
+        "inverse_indices",
+        "update_mask",
+        "update_audio_mask",
+        "token_tags",
+        "block_token_tags",
+        "block_combined_indices",
+        "skip_mask_out_condition",
+        "prompt_embeds",
+        "refined_prompt_embeds_length",
+        "img_pos_info",
+        "audio_pos_info",
+        "text_pos_info",
+        "img_pos_for_infer_output_info",
+        "local_embedding_layout",
+        "packed_seq_params",
+        "refiner_packed_seq_params",
+    }
+)
+
+
+def _ulysses_ctx() -> tuple[int, int]:
+    """(world_size, rank) of the Ulysses sequence-parallel group.
+
+    Returns (1, 0) when model parallelism is not initialized (unit tests /
+    single-process debug paths init tp=1 sp=1 which also yields ws=1).
+    """
+    from sglang.multimodal_gen.runtime.distributed.parallel_state import (
+        get_ulysses_parallel_rank,
+        get_ulysses_parallel_world_size,
+        model_parallel_is_initialized,
+    )
+
+    if not model_parallel_is_initialized():
+        return 1, 0
+    return get_ulysses_parallel_world_size(), get_ulysses_parallel_rank()
+
+
+def _ring_world_size() -> int:
+    from sglang.multimodal_gen.runtime.distributed.parallel_state import (
+        get_ring_parallel_world_size,
+        model_parallel_is_initialized,
+    )
+
+    if not model_parallel_is_initialized():
+        return 1
+    return get_ring_parallel_world_size()
+
+
+def _reorder_grouped_qkv_to_qkv(
+    weight: torch.Tensor,
+    *,
+    num_query_groups: int,
+    heads_per_group: int,
+    head_dim: int,
+) -> torch.Tensor:
+    per_group = (heads_per_group + 2) * head_dim
+    expected_out = num_query_groups * per_group
+    if weight.shape[0] != expected_out:
+        raise ValueError(
+            "qkv weight has incompatible output dim for grouped checkpoint layout: "
+            f"got {tuple(weight.shape)}, expected first dim {expected_out}."
+        )
+
+    rest_shape = weight.shape[1:]
+    grouped = weight.reshape(num_query_groups, per_group, *rest_shape)
+    q, k, v = torch.split(
+        grouped,
+        [heads_per_group * head_dim, head_dim, head_dim],
+        dim=1,
+    )
+    return torch.cat(
+        [
+            q.reshape(num_query_groups * heads_per_group * head_dim, *rest_shape),
+            k.reshape(num_query_groups * head_dim, *rest_shape),
+            v.reshape(num_query_groups * head_dim, *rest_shape),
+        ],
+        dim=0,
+    )
+
+
+def _copy_grouped_qkv_tp_shard(
+    param: torch.Tensor,
+    loaded_weight: torch.Tensor,
+    *,
+    num_query_groups: int,
+    head_dim: int,
+    tp_rank: int,
+    tp_size: int,
+) -> bool:
+    """Copy a dense MHA checkpoint directly into its TP-local Q/K/V rows."""
+    if (
+        tp_size <= 0
+        or not 0 <= tp_rank < tp_size
+        or num_query_groups % tp_size
+        or getattr(param, "output_dim", None) != 0
+        or getattr(param, "is_sharded_weight", False)
+        or getattr(param, "packed_dim", None) is not None
+        or param.dtype != _BF16_DTYPE
+        or loaded_weight.dtype != _BF16_DTYPE
+        or not param.is_contiguous()
+        or not loaded_weight.is_contiguous()
+    ):
+        return False
+
+    expected_rows = num_query_groups * 3 * head_dim
+    local_groups = num_query_groups // tp_size
+    rest_shape = loaded_weight.shape[1:]
+    if loaded_weight.shape[0] != expected_rows or tuple(param.shape) != (
+        3 * local_groups * head_dim,
+        *rest_shape,
+    ):
+        return False
+
+    grouped = loaded_weight.view(num_query_groups, 3, head_dim, *rest_shape)
+    grouped = grouped.narrow(0, tp_rank * local_groups, local_groups)
+    target = param.data.view(3, local_groups, head_dim, *rest_shape)
+    for index in range(3):
+        target[index].copy_(grouped[:, index])
+    return True
+
+
+def _norm(size: int, *, eps: float, dtype: torch.dtype = _BF16_DTYPE) -> nn.RMSNorm:
+    # RMSNorm uses fp32 accumulation with bf16 inputs and outputs.
+    # torch.nn.RMSNorm upcasts reduced-precision inputs for the variance
+    # reduction, matching that accumulation semantic.
+    return nn.RMSNorm(size, eps=eps, dtype=dtype)
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1, x2 = torch.chunk(x, 2, dim=-1)
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _modulate_scale_shift(
+    x: torch.Tensor,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+    indices: torch.Tensor,
+    *,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Apply indexed affine modulation, reusing disposable CUDA BF16 input."""
+    # Apply per-index affine modulation: x * (1 + scale[idx]) + shift[idx].
+    if (
+        x.is_cuda
+        and x.dtype == _BF16_DTYPE
+        and dtype == _BF16_DTYPE
+        and shift.dtype == _BF16_DTYPE
+        and scale.dtype == _BF16_DTYPE
+        and x.is_contiguous()
+    ):
+        return indexed_scale_shift_bf16_(x, shift, scale, indices)
+    return (
+        x * (1.0 + scale.index_select(0, indices)) + shift.index_select(0, indices)
+    ).to(dtype)
+
+
+def _modulate_gate(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    other: torch.Tensor,
+    indices: torch.Tensor,
+    *,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Apply indexed gated residual, reusing disposable CUDA BF16 input."""
+    # Apply the per-index gated residual: x + gate[idx] * other.
+    if (
+        x.is_cuda
+        and x.dtype == _BF16_DTYPE
+        and dtype == _BF16_DTYPE
+        and gate.dtype == _BF16_DTYPE
+        and other.dtype == _BF16_DTYPE
+        and x.is_contiguous()
+        and other.is_contiguous()
+    ):
+        return indexed_gate_bf16_(x, gate, other, indices)
+    return (x + gate.index_select(0, indices) * other).to(dtype)
+
+
+def _silu_mul(hidden: torch.Tensor, *, reuse_input: bool) -> torch.Tensor:
+    if (
+        reuse_input
+        and hidden.is_cuda
+        and hidden.dtype == _BF16_DTYPE
+        and hidden.is_contiguous()
+        and hidden.shape[-1] % 16 == 0
+    ):
+        return silu_and_mul_with_activation_rounding_(hidden)
+    gate, up = hidden.chunk(2, dim=-1)
+    return nn.functional.silu(gate) * up
+
+
+def _apply_qk_norm(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_norm: nn.RMSNorm,
+    k_norm: nn.RMSNorm,
+    head_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if (
+        q.is_cuda
+        and q.dtype == _BF16_DTYPE
+        and q.dtype == k.dtype == q_norm.weight.dtype == k_norm.weight.dtype
+        and q.stride(-1) == k.stride(-1) == 1
+        and q.stride(-2) == k.stride(-2) == head_dim
+        and q_norm.eps == k_norm.eps
+        and not torch.compiler.is_compiling()
+    ):
+        fused_inplace_qknorm(
+            q,
+            k,
+            q_norm.weight,
+            k_norm.weight,
+            eps=q_norm.eps,
+            head_dim=head_dim,
+        )
+        return q, k
+    return q_norm(q), k_norm(k)
+
+
+class MiniMaxH3Rope(nn.Module):
+    """3D rope over (t, h, w); rotates 96 of 128 head dims (rotary_percent 0.75).
+
+    Frequency layout concatenates temporal, height, and width embeddings twice,
+    with 16 frequencies per axis (inv_freq = base^-(arange(0,32,2)/32)).
+    """
+
+    def __init__(self, inv_freq_len: int) -> None:
+        super().__init__()
+        self.register_buffer(
+            "inv_freq",
+            torch.empty(inv_freq_len, dtype=_FP32_DTYPE),
+            persistent=True,
+        )
+
+    def forward(self, img_position_ids: torch.Tensor) -> torch.Tensor:
+        """img_position_ids: [1, S, 3] (t, h, w) -> freqs [S, rot_dim=96]."""
+        if img_position_ids.dim() != 3 or img_position_ids.shape[0] != 1:
+            raise ValueError(
+                "img_position_ids must be [1, S, 3], got "
+                f"{list(img_position_ids.shape)}"
+            )
+        pos = img_position_ids[0].to(_FP32_DTYPE)  # [S, 3]
+        per_axis = pos.unsqueeze(-1) * self.inv_freq.view(1, 1, -1)  # [S, 3, 16]
+        t_f, h_f, w_f = per_axis.unbind(dim=1)  # each [S, 16]
+        half = torch.cat((t_f, h_f, w_f), dim=-1)  # [S, 48]
+        return torch.cat((half, half), dim=-1)  # [S, 96]
+
+
+def _rope_cos_sin_cache(freqs: torch.Tensor, *, dtype: torch.dtype) -> torch.Tensor:
+    """Build the activation-dtype cos|sin cache for fused Q/K RoPE."""
+    half = freqs.shape[-1] // 2
+    return (
+        torch.cat(
+            (torch.cos(freqs[:, :half]), torch.sin(freqs[:, :half])),
+            dim=-1,
+        )
+        .to(dtype=dtype, copy=False)
+        .contiguous()
+    )
+
+
+def _apply_rope_cos_sin(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> torch.Tensor:
+    """Rotate the first cached RoPE dims; pass the remaining head dims through."""
+    rot_dim = cos.shape[-1]
+    x_rot, x_pass = x[..., :rot_dim], x[..., rot_dim:]
+    x_rot = (x_rot * cos) + (_rotate_half(x_rot) * sin)
+    return torch.cat((x_rot, x_pass), dim=-1)
+
+
+def _apply_rope_qk(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if not q.is_cuda:
+        half = cos_sin_cache.shape[-1] // 2
+        cos_half, sin_half = cos_sin_cache.split(half, dim=-1)
+        cos = torch.cat((cos_half, cos_half), dim=-1).unsqueeze(1)
+        sin = torch.cat((sin_half, sin_half), dim=-1).unsqueeze(1)
+        return (
+            _apply_rope_cos_sin(q, cos, sin),
+            _apply_rope_cos_sin(k, cos, sin),
+        )
+
+    from sgl_kernel import rotary_embedding as apply_sgl_kernel_rotary_embedding
+
+    apply_sgl_kernel_rotary_embedding(
+        positions,
+        q.view(q.shape[0], -1),
+        k.view(k.shape[0], -1),
+        q.shape[-1],
+        cos_sin_cache,
+        True,
+    )
+    return q, k
+
+
+class MiniMaxH3TimeEmbedder(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.frequency_embedding_size = arch.timestep_input_dim
+        self.proj_in = ColumnParallelLinear(
+            arch.timestep_input_dim,
+            arch.time_embed_hidden_size,
+            bias=True,
+            gather_output=False,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix=f"{prefix}.proj_in",
+        )
+        self.proj_out = RowParallelLinear(
+            arch.time_embed_hidden_size,
+            arch.time_embed_dim,
+            bias=True,
+            input_is_parallel=True,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix=f"{prefix}.proj_out",
+        )
+        self.register_buffer("_frequency_cache", None, persistent=False)
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        """t: [M] -> [M, time_embed_dim] fp32.
+
+        The sinusoidal embedding stays fp32 throughout and concatenates cosine
+        values before sine values.
+        """
+        half = self.frequency_embedding_size // 2
+        freqs = self._frequency_cache
+        if freqs is None or freqs.device != t.device:
+            # Construct this on the execution device once so the values keep
+            # the established CUDA numerics without repeating arange/exp on
+            # every denoise step.
+            freqs = torch.exp(
+                -math.log(10000.0)
+                * torch.arange(half, dtype=_FP32_DTYPE, device=t.device)
+                / half
+            )
+            self._frequency_cache = freqs
+        args = t.to(_FP32_DTYPE)[:, None] * freqs[None]
+        t_freq = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        hidden, _ = self.proj_in(t_freq)
+        hidden = nn.functional.silu(hidden)
+        out, _ = self.proj_out(hidden)
+        return out
+
+
+@torch.compiler.disable
+def _minimax_h3_attention_core_impl(
+    attention: MiniMaxH3Attention,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor,
+    cu_seqlens_host: tuple[int, ...] | None,
+    max_seqlen: int,
+    ulysses_active: bool,
+) -> torch.Tensor:
+    """Dynamic varlen attention and Ulysses collectives.
+
+    This is the narrow BCG break point: projections, normalization, RoPE,
+    residuals, and MLPs remain captured while the dynamic packed attention
+    kernel and sequence-parallel collectives execute eagerly.
+    """
+
+    return _sol_attn_forward_attention(
+        attention,
+        q,
+        k,
+        v,
+        cu_seqlens=cu_seqlens,
+        cu_seqlens_host=cu_seqlens_host,
+        max_seqlen=max_seqlen,
+        ulysses_active=ulysses_active,
+    )
+
+
+_minimax_h3_attention_core_bcg = eager_on_graph(True)(_minimax_h3_attention_core_impl)
+
+
+class MiniMaxH3Attention(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+        bcg_breakpoint: bool = True,
+    ) -> None:
+        super().__init__()
+        self.bcg_breakpoint = bcg_breakpoint
+        self.tp_size = get_tp_world_size()
+        if arch.num_attention_heads % self.tp_size:
+            raise ValueError(
+                "MiniMax H3 attention heads must be divisible by TP size: "
+                f"{arch.num_attention_heads} % {self.tp_size} != 0"
+            )
+        self.total_num_heads = arch.num_attention_heads
+        self.num_heads = self.total_num_heads // self.tp_size
+        self.head_dim = arch.attention_head_dim
+        self.inner_dim = self.total_num_heads * self.head_dim
+        self.local_inner_dim = self.num_heads * self.head_dim
+        self.softmax_scale = self.head_dim**-0.5
+        self._supported_attention_backends = arch._supported_attention_backends
+        self._attention_impl = None
+        self._sol_attn_layer_index = _sol_attn_parse_layer_index(prefix)
+        # The checkpoint stores one fused qkv tensor. Each logical Q/K/V
+        # matrix must be sharded independently; a plain ColumnParallelLinear
+        # would instead slice across the concatenated tensor and is incorrect
+        # for TP > 1.
+        self.qkv_proj = MergedColumnParallelLinear(
+            arch.hidden_size,
+            [self.inner_dim] * 3,
+            bias=False,
+            gather_output=False,
+            params_dtype=_BF16_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj",
+        )
+        self._install_qkv_weight_loader(arch)
+        self.q_norm = _norm(arch.attention_head_dim, eps=arch.qk_norm_eps)
+        self.k_norm = _norm(arch.attention_head_dim, eps=arch.qk_norm_eps)
+        # cache width covers cos/sin for temporal, height, and width frequencies
+        rope_dim = 6 * arch.rope_inv_freq_len
+        self._use_fused_qknorm_rope = (
+            current_platform.is_cuda()
+            and can_use_fused_inplace_qknorm_rope(
+                arch.attention_head_dim,
+                rope_dim,
+                True,
+                _BF16_DTYPE,
+                cache_dtype=_BF16_DTYPE,
+                round_norm_before_rope=True,
+            )
+        )
+        self.out_proj = RowParallelLinear(
+            self.inner_dim,
+            arch.hidden_size,
+            bias=False,
+            input_is_parallel=True,
+            params_dtype=_BF16_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.out_proj",
+        )
+
+    def _set_attention_backend(self, backend) -> None:
+        impl_cls = backend.get_impl_cls()
+        self._attention_impl = impl_cls(
+            num_heads=self.num_heads,
+            head_size=self.head_dim,
+            causal=False,
+            softmax_scale=self.softmax_scale,
+            num_kv_heads=self.num_heads,
+        )
+
+    def _install_qkv_weight_loader(self, arch: MiniMaxH3DiTArchConfig) -> None:
+        weight = self.qkv_proj.weight
+        base_loader = weight.weight_loader
+
+        def _weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
+            # The grouped checkpoint layout is
+            # [num_query_groups, q_per_group + k + v] before splitting.
+            # MiniMax H3 uses MHA, so checkpoint rows are per-head [q, k, v],
+            # while SGLang stores [q_all, k_all, v_all].
+            if _copy_grouped_qkv_tp_shard(
+                param,
+                loaded_weight,
+                num_query_groups=arch.num_attention_heads,
+                head_dim=arch.attention_head_dim,
+                tp_rank=self.qkv_proj.tp_rank,
+                tp_size=self.tp_size,
+            ):
+                return
+            reordered = _reorder_grouped_qkv_to_qkv(
+                loaded_weight,
+                num_query_groups=arch.num_attention_heads,
+                heads_per_group=1,
+                head_dim=arch.attention_head_dim,
+            )
+            base_loader(param, reordered)
+
+        if hasattr(weight, "_weight_loader"):
+            weight._weight_loader = _weight_loader
+        else:
+            weight.weight_loader = _weight_loader
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        rope_cache: tuple[torch.Tensor, torch.Tensor] | None,
+        cu_seqlens: torch.Tensor,
+        cu_seqlens_host: tuple[int, ...] | None = None,
+        max_seqlen: int,
+        ulysses_active: bool = False,
+    ) -> torch.Tensor:
+        """x: [T, hidden] packed thd rows -> [T, hidden].
+
+        Operation order: fused qkv projection -> per-head q/k RMSNorm -> RoPE
+        on q/k -> variable-length non-causal flash attention -> output projection.
+
+        With Ulysses sequence parallelism, x holds this rank's row shard;
+        qkv/norm/RoPE run locally, an all-to-all trades sequence for heads.
+        Each rank attends the full sequence with heads/world_size local heads,
+        so cu_seqlens retains global packed-document semantics. The inverse
+        all-to-all restores the row shard before the output projection.
+        """
+        total = x.shape[0]
+        qkv, _ = self.qkv_proj(x)
+        q, k, v = qkv.split(self.local_inner_dim, dim=-1)
+        q = q.view(total, self.num_heads, self.head_dim)
+        k = k.view(total, self.num_heads, self.head_dim)
+        v = v.view(total, self.num_heads, self.head_dim)
+        if rope_cache is None:
+            q, k = _apply_qk_norm(
+                q,
+                k,
+                self.q_norm,
+                self.k_norm,
+                self.head_dim,
+            )
+        else:
+            cos_sin_cache, positions = rope_cache
+            if self._use_fused_qknorm_rope and not torch.compiler.is_compiling():
+                fused_inplace_qknorm_rope(
+                    q,
+                    k,
+                    self.q_norm.weight,
+                    self.k_norm.weight,
+                    cos_sin_cache,
+                    positions,
+                    is_neox=True,
+                    eps=self.q_norm.eps,
+                    head_dim=self.head_dim,
+                    rope_dim=cos_sin_cache.shape[-1],
+                    round_norm_before_rope=True,
+                )
+            else:
+                q, k = _apply_qk_norm(
+                    q,
+                    k,
+                    self.q_norm,
+                    self.k_norm,
+                    self.head_dim,
+                )
+                q, k = _apply_rope_qk(q, k, cos_sin_cache, positions)
+
+        attention_core = (
+            _minimax_h3_attention_core_bcg
+            if self.bcg_breakpoint
+            else _minimax_h3_attention_core_impl
+        )
+        out = attention_core(
+            self,
+            q,
+            k,
+            v,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_host=cu_seqlens_host,
+            max_seqlen=max_seqlen,
+            ulysses_active=ulysses_active,
+        )
+        out = out.reshape(total, self.num_heads * self.head_dim)
+        out, _ = self.out_proj(out)
+        return out
+
+
+class MiniMaxH3MLP(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        # As with qkv, gate and up are two independently sharded logical
+        # matrices even though the checkpoint stores them fused.
+        self.fc1 = MergedColumnParallelLinear(
+            arch.hidden_size,
+            [arch.ffn_hidden_size] * 2,
+            bias=False,
+            gather_output=False,
+            params_dtype=_BF16_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.fc1",
+        )
+        # Chunk the fused fc1 output as [gate, up], then compute
+        # silu(gate) * up.
+        self.fc2 = RowParallelLinear(
+            arch.ffn_hidden_size,
+            arch.hidden_size,
+            bias=False,
+            input_is_parallel=True,
+            params_dtype=_BF16_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.fc2",
+        )
+        self.reuse_fc1_activation = quant_config is None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        hidden, _ = self.fc1(x)
+        hidden = _silu_mul(hidden, reuse_input=self.reuse_fc1_activation)
+        out, _ = self.fc2(hidden)
+        return out
+
+
+class MiniMaxH3AdalnProj(nn.Module):
+    """SiLU + zero-init linear over unique condition embeddings.
+
+    Per block, three modalities each produce six H-wide vectors:
+    [M, t_dim] -> [M, 3*6H] -> view(M*3, 6H) -> chunk(6).
+    The final layer uses one modality and produces two H-wide vectors:
+    [M, t_dim] -> [M, 2H] -> chunk(2).
+    """
+
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        out_features: int,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+        expand_ratio: int,
+        modality_num: int,
+    ) -> None:
+        super().__init__()
+        if out_features != expand_ratio * arch.hidden_size * modality_num:
+            raise ValueError(
+                "adaln out_features mismatch: "
+                f"{out_features} != {expand_ratio}*{arch.hidden_size}*{modality_num}"
+            )
+        self.expand_ratio = expand_ratio
+        self.modality_num = modality_num
+        self.hidden_size = arch.hidden_size
+        self.linear = ColumnParallelLinear(
+            arch.time_embed_dim,
+            out_features,
+            bias=True,
+            gather_output=False,
+            params_dtype=_BF16_DTYPE,
+            quant_config=quant_config,
+            prefix=f"{prefix}.linear",
+        )
+
+    def project_local(self, adaln_input: torch.Tensor) -> torch.Tensor:
+        x, _ = self.linear(adaln_input)
+        return x
+
+    def split_output(self, x: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        m = x.shape[0]
+        x = x.view(m * self.modality_num, self.expand_ratio * self.hidden_size)
+        return tuple(x.chunk(self.expand_ratio, dim=-1))
+
+    def forward(self, adaln_input: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        """adaln_input: SiLU(t_emb) BF16 -> expand_ratio tensors of [M*modality_num, H]."""
+        x = self.project_local(adaln_input)
+        if get_tp_world_size() > 1:
+            x = tensor_model_parallel_all_gather(x)
+        return self.split_output(x)
+
+
+class MiniMaxH3TokenRefinerBlock(nn.Module):
+    """Standard pre-norm transformer block without AdaLN or RoPE."""
+
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.norm1 = _norm(arch.hidden_size, eps=arch.norm_eps)
+        self.norm2 = _norm(arch.hidden_size, eps=arch.norm_eps)
+        # The whole dynamic text-refiner/scatter phase is one BCG break point;
+        # do not nest per-attention graph breaks inside it.
+        self.attn = MiniMaxH3Attention(
+            arch,
+            quant_config,
+            prefix=f"{prefix}.attn",
+            bcg_breakpoint=False,
+        )
+        self.mlp = MiniMaxH3MLP(arch, quant_config, prefix=f"{prefix}.mlp")
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor,
+        cu_seqlens_host: tuple[int, ...] | None = None,
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        x = x + self.attn(
+            self.norm1(x),
+            rope_cache=None,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_host=cu_seqlens_host,
+            max_seqlen=max_seqlen,
+        )
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class MiniMaxH3TokenRefiner(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.blocks = nn.ModuleList(
+            [
+                MiniMaxH3TokenRefinerBlock(
+                    arch,
+                    quant_config,
+                    prefix=f"{prefix}.blocks.{index}",
+                )
+                for index in range(arch.token_refiner_num_layers)
+            ]
+        )
+        self.final_norm = _norm(arch.hidden_size, eps=arch.final_norm_eps)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor,
+        cu_seqlens_host: tuple[int, ...] | None = None,
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        for block in self.blocks:
+            x = block(
+                x,
+                cu_seqlens=cu_seqlens,
+                cu_seqlens_host=cu_seqlens_host,
+                max_seqlen=max_seqlen,
+            )
+        return self.final_norm(x)
+
+
+class MiniMaxH3DiTBlock(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.norm1 = _norm(arch.hidden_size, eps=arch.norm_eps)
+        self.norm2 = _norm(arch.hidden_size, eps=arch.norm_eps)
+        self.attn = MiniMaxH3Attention(
+            arch,
+            quant_config,
+            prefix=f"{prefix}.attn",
+        )
+        self.mlp = MiniMaxH3MLP(arch, quant_config, prefix=f"{prefix}.mlp")
+        self.adaln_proj = MiniMaxH3AdalnProj(
+            arch,
+            arch.adaln_out_features,
+            quant_config,
+            prefix=f"{prefix}.adaln_proj",
+            expand_ratio=6,
+            modality_num=MINIMAX_H3_ADALN_MODALITY_NUM,
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        adaln_input: torch.Tensor,
+        combined_indices: torch.Tensor,
+        rope_cache: tuple[torch.Tensor, torch.Tensor],
+        cu_seqlens: torch.Tensor,
+        cu_seqlens_host: tuple[int, ...] | None = None,
+        max_seqlen: int,
+        ulysses_active: bool = False,
+        adaln_params: tuple[torch.Tensor, ...] | None = None,
+    ) -> torch.Tensor:
+        """x: [T, H]; adaln_input: [M, t_dim]; combined_indices: [T]
+        (= inverse_indices * modality_num + token_tags.clamp(min=0)).
+
+        Each block computes AdaLN parameters once, then applies
+        norm1 -> scale/shift -> attention -> gated residual, followed by
+        norm2 -> scale/shift -> MLP -> gated residual.
+        """
+        if adaln_params is None:
+            adaln_params = self.adaln_proj(adaln_input)
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = adaln_params
+
+        residual = x
+        h = self.norm1(x)
+        h = _modulate_scale_shift(
+            h, shift_msa, scale_msa, combined_indices, dtype=_BF16_DTYPE
+        )
+        h = self.attn(
+            h,
+            rope_cache=rope_cache,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_host=cu_seqlens_host,
+            max_seqlen=max_seqlen,
+            ulysses_active=ulysses_active,
+        )
+        x = _modulate_gate(residual, gate_msa, h, combined_indices, dtype=_BF16_DTYPE)
+
+        residual = x
+        h = self.norm2(x)
+        h = _modulate_scale_shift(
+            h, shift_mlp, scale_mlp, combined_indices, dtype=_BF16_DTYPE
+        )
+        h = self.mlp(h)
+        return _modulate_gate(
+            residual, gate_mlp, h, combined_indices, dtype=_BF16_DTYPE
+        )
+
+
+class MiniMaxH3FinalLayer(nn.Module):
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        quant_config: QuantizationConfig | None,
+        *,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        video_patch_dim = (
+            arch.latents_dim
+            * arch.patch_size[0]
+            * arch.patch_size[1]
+            * arch.patch_size[2]
+        )
+        self.norm = _norm(arch.hidden_size, eps=arch.final_norm_eps)
+        self.adaln_proj = MiniMaxH3AdalnProj(
+            arch,
+            arch.final_adaln_out_features,
+            quant_config,
+            prefix=f"{prefix}.adaln_proj",
+            expand_ratio=2,
+            modality_num=1,
+        )
+        self.video_out = ColumnParallelLinear(
+            arch.hidden_size,
+            video_patch_dim,
+            bias=True,
+            gather_output=False,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix=f"{prefix}.video_out",
+        )
+        self.audio_out = ColumnParallelLinear(
+            arch.hidden_size,
+            arch.audio_latents_dim,
+            bias=True,
+            gather_output=False,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix=f"{prefix}.audio_out",
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        adaln_input: torch.Tensor,
+        inverse_indices: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Project all rows into TP-local video/audio output shards.
+
+        Apply single-modality shift/scale AdaLN to the final normalized
+        activations, cast to fp32, then apply both output heads to all rows.
+        The model gathers output columns only after selecting live media rows,
+        preserving the GEMM shape while reducing collective payload.
+        """
+        shift, scale = self.adaln_proj(adaln_input)
+        h = self.norm(x)
+        h = _modulate_scale_shift(h, shift, scale, inverse_indices, dtype=_BF16_DTYPE)
+        # Preserve full precision through both final output projections.
+        h = h.to(_FP32_DTYPE)
+        video, _ = self.video_out(h)
+        audio, _ = self.audio_out(h)
+        return video, audio
+
+
+class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
+    _fsdp_shard_conditions = _ARCH_DEFAULTS._fsdp_shard_conditions
+    # parameters mix fp32 (patch projections, timestep embedder, and output
+    # heads) with bf16 blocks; FSDP must gather in each parameter's own dtype
+    _fsdp_mixed_dtype_params = True
+    _compile_conditions = _ARCH_DEFAULTS._compile_conditions
+    _supported_attention_backends = _ARCH_DEFAULTS._supported_attention_backends
+    param_names_mapping = _ARCH_DEFAULTS.param_names_mapping
+    reverse_param_names_mapping = _ARCH_DEFAULTS.reverse_param_names_mapping
+    lora_param_names_mapping = _ARCH_DEFAULTS.lora_param_names_mapping
+
+    def _can_batch_block_adaln(self) -> bool:
+        return (
+            get_tp_world_size() > 1
+            and not torch.compiler.is_compiling()
+            and not envs.SGLANG_CACHE_DIT_ENABLED
+            and not hasattr(self, "_sglang_cache_dit_adapter")
+            and not is_layerwise_offloaded_module(self)
+            and all(type(block) is MiniMaxH3DiTBlock for block in self.blocks)
+        )
+
+    def _validate_tp_config(
+        self, *, arch: MiniMaxH3DiTArchConfig, tp_size: int
+    ) -> None:
+        if tp_size <= 0:
+            raise ValueError("TP size must be positive.")
+        if arch.num_attention_heads <= 0:
+            raise ValueError("num_attention_heads must be positive.")
+        if arch.hidden_size <= 0:
+            raise ValueError("hidden_size must be positive.")
+        if arch.attention_head_dim <= 0:
+            raise ValueError("attention_head_dim must be positive.")
+        if arch.ffn_hidden_size <= 0:
+            raise ValueError("ffn_hidden_size must be positive.")
+        for name, value in (
+            ("num_attention_heads", arch.num_attention_heads),
+            ("hidden_size", arch.hidden_size),
+            ("ffn_hidden_size", arch.ffn_hidden_size),
+            ("time_embed_hidden_size", arch.time_embed_hidden_size),
+            ("adaln_out_features", arch.adaln_out_features),
+            ("final_adaln_out_features", arch.final_adaln_out_features),
+            ("video_patch_output_dim", arch.latents_dim * math.prod(arch.patch_size)),
+            ("audio_patch_output_dim", arch.audio_latents_dim),
+        ):
+            if value % tp_size:
+                raise ValueError(
+                    f"MiniMax H3 {name}={value} must be divisible by "
+                    f"TP size {tp_size}."
+                )
+
+    @staticmethod
+    def _validate_sequence_parallel_config(
+        *,
+        arch: MiniMaxH3DiTArchConfig,
+        tp_size: int,
+        ulysses_size: int,
+        ring_size: int,
+    ) -> None:
+        if ulysses_size <= 0:
+            raise ValueError("MiniMax H3 Ulysses size must be positive.")
+        if ring_size != 1:
+            raise NotImplementedError(
+                "MiniMax H3 packed multi-segment attention does not support "
+                "Ring or mixed USP. Set --ring-degree 1 and use Ulysses "
+                "sequence parallelism."
+            )
+        local_heads = arch.num_attention_heads // tp_size
+        if local_heads % ulysses_size:
+            raise ValueError(
+                f"MiniMax H3 TP-local heads {local_heads} must be divisible by "
+                f"Ulysses size {ulysses_size} (total heads="
+                f"{arch.num_attention_heads}, TP={tp_size})."
+            )
+        if MINIMAX_H3_PACKED_SEQUENCE_ALIGNMENT % ulysses_size:
+            raise ValueError(
+                "MiniMax H3 packed sequence alignment "
+                f"{MINIMAX_H3_PACKED_SEQUENCE_ALIGNMENT} must be divisible by "
+                f"Ulysses size {ulysses_size}. Choose a Ulysses size that "
+                "divides both the TP-local attention heads and the packed "
+                "sequence alignment."
+            )
+
+    def __init__(
+        self,
+        config: MiniMaxH3DiTConfig,
+        hf_config: dict[str, Any],
+        quant_config: QuantizationConfig | None = None,
+    ) -> None:
+        super().__init__(config=config, hf_config=hf_config)
+        arch = config.arch_config
+        self.arch = arch
+        self.hidden_size = arch.hidden_size
+        self.num_attention_heads = arch.num_attention_heads
+        self.num_channels_latents = arch.latents_dim
+        tp_size = get_tp_world_size()
+        ulysses_size, _ = _ulysses_ctx()
+        self._validate_tp_config(arch=arch, tp_size=tp_size)
+        self._validate_sequence_parallel_config(
+            arch=arch,
+            tp_size=tp_size,
+            ulysses_size=ulysses_size,
+            ring_size=_ring_world_size(),
+        )
+
+        self.video_patch_proj = ColumnParallelLinear(
+            arch.latents_dim
+            * arch.patch_size[0]
+            * arch.patch_size[1]
+            * arch.patch_size[2],
+            arch.hidden_size,
+            bias=True,
+            gather_output=True,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix="video_patch_proj",
+        )
+        self.audio_patch_proj = ColumnParallelLinear(
+            arch.audio_latents_dim,
+            arch.hidden_size,
+            bias=True,
+            gather_output=True,
+            params_dtype=_FP32_DTYPE,
+            quant_config=None,
+            prefix="audio_patch_proj",
+        )
+        self.condition_proj = ColumnParallelLinear(
+            arch.text_dim,
+            arch.hidden_size,
+            bias=True,
+            gather_output=True,
+            params_dtype=_BF16_DTYPE,
+            quant_config=quant_config,
+            prefix="condition_proj",
+        )
+        self.time_embedder = MiniMaxH3TimeEmbedder(
+            arch,
+            prefix="time_embedder",
+        )
+        self.rope = MiniMaxH3Rope(arch.rope_inv_freq_len)
+        self.token_refiner = MiniMaxH3TokenRefiner(
+            arch,
+            quant_config,
+            prefix="token_refiner",
+        )
+        self.blocks = nn.ModuleList(
+            [
+                MiniMaxH3DiTBlock(
+                    arch,
+                    quant_config,
+                    prefix=f"blocks.{index}",
+                )
+                for index in range(arch.num_layers)
+            ]
+        )
+        self.layer_names = ["blocks"]
+        self.final_layer = MiniMaxH3FinalLayer(
+            arch,
+            quant_config,
+            prefix="final_layer",
+        )
+        self._resolved_attention_backend: AttentionBackendEnum | None = None
+        self._mark_missing_params_required()
+
+    def _resolve_attention_backend_once(self) -> None:
+        if self._resolved_attention_backend is not None:
+            return
+        backend = get_attn_backend(
+            self.arch.attention_head_dim,
+            _BF16_DTYPE,
+            supported_attention_backends=self._supported_attention_backends,
+        )
+        for module in self.modules():
+            if isinstance(module, MiniMaxH3Attention):
+                module._set_attention_backend(backend)
+        self._resolved_attention_backend = backend.get_enum()
+
+    def _mark_missing_params_required(self) -> None:
+        for _, param in self.named_parameters():
+            param.missing_param_init = "error"
+
+    def post_load_weights(self) -> None:
+        for name in _MINIMAX_H3_FP32_PARAM_NAMES_IN_MODEL_ORDER:
+            param = self.get_parameter(name)
+            if param.dtype != _FP32_DTYPE:
+                raise ValueError(
+                    f"{name} must stay fp32 after load, got {param.dtype}."
+                )
+        # assign=True loading may re-register this persistent buffer as a parameter
+        rope_inv_freq = self.rope.inv_freq
+        if rope_inv_freq.dtype != _FP32_DTYPE:
+            raise ValueError(
+                f"rope.inv_freq must stay fp32 after load, got {rope_inv_freq.dtype}."
+            )
+
+    @staticmethod
+    def _pos_ids(pos_info: Any, key: str) -> torch.Tensor:
+        if isinstance(pos_info, dict):
+            ids = pos_info.get("position_ids")
+        else:
+            ids = getattr(pos_info, "position_ids", None)
+        if ids is None:
+            raise ValueError(f"{key}.position_ids is required")
+        return ids.view(-1).to(torch.long)
+
+    @staticmethod
+    def _psp_field(psp: Any, key: str, field: str) -> Any:
+        if isinstance(psp, dict):
+            value = psp.get(field)
+        else:
+            value = getattr(psp, field, None)
+        if value is None:
+            raise ValueError(f"{key}.{field} is required")
+        return value
+
+    @staticmethod
+    def _psp_optional_field(psp: Any, field: str) -> Any:
+        if isinstance(psp, dict):
+            return psp.get(field)
+        return getattr(psp, field, None)
+
+    def refine_prompt_embeds(
+        self,
+        prompt_embeds: torch.Tensor,
+        refiner_cu_seqlens: torch.Tensor,
+        *,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Project and refine request-static text conditioning once."""
+        text_len = int(refiner_cu_seqlens[1].item())
+        if text_len <= 0 or text_len > int(prompt_embeds.shape[0]):
+            raise ValueError(
+                "refiner cu_seqlens live text length must be in "
+                f"[1, {int(prompt_embeds.shape[0])}], got {text_len}"
+            )
+        text_rows = prompt_embeds[:text_len].to(device=device, dtype=_BF16_DTYPE)
+        true_refiner_cu = torch.stack(
+            (
+                refiner_cu_seqlens[0],
+                refiner_cu_seqlens[1],
+                refiner_cu_seqlens[1],
+            )
+        )
+        text_embed, _ = self.condition_proj(text_rows)
+        return self.token_refiner(
+            text_embed,
+            cu_seqlens=true_refiner_cu,
+            cu_seqlens_host=(0, text_len, text_len),
+            max_seqlen=text_len,
+        )
+
+    def build_rope_cache(
+        self,
+        img_position_ids: torch.Tensor,
+        *,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build request-static RoPE inputs for this Ulysses rank."""
+        if img_position_ids.dim() != 3 or img_position_ids.shape[0] != 1:
+            raise ValueError(
+                "img_position_ids must be [1, S, 3], got "
+                f"{list(img_position_ids.shape)}"
+            )
+        seq_len = int(img_position_ids.shape[1])
+        sp_ws, sp_rank = _ulysses_ctx()
+        if seq_len % sp_ws:
+            raise ValueError(
+                f"packed seq_len {seq_len} not divisible by ulysses world size {sp_ws}"
+            )
+        local_seq_len = seq_len // sp_ws
+        row_start = sp_rank * local_seq_len
+        rope_freqs = self.rope(
+            img_position_ids[:, row_start : row_start + local_seq_len]
+        ).to(device)
+        return (
+            _rope_cos_sin_cache(rope_freqs, dtype=_BF16_DTYPE),
+            torch.arange(
+                local_seq_len,
+                device=device,
+                dtype=torch.long,
+            ),
+        )
+
+    @eager_on_graph(True)
+    def _embed(
+        self,
+        *,
+        x: torch.Tensor,
+        audio_x: torch.Tensor,
+        text_embeddings_selected: torch.Tensor,
+        unique_timesteps: torch.Tensor,
+        img_pos: torch.Tensor,
+        audio_pos: torch.Tensor,
+        text_pos: torch.Tensor,
+        refiner_cu_seqlens: torch.Tensor,
+        refiner_max_seqlen: int,
+        row_start: int,
+        row_stop: int,
+        device: torch.device,
+        refined_prompt_embeds_length: int | torch.Tensor | None = None,
+        local_embedding_layout: dict[str, torch.Tensor | int] | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build embeddings for one contiguous block-stack row shard.
+
+        Returns (decoder_input [S_local, H] bf16, t_emb [M, t_dim] fp32).
+        """
+        # BCG pads the prompt tensor only to stabilize its input signature.
+        # Raw-input callers recover the live length from refiner metadata;
+        # request-static refined inputs carry it as a host integer and avoid a
+        # per-step device scalar read. Running the refiner at the bucketed M
+        # dimension changes GEMM selection and is not bitwise equivalent.
+        if refined_prompt_embeds_length is None:
+            text_len = int(refiner_cu_seqlens[1].item())
+        elif torch.is_tensor(refined_prompt_embeds_length):
+            # BCG turns this request-varying host constant into a scalar input
+            # so different live lengths can replay one padded-text signature.
+            # _embed is an eager graph break, so this value is read outside
+            # captured CUDA graphs.
+            text_len = int(refined_prompt_embeds_length.item())
+        else:
+            text_len = int(refined_prompt_embeds_length)
+        if text_len <= 0 or text_len > int(text_embeddings_selected.shape[0]):
+            raise ValueError(
+                "refiner cu_seqlens live text length must be in "
+                f"[1, {int(text_embeddings_selected.shape[0])}], got {text_len}"
+            )
+        text_pos = text_pos[:text_len]
+        if refined_prompt_embeds_length is not None:
+            text_embed = text_embeddings_selected[:text_len].to(
+                device=device, dtype=_BF16_DTYPE
+            )
+            if int(text_embed.shape[-1]) != self.hidden_size:
+                raise ValueError(
+                    "refined prompt embeddings must have hidden width "
+                    f"{self.hidden_size}, got {int(text_embed.shape[-1])}"
+                )
+        else:
+            text_embed = self.refine_prompt_embeds(
+                text_embeddings_selected,
+                refiner_cu_seqlens,
+                device=device,
+            )
+
+        local_seq_len = row_stop - row_start
+        trusted_layout = local_embedding_layout is not None
+        if trusted_layout:
+            used_len = text_len + int(img_pos.numel()) + int(audio_pos.numel())
+            local_live_rows = min(max(used_len - row_start, 0), local_seq_len)
+            embeddings = torch.empty(
+                (local_seq_len, self.hidden_size), device=device, dtype=_BF16_DTYPE
+            )
+            if local_live_rows < local_seq_len:
+                embeddings[local_live_rows:].zero_()
+        else:
+            # Direct model callers do not provide the serving-time partition
+            # contract. Preserve their historical zero-fill/add semantics for
+            # sparse or overlapping row maps.
+            embeddings = torch.zeros(
+                (local_seq_len, self.hidden_size), device=device, dtype=_BF16_DTYPE
+            )
+
+        if local_embedding_layout is None:
+            text_source_ids = torch.nonzero(
+                (text_pos >= row_start) & (text_pos < row_stop),
+                as_tuple=False,
+            ).view(-1)
+            text_row_ids = text_pos.index_select(0, text_source_ids) - row_start
+            img_global_ids = img_pos.index_select(
+                0,
+                torch.nonzero(
+                    (img_pos >= row_start) & (img_pos < row_stop),
+                    as_tuple=False,
+                ).view(-1),
+            )
+            img_row_ids = img_global_ids - row_start
+            audio_global_ids = audio_pos.index_select(
+                0,
+                torch.nonzero(
+                    (audio_pos >= row_start) & (audio_pos < row_stop),
+                    as_tuple=False,
+                ).view(-1),
+            )
+            audio_row_ids = audio_global_ids - row_start
+        else:
+            text_source_start = int(local_embedding_layout["text_source_start"])
+            text_source_stop = int(local_embedding_layout["text_source_stop"])
+            img_global_ids = local_embedding_layout["img_global_ids"]
+            img_row_ids = local_embedding_layout["img_row_ids"]
+            audio_global_ids = local_embedding_layout["audio_global_ids"]
+            audio_row_ids = local_embedding_layout["audio_row_ids"]
+
+        write_rows = embeddings.index_copy_ if trusted_layout else embeddings.index_add_
+        if trusted_layout:
+            text_rows = text_source_stop - text_source_start
+            if text_rows:
+                embeddings[:text_rows].copy_(
+                    text_embed[text_source_start:text_source_stop]
+                )
+        elif text_row_ids.numel():
+            write_rows(
+                0,
+                text_row_ids,
+                text_embed.index_select(0, text_source_ids).to(_BF16_DTYPE),
+            )
+
+        # latent embedders stay fp32; only rows owned by this SP rank are
+        # projected, then cast during scattering into the bf16 sequence
+        if img_row_ids.numel():
+            x_rows = (
+                x.view(-1, x.shape[-1]).index_select(0, img_global_ids).to(_FP32_DTYPE)
+            )
+            video_embed, _ = self.video_patch_proj(x_rows)
+            write_rows(
+                0,
+                img_row_ids,
+                video_embed.to(_BF16_DTYPE),
+            )
+
+        if audio_row_ids.numel():
+            audio_rows = (
+                audio_x.view(-1, audio_x.shape[-1])
+                .index_select(0, audio_global_ids)
+                .to(_FP32_DTYPE)
+            )
+            audio_embed, _ = self.audio_patch_proj(audio_rows)
+            write_rows(
+                0,
+                audio_row_ids,
+                audio_embed.to(_BF16_DTYPE),
+            )
+
+        t_emb = self.time_embedder(unique_timesteps)
+        return embeddings, t_emb
+
+    def forward(self, **kwargs: Any) -> tuple[torch.Tensor, torch.Tensor]:
+        """Packed inference forward.
+
+        Keyword names follow the checkpoint's serving contract.
+        Returns `(video_logits, audio_logits)` from rows selected by
+        `img_pos_for_infer_output_info` and `audio_pos_info`, with condition
+        rows zeroed by update masks.
+        """
+        # Strict keyword contract: refuse any kwarg forward does not consume.
+        unexpected = sorted(set(kwargs) - _FORWARD_SUPPORTED_KWARGS)
+        if unexpected:
+            raise TypeError(
+                "MiniMaxH3DiTModel.forward received unexpected kwargs: "
+                f"{unexpected}; supported kwargs: "
+                f"{sorted(_FORWARD_SUPPORTED_KWARGS)}"
+            )
+
+        x = _required_kwarg(kwargs, "x")
+        audio_x = _required_kwarg(kwargs, "audio_x")
+        img_position_ids = _required_kwarg(kwargs, "img_position_ids")
+        unique_timesteps = _required_kwarg(kwargs, "unique_timesteps")
+        inverse_indices = (
+            _required_kwarg(kwargs, "inverse_indices").view(-1).to(torch.long)
+        )
+        update_mask = _required_kwarg(kwargs, "update_mask")
+        block_token_tags = kwargs.get("block_token_tags")
+        token_tags = kwargs.get("token_tags")
+        if block_token_tags is None:
+            token_tags = _required_kwarg(kwargs, "token_tags").view(-1).to(torch.long)
+        else:
+            block_token_tags = block_token_tags.view(-1).to(torch.long)
+            token_tags = None
+        skip_mask_out_condition = bool(kwargs.get("skip_mask_out_condition", False))
+
+        text_selected = _required_kwarg(kwargs, "prompt_embeds")
+
+        img_pos = self._pos_ids(_required_kwarg(kwargs, "img_pos_info"), "img_pos_info")
+        audio_pos = self._pos_ids(
+            _required_kwarg(kwargs, "audio_pos_info"), "audio_pos_info"
+        )
+        text_pos = self._pos_ids(
+            _required_kwarg(kwargs, "text_pos_info"),
+            "text_pos_info",
+        )
+        infer_out_pos = self._pos_ids(
+            _required_kwarg(kwargs, "img_pos_for_infer_output_info"),
+            "img_pos_for_infer_output_info",
+        )
+
+        psp = _required_kwarg(kwargs, "packed_seq_params")
+        cu_seqlens = self._psp_field(psp, "packed_seq_params", "cu_seqlens_q").to(
+            torch.int32
+        )
+        raw_cu_seqlens_host = self._psp_optional_field(psp, "cu_seqlens_q_host")
+        cu_seqlens_host = tuple(
+            int(value)
+            for value in (
+                cu_seqlens.tolist()
+                if raw_cu_seqlens_host is None
+                else raw_cu_seqlens_host
+            )
+        )
+        max_seqlen = int(self._psp_field(psp, "packed_seq_params", "max_seqlen_q"))
+        refiner_psp = _required_kwarg(kwargs, "refiner_packed_seq_params")
+        refiner_cu = self._psp_field(
+            refiner_psp, "refiner_packed_seq_params", "cu_seqlens_q"
+        ).to(torch.int32)
+        refiner_max = int(
+            self._psp_field(refiner_psp, "refiner_packed_seq_params", "max_seqlen_q")
+        )
+
+        if x.dim() != 3 or x.shape[0] != 1:
+            raise ValueError(f"x must be [1, S, C], got {list(x.shape)}")
+        seq_len = int(x.shape[1])
+        if token_tags is not None and token_tags.shape[0] != seq_len:
+            raise ValueError(
+                "token_tags must cover the full packed sequence "
+                f"({seq_len}), got {token_tags.shape[0]}."
+            )
+        if inverse_indices.shape[0] != seq_len:
+            raise ValueError(
+                f"inverse_indices must be [{seq_len}], got {list(inverse_indices.shape)}"
+            )
+        sol_attn_context = _sol_attn_begin_model_forward(
+            unique_timesteps=unique_timesteps,
+            text_positions=text_pos,
+            image_positions=img_pos,
+            audio_positions=audio_pos,
+            cu_seqlens_host=cu_seqlens_host,
+            total_tokens=seq_len,
+            num_layers=len(self.blocks),
+        )
+        device = x.device
+        self._resolve_attention_backend_once()
+        if _ring_world_size() != 1:
+            raise NotImplementedError(
+                "MiniMax H3 packed multi-segment attention requires "
+                "--ring-degree 1; Ring and mixed USP are unsupported."
+            )
+
+        sp_ws, sp_rank = _ulysses_ctx()
+        local_seq_len = seq_len
+        if sp_ws > 1:
+            if seq_len % sp_ws:
+                raise ValueError(
+                    f"packed seq_len {seq_len} not divisible by ulysses "
+                    f"world size {sp_ws}"
+                )
+            local_heads = self.num_attention_heads // get_tp_world_size()
+            if local_heads % sp_ws:
+                raise ValueError(
+                    f"TP-local heads {local_heads} not divisible by Ulysses "
+                    f"world size {sp_ws} (total heads={self.num_attention_heads}, "
+                    f"TP={get_tp_world_size()})"
+                )
+            local_seq_len = seq_len // sp_ws
+        row_start = sp_rank * local_seq_len
+        row_stop = row_start + local_seq_len
+
+        # RoPE and latent projections are row-local before Ulysses exchanges
+        # sequence for heads inside attention. Serving normally prepares the
+        # request-static cache once; direct model callers use this fallback.
+        rope_cache = kwargs.get("rope_cache")
+        if rope_cache is None:
+            rope_freqs = self.rope(img_position_ids[:, row_start:row_stop]).to(device)
+            rope_cache = (
+                _rope_cos_sin_cache(rope_freqs, dtype=_BF16_DTYPE),
+                torch.arange(
+                    local_seq_len,
+                    device=device,
+                    dtype=torch.long,
+                ),
+            )
+        img_pos = img_pos.to(device)
+        audio_pos = audio_pos.to(device)
+        text_pos = text_pos.to(device)
+
+        decoder_input, t_emb = self._embed(
+            x=x,
+            audio_x=audio_x,
+            text_embeddings_selected=text_selected,
+            unique_timesteps=unique_timesteps.view(-1).to(device),
+            img_pos=img_pos,
+            audio_pos=audio_pos,
+            text_pos=text_pos,
+            refiner_cu_seqlens=refiner_cu.to(device),
+            refiner_max_seqlen=refiner_max,
+            row_start=row_start,
+            row_stop=row_stop,
+            device=device,
+            refined_prompt_embeds_length=kwargs.get("refined_prompt_embeds_length"),
+            local_embedding_layout=kwargs.get("local_embedding_layout"),
+        )
+        # request-step AdaLN input shared by all blocks
+        adaln_input = nn.functional.silu(t_emb).to(_BF16_DTYPE)
+        inverse_indices = inverse_indices.to(device)
+        block_inverse = inverse_indices[row_start:row_stop]
+        if block_token_tags is None:
+            assert token_tags is not None
+            token_tags = token_tags.to(device)
+            block_token_tags = token_tags[row_start:row_stop].clamp(min=0)
+        else:
+            block_token_tags = block_token_tags.to(device)
+            if block_token_tags.shape[0] != local_seq_len:
+                raise ValueError(
+                    "block_token_tags must cover the rank-local packed sequence "
+                    f"({local_seq_len}), got {block_token_tags.shape[0]}."
+                )
+        block_combined = kwargs.get("block_combined_indices")
+        if block_combined is None:
+            block_combined = torch.add(
+                block_token_tags,
+                block_inverse,
+                alpha=MINIMAX_H3_ADALN_MODALITY_NUM,
+            )
+
+        teacache_enabled = _sol_engine_teacache_enabled()
+        if teacache_enabled:
+            teacache_adaln = self.blocks[0].adaln_proj(adaln_input)
+            teacache_probe = _modulate_scale_shift(
+                self.blocks[0].norm1(decoder_input),
+                teacache_adaln[0],
+                teacache_adaln[1],
+                block_combined,
+                dtype=_BF16_DTYPE,
+            )
+            hidden, cache_action = _sol_engine_teacache_before_blocks(
+                decoder_input,
+                teacache_probe,
+                context=sol_attn_context,
+            )
+        else:
+            hidden, cache_action = decoder_input, None
+        cu_seqlens = cu_seqlens.to(device)
+        if cache_action != "reuse":
+            block_adaln_params = None
+            if self._can_batch_block_adaln():
+                local_adaln = torch.stack(
+                    [
+                        block.adaln_proj.project_local(adaln_input)
+                        for block in self.blocks
+                    ]
+                )
+                gathered_adaln = tensor_model_parallel_all_gather(local_adaln)
+                block_adaln_params = tuple(
+                    block.adaln_proj.split_output(output)
+                    for block, output in zip(self.blocks, gathered_adaln)
+                )
+            # With Ulysses sequence parallelism, shard rows across the group for
+            # the block stack. Attention trades sequence for heads internally.
+            for index, block in enumerate(self.blocks):
+                hidden = block(
+                    hidden,
+                    adaln_input=adaln_input,
+                    combined_indices=block_combined,
+                    rope_cache=rope_cache,
+                    cu_seqlens=cu_seqlens,
+                    cu_seqlens_host=cu_seqlens_host,
+                    max_seqlen=max_seqlen,
+                    ulysses_active=sp_ws > 1,
+                    adaln_params=(
+                        None
+                        if block_adaln_params is None
+                        else block_adaln_params[index]
+                    ),
+                )
+            if cache_action == "compute":
+                hidden = _sol_engine_teacache_after_blocks(hidden)
+        video_logits, audio_logits = self.final_layer(
+            hidden,
+            adaln_input=adaln_input,
+            inverse_indices=block_inverse,
+        )
+        if sp_ws > 1:
+            from sglang.multimodal_gen.runtime.distributed.parallel_state import (
+                get_sp_group,
+            )
+
+            video_width = video_logits.shape[-1]
+            logits = get_sp_group().all_gather(
+                torch.cat((video_logits, audio_logits), dim=-1), dim=0
+            )
+            video_logits, audio_logits = logits.split(
+                (video_width, logits.shape[-1] - video_width), dim=-1
+            )
+
+        # Preserve the full-row output GEMM (and therefore its numerical
+        # contract), but defer TP column gathers until after dead text/padding
+        # rows have been removed. For hybrid TP+Ulysses, the preceding SP row
+        # gather also carries only the TP-local output width.
+        video_logits = video_logits.index_select(0, infer_out_pos.to(device))
+        audio_logits = audio_logits.index_select(0, audio_pos.to(device))
+        if get_tp_world_size() > 1:
+            video_logits = tensor_model_parallel_all_gather(video_logits)
+            audio_logits = tensor_model_parallel_all_gather(audio_logits)
+        if not skip_mask_out_condition:
+            update_mask = update_mask.view(-1).to(device)
+            if update_mask.shape[0] != video_logits.shape[0]:
+                raise ValueError(
+                    "update_mask length mismatch: "
+                    f"{update_mask.shape[0]} != {video_logits.shape[0]}"
+                )
+            video_logits = video_logits * update_mask.unsqueeze(-1)
+            # Audio has no condition rows in the supported tasks, so its
+            # derived update mask is all ones. Honor an explicit mask when
+            # provided.
+            update_audio_mask = kwargs.get("update_audio_mask")
+            if update_audio_mask is not None:
+                audio_logits = audio_logits * update_audio_mask.view(-1).unsqueeze(-1)
+        return video_logits, audio_logits
+
+
+EntryClass = MiniMaxH3DiTModel
+
+__all__ = [
+    "MINIMAX_H3_FP32_BUFFER_NAMES",
+    "MINIMAX_H3_FP32_PARAM_NAMES",
+    "MiniMaxH3DiTModel",
+    "_reorder_grouped_qkv_to_qkv",
+]

--- a/models/minimax_h3/RTX4090/pipeline.py
+++ b/models/minimax_h3/RTX4090/pipeline.py
@@ -1,0 +1,254 @@
+"""RTX 4090 pipeline stages that differ from pinned SGLang MiniMax-H3."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import time
+
+import torch
+
+from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload import (
+    is_layerwise_offloaded_module,
+)
+from sglang.multimodal_gen.runtime.pipelines.minimax_h3_pipeline import (
+    MiniMaxH3Pipeline,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages import InputValidationStage
+from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.minimax_h3 import (
+    MiniMaxH3AudioEncodingStage,
+    MiniMaxH3DecodingStage,
+    MiniMaxH3DenoisingStage,
+    MiniMaxH3LatentPreparationStage,
+    MiniMaxH3TextEncodingStage,
+    MiniMaxH3TimestepPreparationStage,
+    MiniMaxH3VisualEncodingStage,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.minimax_h3.release_metadata import (
+    MiniMaxH3PartitionAdmissionStage,
+)
+from sglang.multimodal_gen.runtime.server_args import ServerArgs
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+
+logger = init_logger(__name__)
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _resident_vae_dtype() -> torch.dtype | None:
+    raw_dtype = os.environ.get("H3_FULL_VAE_DTYPE", "").strip().lower()
+    if not raw_dtype:
+        return None
+    aliases = {
+        "bf16": torch.bfloat16,
+        "bfloat16": torch.bfloat16,
+        "fp16": torch.float16,
+        "float16": torch.float16,
+        "fp32": torch.float32,
+        "float32": torch.float32,
+    }
+    try:
+        return aliases[raw_dtype]
+    except KeyError as exc:
+        raise ValueError(
+            "H3_FULL_VAE_DTYPE must be bf16, fp16, or fp32; "
+            f"got {raw_dtype!r}"
+        ) from exc
+
+
+@contextlib.contextmanager
+def _full_video_vae_residency(video_vae):
+    """Materialize the layerwise-offloaded video VAE for one decode."""
+
+    enabled = _env_flag("H3_FULL_VAE_AFTER_DENOISE")
+    was_layerwise = (
+        enabled
+        and video_vae is not None
+        and is_layerwise_offloaded_module(video_vae)
+    )
+    if not was_layerwise:
+        yield
+        return
+
+    device = torch.get_device_module()
+    resident_dtype = _resident_vae_dtype()
+    device.synchronize()
+    device.empty_cache()
+    if resident_dtype is not None:
+        video_vae.to(dtype=resident_dtype)
+
+    started = time.perf_counter()
+    video_vae.disable_offload()
+    if resident_dtype is not None:
+        video_vae.to(dtype=resident_dtype)
+    device.synchronize()
+    logger.info(
+        "MiniMax-H3 video VAE became resident in %.3f s (dtype=%s)",
+        time.perf_counter() - started,
+        resident_dtype,
+    )
+    try:
+        yield
+    finally:
+        video_vae.enable_offload()
+        device.synchronize()
+        device.empty_cache()
+
+
+@contextlib.contextmanager
+def _bounded_video_vae_tile_batch(video_vae):
+    """Bound stacked spatial-tile batches without changing tile geometry."""
+
+    raw_batch_size = os.environ.get("H3_FULL_VAE_TILE_BATCH_SIZE", "0")
+    try:
+        tile_batch_size = int(raw_batch_size)
+    except ValueError as exc:
+        raise ValueError(
+            "H3_FULL_VAE_TILE_BATCH_SIZE must be an integer, got "
+            f"{raw_batch_size!r}"
+        ) from exc
+
+    original_run_tile_tasks = getattr(video_vae, "_run_tile_tasks", None)
+    if tile_batch_size <= 0 or not callable(original_run_tile_tasks):
+        yield
+        return
+
+    def run_tile_tasks(tiles, tile_indices, forward_fn, stack_tiling, cls_agg=None):
+        if not stack_tiling or len(tile_indices) <= tile_batch_size:
+            return original_run_tile_tasks(
+                tiles, tile_indices, forward_fn, stack_tiling, cls_agg
+            )
+
+        outputs = []
+        for start in range(0, len(tile_indices), tile_batch_size):
+            chunk_indices = tile_indices[start : start + tile_batch_size]
+            outputs.extend(
+                original_run_tile_tasks(
+                    tiles, chunk_indices, forward_fn, True, cls_agg
+                )
+            )
+        return outputs
+
+    video_vae._run_tile_tasks = run_tile_tasks
+    try:
+        yield
+    finally:
+        video_vae._run_tile_tasks = original_run_tile_tasks
+
+
+class RTX4090MiniMaxH3DenoisingStage(MiniMaxH3DenoisingStage):
+    """Keep explicit DiT layerwise offload after compile warmup."""
+
+    def _maybe_offload_during_compile(self, module: object) -> None:
+        requested = set(self.server_args.layerwise_offload_components or ())
+        if requested.intersection({"dit", "transformer"}):
+            return
+        super()._maybe_offload_during_compile(module)
+
+
+class RTX4090MiniMaxH3DecodingStage(MiniMaxH3DecodingStage):
+    """Use one post-denoise H2D transfer for the complete video VAE."""
+
+    @contextlib.contextmanager
+    def use_declared_component(self, *, component_name: str, module):
+        with super().use_declared_component(
+            component_name=component_name,
+            module=module,
+        ) as selected:
+            if component_name != "video_vae" or selected is None:
+                yield selected
+                return
+            with (
+                _full_video_vae_residency(selected),
+                _bounded_video_vae_tile_batch(selected),
+            ):
+                yield selected
+
+    def _get_vae_decode_fn(
+        self,
+        vae,
+        server_args: ServerArgs,
+        *,
+        decode_fn=None,
+        compiled_callable=None,
+    ):
+        if (
+            vae is self.video_vae
+            and _env_flag("H3_FULL_VAE_AFTER_DENOISE")
+            and not _env_flag("H3_FULL_VAE_TORCH_COMPILE")
+        ):
+            return decode_fn or vae.decode
+        return super()._get_vae_decode_fn(
+            vae,
+            server_args,
+            decode_fn=decode_fn,
+            compiled_callable=compiled_callable,
+        )
+
+
+class MiniMaxH3RTX4090Pipeline(MiniMaxH3Pipeline):
+    """Stock MiniMax-H3 wiring with two RTX-4090 memory-stage overrides."""
+
+    def create_pipeline_stages(self, server_args: ServerArgs) -> None:
+        release_metadata = getattr(self, "release_metadata", None)
+        sigma_shift_scales = (
+            release_metadata.sigma_shift_scales
+            if release_metadata is not None
+            else None
+        )
+        self.add_stage(InputValidationStage())
+        if release_metadata is not None:
+            self.add_stage(MiniMaxH3PartitionAdmissionStage(release_metadata))
+        self.add_stage(
+            MiniMaxH3TextEncodingStage(
+                text_encoder=self.get_module("text_encoder"),
+                tokenizer=self.get_module("tokenizer"),
+                processor=self.get_module("processor"),
+            )
+        )
+        self.add_stage(
+            MiniMaxH3VisualEncodingStage(
+                video_vae=self.get_module("video_vae"),
+                vae_arch_config=server_args.pipeline_config.vae_config.arch_config,
+            )
+        )
+        self.add_stage(
+            MiniMaxH3AudioEncodingStage(
+                audio_vae=self.get_module("audio_vae"),
+                vae_arch_config=server_args.pipeline_config.audio_vae_config.arch_config,
+            )
+        )
+        self.add_stage(MiniMaxH3LatentPreparationStage())
+        self.add_stage(
+            MiniMaxH3TimestepPreparationStage(
+                sigma_shift_scales=sigma_shift_scales,
+            )
+        )
+        self.add_stage(
+            RTX4090MiniMaxH3DenoisingStage(
+                transformer=self.get_module("transformer"),
+                pipeline=self,
+            )
+        )
+        self.add_stage(
+            RTX4090MiniMaxH3DecodingStage(
+                video_vae=self.get_module("video_vae"),
+                audio_vae=self.get_module("audio_vae"),
+            )
+        )
+
+
+EntryClass = MiniMaxH3RTX4090Pipeline
+
+
+__all__ = [
+    "MiniMaxH3RTX4090Pipeline",
+    "RTX4090MiniMaxH3DecodingStage",
+    "RTX4090MiniMaxH3DenoisingStage",
+]

--- a/models/minimax_h3/RTX4090/registration.py
+++ b/models/minimax_h3/RTX4090/registration.py
@@ -1,0 +1,80 @@
+"""Register the RTX 4090 runtime without modifying the SGLang installation."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import os
+from pathlib import Path
+
+
+_PINNED_SOURCES = {
+    "sglang.multimodal_gen.runtime.models.dits.minimax_h3": (
+        "5f87319969c446685ee93d422fc34a7c040defb238eff2274d664f2f8310e997"
+    ),
+    "sglang.multimodal_gen.runtime.pipelines_core.stages.denoising": (
+        "2325b039c055d2db8c320a00f65e2880816888fd5fa107b72cfd6a85be104399"
+    ),
+    "sglang.multimodal_gen.runtime.pipelines_core.stages."
+    "model_specific_stages.minimax_h3.stages.decoding": (
+        "5e2cf87da11e0c744d6c7703d8151abd7da7937e1ad67d576fdbf6c678380954"
+    ),
+}
+
+
+def _verify_module_source(module_name: str) -> None:
+    spec = importlib.util.find_spec(module_name)
+    if spec is None or spec.origin is None:
+        raise RuntimeError(f"Pinned SGLang module is unavailable: {module_name}")
+    path = Path(spec.origin)
+    actual = hashlib.sha256(path.read_bytes()).hexdigest()
+    expected = _PINNED_SOURCES[module_name]
+    if actual != expected:
+        raise RuntimeError(
+            f"Unexpected SGLang source for {module_name}: {actual}; "
+            f"expected {expected}"
+        )
+
+
+def register_runtime() -> str:
+    """Install process-local model and pipeline registry entries."""
+
+    profile = os.environ.get("H3_RTX4090_PROFILE", "dense").strip().lower()
+    if profile not in {"dense", "sol", "fullopt"}:
+        raise ValueError("H3_RTX4090_PROFILE must be dense, sol, or fullopt")
+
+    _verify_module_source(
+        "sglang.multimodal_gen.runtime.models.dits.minimax_h3"
+    )
+    if profile == "dense":
+        return profile
+
+    from model import MiniMaxH3DiTModel
+    from sglang.multimodal_gen.runtime.models.registry import ModelRegistry
+
+    ModelRegistry.register_model("MiniMaxH3DiTModel", MiniMaxH3DiTModel)
+    ModelRegistry.register_model(
+        "MiniMaxH3Transformer3DModel", MiniMaxH3DiTModel
+    )
+
+    if profile == "fullopt":
+        _verify_module_source(
+            "sglang.multimodal_gen.runtime.pipelines_core.stages.denoising"
+        )
+        _verify_module_source(
+            "sglang.multimodal_gen.runtime.pipelines_core.stages."
+            "model_specific_stages.minimax_h3.stages.decoding"
+        )
+
+        from pipeline import MiniMaxH3RTX4090Pipeline
+        from sglang.multimodal_gen import registry
+
+        registry._discover_and_register_pipelines()
+        registry._PIPELINE_REGISTRY[
+            MiniMaxH3RTX4090Pipeline.pipeline_name
+        ] = MiniMaxH3RTX4090Pipeline
+
+    return profile
+
+
+__all__ = ["register_runtime"]

--- a/models/minimax_h3/RTX4090/run_minimax_h3_gpu.sh
+++ b/models/minimax_h3/RTX4090/run_minimax_h3_gpu.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${OUT_DIR:?OUT_DIR must be set by scripts/launch_config.py}"
+: "${H3_MODEL_PATH:?H3_MODEL_PATH must point to the MiniMax-H3 FL2VA directory}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+H3_ROOT="${H3_ROOT:-${HOME}/minimax_h3_4090}"
+PYTHON_BIN="${PYTHON_BIN:-${H3_ROOT}/.venv/bin/python}"
+FFMPEG_BIN_DIR="${H3_FFMPEG_BIN_DIR:-${H3_ROOT}/tools/ffmpeg-static}"
+
+# H3_PROMPT_FILE may arrive repo-relative -- that is how every config writes it.
+# Whether it resolves depends on the launcher: scripts/run.py leaves cwd at the
+# repo root, launch_config.py cds to the runtime dir first. Pin it here. This
+# was the one variant of the five that did not, and gpu_infer.py reads the value
+# straight through, so a run died on
+# `FileNotFoundError: models/minimax_h3/demo_prompt.json` after loading the model.
+REPO_ROOT="$(cd "${HERE}/../../.." && pwd)"
+if [[ -n "${H3_PROMPT_FILE:-}" && "${H3_PROMPT_FILE}" != /* ]]; then
+  export H3_PROMPT_FILE="${REPO_ROOT}/${H3_PROMPT_FILE}"
+fi
+
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+  echo "Python executable is not available: ${PYTHON_BIN}" >&2
+  exit 2
+fi
+
+mkdir -p "${OUT_DIR}" "${H3_ROOT}/cache/huggingface"
+mkdir -p "${H3_ROOT}/cache/triton" "${H3_ROOT}/cache/torchinductor-sm89"
+mkdir -p "${H3_ROOT}/cache/cuda-sm89"
+
+export CUDA_VISIBLE_DEVICES="${H3_CUDA_VISIBLE_DEVICES:-0}"
+export OMP_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export NUMEXPR_NUM_THREADS=1
+export TOKENIZERS_PARALLELISM=false
+export PYTHONUNBUFFERED=1
+export PATH="$(dirname "${PYTHON_BIN}"):${PATH}"
+if [[ -d "${FFMPEG_BIN_DIR}" ]]; then
+  export PATH="${FFMPEG_BIN_DIR}:${PATH}"
+fi
+export PYTHONPATH="${HERE}:${HERE}/../../../techniques/sparse_backends${PYTHONPATH:+:${PYTHONPATH}}"
+export HF_HOME="${HF_HOME:-${H3_ROOT}/cache/huggingface}"
+export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-${H3_ROOT}/cache/triton}"
+export TORCHINDUCTOR_CACHE_DIR="${TORCHINDUCTOR_CACHE_DIR:-${H3_ROOT}/cache/torchinductor-sm89}"
+export CUDA_CACHE_PATH="${CUDA_CACHE_PATH:-${H3_ROOT}/cache/cuda-sm89}"
+export TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST:-8.9}"
+export SGLANG_USE_RUNAI_MODEL_STREAMER=false
+
+for media_tool in ffmpeg ffprobe; do
+  if ! command -v "${media_tool}" >/dev/null 2>&1; then
+    echo "${media_tool} is required in ${FFMPEG_BIN_DIR}, $(dirname "${PYTHON_BIN}"), or PATH" >&2
+    exit 2
+  fi
+done
+
+export SOL_ATTN_STRICT=1
+export SOL_ATTN_TAU="${SOL_ATTN_TAU:-1.0}"
+export SOL_ATTN_THRESH_TYPE="${SOL_ATTN_THRESH_TYPE:-diag}"
+export SOL_ATTN_FIRST_DENSE_STEPS="${SOL_ATTN_FIRST_DENSE_STEPS:-10}"
+export SOL_ATTN_FIRST_DENSE_LAYER_RATIO="${SOL_ATTN_FIRST_DENSE_LAYER_RATIO:-0.03}"
+export SOL_ATTN_FIRST_DENSE_LAYERS="${SOL_ATTN_FIRST_DENSE_LAYERS:-2}"
+export SOL_ATTN_CORRECTNESS_GATE="${SOL_ATTN_CORRECTNESS_GATE:-1}"
+if [[ -z "${SOL_ATTN_EVENT_LOG:-}" ]]; then
+  export SOL_ATTN_EVENT_LOG="${OUT_DIR}/sol_events_rank{rank}.jsonl"
+fi
+export SOL_ATTN_REQUEST_EPOCH_FILE="${SOL_ATTN_REQUEST_EPOCH_FILE:-${OUT_DIR}/request_epoch.txt}"
+
+export H3_TEACACHE_THRESHOLD="${H3_TEACACHE_THRESHOLD:-0.10}"
+export H3_TEACACHE_RETAIN_STEPS="${H3_TEACACHE_RETAIN_STEPS:-5}"
+export H3_TEACACHE_COOLDOWN_STEPS="${H3_TEACACHE_COOLDOWN_STEPS:-1}"
+export H3_TEACACHE_NUM_FORWARDS="${H3_TEACACHE_NUM_FORWARDS:-49}"
+export H3_TEACACHE_COEFFICIENTS="${H3_TEACACHE_COEFFICIENTS:-1.0,0.0}"
+export H3_FULL_VAE_DTYPE="${H3_FULL_VAE_DTYPE:-bfloat16}"
+export H3_FULL_VAE_TILE_BATCH_SIZE="${H3_FULL_VAE_TILE_BATCH_SIZE:-0}"
+
+case "${H3_RTX4090_PROFILE:-dense}" in
+  dense)
+    export H3_TEACACHE_ENABLED=0
+    export H3_FULL_VAE_AFTER_DENOISE=0
+    ;;
+  sol)
+    export H3_TEACACHE_ENABLED=0
+    export H3_FULL_VAE_AFTER_DENOISE=0
+    ;;
+  fullopt)
+    export H3_TEACACHE_ENABLED="${H3_TEACACHE_ENABLED:-1}"
+    export H3_FULL_VAE_AFTER_DENOISE="${H3_FULL_VAE_AFTER_DENOISE:-1}"
+    export H3_FULL_VAE_TORCH_COMPILE="${H3_FULL_VAE_TORCH_COMPILE:-0}"
+    ;;
+  *)
+    echo "H3_RTX4090_PROFILE must be dense, sol, or fullopt" >&2
+    exit 2
+    ;;
+esac
+
+exec "${PYTHON_BIN}" "${HERE}/gpu_infer.py"

--- a/models/minimax_h3/RTX4090/teacache.py
+++ b/models/minimax_h3/RTX4090/teacache.py
@@ -1,0 +1,231 @@
+"""TeaCache residual reuse for the packed MiniMax-H3 main DiT."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+import torch
+import torch.distributed as dist
+
+from adapter import StepContext, emit_event
+
+
+def _env_int(name: str, default: int) -> int:
+    return int(os.getenv(name, str(default)))
+
+
+def _env_float(name: str, default: float) -> float:
+    return float(os.getenv(name, str(default)))
+
+
+def _coefficients() -> tuple[float, ...]:
+    raw = os.getenv("H3_TEACACHE_COEFFICIENTS", "1.0,0.0")
+    values = tuple(float(value.strip()) for value in raw.split(",") if value.strip())
+    if not values:
+        raise ValueError("H3_TEACACHE_COEFFICIENTS must not be empty")
+    return values
+
+
+def enabled() -> bool:
+    return os.getenv("H3_TEACACHE_ENABLED", "0") == "1"
+
+
+@dataclass(frozen=True)
+class TeaCacheConfig:
+    threshold: float
+    retain_steps: int
+    cooldown_steps: int
+    coefficients: tuple[float, ...]
+
+    @classmethod
+    def from_env(cls) -> "TeaCacheConfig":
+        config = cls(
+            threshold=_env_float("H3_TEACACHE_THRESHOLD", 0.10),
+            retain_steps=_env_int("H3_TEACACHE_RETAIN_STEPS", 5),
+            cooldown_steps=_env_int("H3_TEACACHE_COOLDOWN_STEPS", 1),
+            coefficients=_coefficients(),
+        )
+        if config.threshold <= 0:
+            raise ValueError("H3_TEACACHE_THRESHOLD must be positive")
+        if min(config.retain_steps, config.cooldown_steps) < 0:
+            raise ValueError("MiniMax-H3 TeaCache step counts must be non-negative")
+        return config
+
+
+def _polyval(coefficients: tuple[float, ...], value: float) -> float:
+    result = 0.0
+    for coefficient in coefficients:
+        result = result * value + coefficient
+    return result
+
+
+@torch.no_grad()
+def _relative_l1(current: torch.Tensor, previous: torch.Tensor) -> float:
+    if current.shape != previous.shape:
+        raise ValueError(
+            f"MiniMax-H3 TeaCache probe shape changed: {current.shape} != {previous.shape}"
+        )
+    totals = torch.stack(
+        (
+            (current - previous).abs().sum(dtype=torch.float32),
+            previous.abs().sum(dtype=torch.float32),
+        )
+    )
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(totals, op=dist.ReduceOp.SUM)
+    return float((totals[0] / totals[1].clamp_min(1.0e-8)).cpu().item())
+
+
+class _TeaCacheController:
+    def __init__(self, config: TeaCacheConfig) -> None:
+        self.config = config
+        self.request_epoch: str | None = None
+        self.previous_modulated_input: torch.Tensor | None = None
+        self.residual: torch.Tensor | None = None
+        self.pending_input: torch.Tensor | None = None
+        self.accumulator = 0.0
+        self.calls = 0
+        self.compute = 0
+        self.reuse = 0
+
+    def _emit_summary(self) -> None:
+        if self.request_epoch is None or self.calls == 0:
+            return
+        emit_event(
+            "teacache_generation_summary",
+            request_epoch=self.request_epoch,
+            calls=self.calls,
+            compute=self.compute,
+            reuse=self.reuse,
+            reuse_rate=self.reuse / self.calls,
+            threshold=self.config.threshold,
+            coefficients=self.config.coefficients,
+        )
+
+    def _begin_generation(self, request_epoch: str) -> None:
+        self._emit_summary()
+        self.request_epoch = request_epoch
+        self.previous_modulated_input = None
+        self.residual = None
+        self.pending_input = None
+        self.accumulator = 0.0
+        self.calls = 0
+        self.compute = 0
+        self.reuse = 0
+        emit_event(
+            "teacache_generation_start",
+            request_epoch=request_epoch,
+            threshold=self.config.threshold,
+            retain_steps=self.config.retain_steps,
+            cooldown_steps=self.config.cooldown_steps,
+            coefficients=self.config.coefficients,
+        )
+
+    @torch.no_grad()
+    def before_blocks(
+        self,
+        hidden: torch.Tensor,
+        modulated_input: torch.Tensor,
+        *,
+        context: StepContext,
+    ) -> tuple[torch.Tensor, str]:
+        if self.request_epoch != context.request_epoch:
+            self._begin_generation(context.request_epoch)
+
+        num_forwards = _env_int("H3_TEACACHE_NUM_FORWARDS", 49)
+        step = context.step_index
+        relative_l1: float | None = None
+        rescaled_l1: float | None = None
+        reason = "threshold"
+        must_compute = step < self.config.retain_steps
+        if must_compute:
+            reason = "warmup"
+            self.accumulator = 0.0
+        elif step >= num_forwards - self.config.cooldown_steps:
+            must_compute = True
+            reason = "cooldown"
+            self.accumulator = 0.0
+        elif self.previous_modulated_input is None or self.residual is None:
+            must_compute = True
+            reason = "initialize"
+        else:
+            relative_l1 = _relative_l1(modulated_input, self.previous_modulated_input)
+            rescaled_l1 = _polyval(self.config.coefficients, relative_l1)
+            self.accumulator += rescaled_l1
+            must_compute = self.accumulator >= self.config.threshold
+            if must_compute:
+                self.accumulator = 0.0
+            else:
+                reason = "below_threshold"
+
+        self.previous_modulated_input = modulated_input.detach().clone()
+        self.calls += 1
+        if must_compute:
+            self.compute += 1
+            self.pending_input = hidden.detach().clone()
+            action = "compute"
+        else:
+            self.reuse += 1
+            self.pending_input = None
+            hidden = hidden + self.residual
+            action = "reuse"
+
+        emit_event(
+            "teacache_decision",
+            request_epoch=context.request_epoch,
+            step_index=step,
+            action=action,
+            reason=reason,
+            relative_l1=relative_l1,
+            rescaled_l1=rescaled_l1,
+            accumulator=self.accumulator,
+        )
+        return hidden, action
+
+    @torch.no_grad()
+    def after_blocks(self, hidden: torch.Tensor) -> torch.Tensor:
+        if self.pending_input is None:
+            raise RuntimeError("MiniMax-H3 TeaCache is missing its block input")
+        self.residual = (hidden - self.pending_input).detach()
+        self.pending_input = None
+        return hidden
+
+
+_CONTROLLER: _TeaCacheController | None = None
+_CONFIG: TeaCacheConfig | None = None
+
+
+def _controller() -> _TeaCacheController | None:
+    global _CONFIG, _CONTROLLER
+    if not enabled():
+        return None
+    config = TeaCacheConfig.from_env()
+    if _CONTROLLER is None or config != _CONFIG:
+        _CONFIG = config
+        _CONTROLLER = _TeaCacheController(config)
+    return _CONTROLLER
+
+
+@torch.no_grad()
+def before_blocks(
+    hidden: torch.Tensor,
+    modulated_input: torch.Tensor,
+    *,
+    context: StepContext,
+) -> tuple[torch.Tensor, str | None]:
+    controller = _controller()
+    if controller is None:
+        return hidden, None
+    return controller.before_blocks(hidden, modulated_input, context=context)
+
+
+@torch.no_grad()
+def after_blocks(hidden: torch.Tensor) -> torch.Tensor:
+    controller = _controller()
+    if controller is None:
+        return hidden
+    return controller.after_blocks(hidden)
+
+
+__all__ = ["TeaCacheConfig", "after_blocks", "before_blocks", "enabled"]


### PR DESCRIPTION
## Summary

- add a self-contained MiniMax-H3 runtime for one GeForce RTX 4090, derived from the validated single-GPU RTX 5090 runtime and dispatched through the released SM89 CuTe DSL Sol-Attn backend
- add one released `rtx4090_fullopt.toml` config combining SM89 Sol-Attn, TeaCache, regional `torch.compile`, full BF16 VAE decode, and layerwise component offload
- register the RTX 4090 runtime in the MiniMax-H3 model manifest and document its E2E result and controlled Cache / Sol-Attn attribution
- record the real CUDA device name and SM89 capability in benchmark output, while keeping CUDA, Triton, and TorchInductor caches architecture-specific

## Result

For the recorded 1344x768, 5-second, 50-step BF16 FL2VA workload on one RTX 4090:

- dense: 2239.216771 s
- fullopt: 504.329254 s
- dense / fullopt: 4.439990x

The controlled optimized-stack breakdown measured 1951.274193 s for lossless opt, 613.707341 s after adding TeaCache, and 504.329254 s after adding Sol-Attn. This corresponds to 3.179486x from Cache and a further 1.216878x from Sol-Attn.

## Validation

- parsed all seven Python files with `ast.parse`
- passed `bash -n` for the launcher and JSON/TOML parsing for the source snapshot, model manifest, and fullopt config
- verified every declared runtime SHA-256 and the single-config manifest contract
- rendered `scripts/run.py config/minimax_h3/rtx4090_fullopt.toml --print` successfully
- passed `git diff --check`
- existing RTX 4090 evidence recorded a real sparse forward at 19.65% effective density and passed the real-QKV gate (`max_abs=0.0625`, `mean_abs=0.000289`, `rel_l2=0.000609`)
- TeaCache recorded 14 computations and 35 reuses over 49 measured decisions

## Limitations

The E2E and correctness evidence was collected from the same runtime stack before it was split into this RTX4090-named package. The new package changes platform naming, cache paths, capability validation, and benchmark metadata; its attention and TeaCache implementations are byte-identical to the measured stack. The renamed entry has not been rerun end-to-end after packaging.

The timings are single samples. No perceptual or embedding video-similarity metric was measured, so this PR does not claim bitwise or E2E video-quality equivalence.
