### PR TITLE
fix(MiniMax-H3): 单卡 GB200 推理时 _swiglu_kernel 的 row 溢出

### DIFF
--- a/models/minimax_h3/GB200/fusions.py
+++ b/models/minimax_h3/GB200/fusions.py
@@ -115,7 +115,7 @@ if HAVE_TRITON:
 
     @triton.jit
     def _swiglu_kernel(out_ptr, x_ptr, n_cols, stride_in_row, stride_out_row, BLOCK: tl.constexpr):
-        row = tl.program_id(0)
+        row = tl.program_id(0).to(tl.int64)
         cols = tl.arange(0, BLOCK)
         mask = cols < n_cols
         value = tl.load(x_ptr + row * stride_in_row + cols, mask=mask, other=0.0).to(tl.float32)


### PR DESCRIPTION
# Bug 表现
MiniMax-H3 推理 768×1344 / 15s 视频，**单卡** GB200（`SP=1 DP=1 world=1`），step 0/49：

```
RuntimeError: Triton Error [CUDA]: an illegal memory access was encountered
  fusion_install.py:65  ff_output = out_proj(fused_swiglu(swiglu.proj(normed)))
  fusions.py:194        _swiglu_kernel[(flat.shape[0],)](...)
```
# 原因

`models/minimax_h3/GB200/fusions.py:118` 的 `row = tl.program_id(0)` 是 int32，而
`row * stride_in_row` 是标量乘法。swiglu 的行宽是 `2 * ffn_dim = 28672`，
所以 `row >= 74899` 时乘积越过 `2**31`。MiniMax-H3 的 `ffn_dim = 14336`，swiglu 输入行宽 `2 * 14336 = 28672`：

```
74898 * 28672 = 2,147,475,456  <  2**31 = 2,147,483,648   最后一个安全行
74899 * 28672 = 2,147,504,128  >  2**31                   第一个损坏行
```

| rows | 整行全错的行数 | 备注 |
|---|---|---|
| 60200 | 0 | SP=2 时每 rank 的行数 |
| 74898 | 0 | 最后一个安全行 |
| 74907 | 8 | 正好是 74899..74906 |
| 76000 | 1101 | 首个全错行 = **74899**，连续到末行 |
| 89819 | 14920 | 768×1344 / 10s packed |
| 120399 | 45500 | 768×1344 / 15s packed |

# 修复方案

改一行代码即可，对速度无影响：

```diff
--- a/models/minimax_h3/GB200/fusions.py
+++ b/models/minimax_h3/GB200/fusions.py
@@ -116,7 +116,7 @@ if HAVE_TRITON:
     @triton.jit
     def _swiglu_kernel(out_ptr, x_ptr, n_cols, stride_in_row, stride_out_row, BLOCK: tl.constexpr):
-        row = tl.program_id(0)
+        row = tl.program_id(0).to(tl.int64)
         cols = tl.arange(0, BLOCK)
         mask = cols < n_cols
         value = tl.load(x_ptr + row * stride_in_row + cols, mask=mask, other=0.0).to(tl.float32)
```