### PR TITLE
docs: add hidden Sol-H3 page-view tracking

### DIFF
--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -5111,5 +5111,17 @@
       }
     })();
   </script>
+  <script>
+    (() => {
+      const path = location.pathname.replace(/\/+$/, '');
+      const isSolH3Page = path === '/Sana/Sol-Engine/Sol-H3' || path === '/Sana/Sol-Engine/Sol-H3/index.html';
+      if (location.hostname !== 'nvlabs.github.io' || !isSolH3Page) return;
+      const tracker = new Image();
+      tracker.referrerPolicy = 'no-referrer';
+      tracker.src = 'https://hits.sh/nvlabs.github.io/Sana/Sol-Engine/Sol-H3.svg';
+      window.solH3PageViewTracker = tracker;
+    })();
+  </script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a hidden hits.sh page-view tracker for the published Sol-H3 project page
- count only the canonical `nvlabs.github.io/Sana/Sol-Engine/Sol-H3/` URL (including explicit `index.html`)
- keep the counter out of the DOM and expose no visible badge or dashboard link on the blog
- exclude local development, HTMLPreview, PR previews, and other Sol-Engine pages from the count

## Validation
- tested production, explicit-index, preview, localhost, and unrelated-page URL cases
- HTML parsed successfully
- `git diff --check` passed
- hits.sh dashboard endpoint returns HTTP 200