### PR TITLE
Publish Sol-H3 project page and multi-GPU benchmarks

### DIFF
--- a/Sol-Engine/Sol-H3/assets/favicon.svg
+++ b/Sol-Engine/Sol-H3/assets/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="6" fill="#d1ff61"/><text x="16" y="24" text-anchor="middle" font-family="Arial,sans-serif" font-weight="700" font-size="24" fill="#172200">S</text></svg>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -5164,15 +5164,35 @@
         </header>
 
         <div class="acceleration-list">
-          <div class="acceleration-pair">
+          <div class="acceleration-pair featured">
             <article class="tech-card reveal" data-index="01">
+              <span class="tech-label">Sol-Attn</span>
+              <h3>Sparsify on the fly</h3>
+              <div class="tech-summary"><strong>Query-dependent · one-pass · training-free</strong></div>
+              <div class="tech-viz prefix-viz" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i><i></i></div>
+            </article>
+            <article class="detail-row featured reveal" id="detail-sol-attn">
+              <div class="detail-marker"><strong>01</strong><span>Sol-Attn</span></div>
+              <div class="detail-copy">
+                <h3>Select blocks while attention runs.</h3>
+                <div class="detail-explanation">
+                  <div class="detail-part"><span>Mechanism</span><p>Each 64-token query block sets its own threshold: mean + β × standard deviation over lightweight query–key scores. Blocks above it run exact attention; skipped blocks contribute a low-cost approximation using pooled keys and value sums.</p></div>
+                  <div class="detail-part"><span>Why it is faster</span><p>Sol-Attn consumes each score tile inside online softmax: the same tile selects exact blocks and updates the approximation. It writes no separate router output, full score map, or routing-index tensor, and needs no retraining.</p></div>
+                </div>
+              </div>
+              <aside class="detail-evidence"><span>Key property</span><strong>One pass</strong><small>query-dependent · training-free sparsification</small></aside>
+            </article>
+          </div>
+
+          <div class="acceleration-pair">
+            <article class="tech-card reveal" data-index="02">
               <span class="tech-label">GPU kernels</span>
               <h3>Fuse repeated operations</h3>
               <div class="tech-summary"><strong>Norm · RoPE · MLP</strong></div>
               <div class="tech-viz fusion-viz" aria-hidden="true"><div class="fusion-stack"><i></i><i></i><i></i><i></i></div><span class="fusion-arrow"></span><span class="fusion-one"></span></div>
             </article>
             <article class="detail-row reveal" id="detail-kernels">
-              <div class="detail-marker"><strong>01</strong><span>GPU kernels</span></div>
+              <div class="detail-marker"><strong>02</strong><span>GPU kernels</span></div>
               <div class="detail-copy">
                 <h3>Move less data between operations.</h3>
                 <div class="detail-explanation">
@@ -5185,14 +5205,14 @@
           </div>
 
           <div class="acceleration-pair">
-            <article class="tech-card reveal" data-index="02">
+            <article class="tech-card reveal" data-index="03">
               <span class="tech-label">Multi-GPU communication</span>
               <h3>Faster 8-GPU data exchange</h3>
               <div class="tech-summary"><strong>Pack · all-to-all · merge</strong></div>
               <div class="tech-viz ulysses-viz" aria-hidden="true"><i style="--n:0"></i><i style="--n:1"></i><i style="--n:2"></i><i style="--n:3"></i><i style="--n:4"></i><i style="--n:5"></i><i style="--n:6"></i><i style="--n:7"></i></div>
             </article>
             <article class="detail-row reveal" id="detail-communication">
-              <div class="detail-marker"><strong>02</strong><span>8-GPU exchange</span></div>
+              <div class="detail-marker"><strong>03</strong><span>8-GPU exchange</span></div>
               <div class="detail-copy">
                 <h3>Pack, exchange, and merge directly.</h3>
                 <div class="detail-explanation">
@@ -5205,14 +5225,14 @@
           </div>
 
           <div class="acceleration-pair">
-            <article class="tech-card reveal" data-index="03">
+            <article class="tech-card reveal" data-index="04">
               <span class="tech-label">Sparse-attention setup</span>
               <h3>Fuse the setup work</h3>
               <div class="tech-summary"><strong>K/V summaries · threshold · metadata</strong></div>
               <div class="tech-viz route-viz" aria-hidden="true"><span><i style="--w:100%"></i><b>Before</b></span><span><i style="--w:24%"></i><b>Fused</b></span></div>
             </article>
             <article class="detail-row reveal" id="detail-setup">
-              <div class="detail-marker"><strong>03</strong><span>Sparse setup</span></div>
+              <div class="detail-marker"><strong>04</strong><span>Sparse setup</span></div>
               <div class="detail-copy">
                 <h3>Build the sparse plan in fewer passes.</h3>
                 <div class="detail-explanation">
@@ -5221,26 +5241,6 @@
                 </div>
               </div>
               <aside class="detail-evidence"><span>Measured setup</span><strong>0.285 ms</strong><small>from 1.206 ms · 76.4% lower</small></aside>
-            </article>
-          </div>
-
-          <div class="acceleration-pair featured">
-            <article class="tech-card reveal" data-index="04">
-              <span class="tech-label">Sol-Attn</span>
-              <h3>Sparsify on the fly</h3>
-              <div class="tech-summary"><strong>Query-dependent · one-pass · training-free</strong></div>
-              <div class="tech-viz prefix-viz" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i><i></i></div>
-            </article>
-            <article class="detail-row featured reveal" id="detail-sol-attn">
-              <div class="detail-marker"><strong>04</strong><span>Sol-Attn</span></div>
-              <div class="detail-copy">
-                <h3>Select blocks while attention runs.</h3>
-                <div class="detail-explanation">
-                  <div class="detail-part"><span>Mechanism</span><p>Each 64-token query block sets its own threshold: mean + β × standard deviation over lightweight query–key scores. Blocks above it run exact attention; skipped blocks contribute a low-cost approximation using pooled keys and value sums.</p></div>
-                  <div class="detail-part"><span>Why it is faster</span><p>Sol-Attn consumes each score tile inside online softmax: the same tile selects exact blocks and updates the approximation. It writes no separate router output, full score map, or routing-index tensor, and needs no retraining.</p></div>
-                </div>
-              </div>
-              <aside class="detail-evidence"><span>Key property</span><strong>One pass</strong><small>query-dependent · training-free sparsification</small></aside>
             </article>
           </div>
 

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -5100,6 +5100,51 @@
       </div>
     </section>
 
+    <script>
+      (() => {
+        const tabs = [...document.querySelectorAll('[data-benchmark-duration-control]')];
+        const cells = [...document.querySelectorAll('[data-benchmark-duration]')];
+        const panel = document.getElementById('latency-panel');
+        const scale = document.getElementById('benchmark-scale');
+        const scales = {
+          '5': 'Shared scale · 0–129.898 s',
+          '10': 'Shared scale · 0–376.942 s',
+          '15': 'Shared scale · 0–746.885 s'
+        };
+
+        const selectDuration = (duration, moveFocus = false) => {
+          const activeTab = tabs.find((tab) => tab.dataset.benchmarkDurationControl === duration);
+          if (!activeTab || !panel || !scale) return;
+
+          tabs.forEach((tab) => {
+            const active = tab === activeTab;
+            tab.setAttribute('aria-selected', String(active));
+            tab.tabIndex = active ? 0 : -1;
+          });
+          cells.forEach((cell) => {
+            cell.hidden = cell.dataset.benchmarkDuration !== duration;
+          });
+          scale.textContent = scales[duration];
+          panel.setAttribute('aria-labelledby', activeTab.id);
+          if (moveFocus) activeTab.focus();
+        };
+
+        tabs.forEach((tab, index) => {
+          tab.addEventListener('click', () => selectDuration(tab.dataset.benchmarkDurationControl));
+          tab.addEventListener('keydown', (event) => {
+            let nextIndex = null;
+            if (event.key === 'ArrowLeft') nextIndex = (index - 1 + tabs.length) % tabs.length;
+            if (event.key === 'ArrowRight') nextIndex = (index + 1) % tabs.length;
+            if (event.key === 'Home') nextIndex = 0;
+            if (event.key === 'End') nextIndex = tabs.length - 1;
+            if (nextIndex === null) return;
+            event.preventDefault();
+            selectDuration(tabs[nextIndex].dataset.benchmarkDurationControl, true);
+          });
+        });
+      })();
+    </script>
+
     <section class="section comparison-section" id="compare" aria-labelledby="comparison-title">
       <div class="wide-shell">
         <header class="section-head reveal">
@@ -5664,46 +5709,6 @@
         });
       }, { rootMargin: '-25% 0px -60% 0px', threshold: 0 });
       navSections.forEach((section) => navObserver.observe(section));
-
-      const benchmarkTabs = [...document.querySelectorAll('[data-benchmark-duration-control]')];
-      const benchmarkCells = [...document.querySelectorAll('[data-benchmark-duration]')];
-      const benchmarkPanel = document.getElementById('latency-panel');
-      const benchmarkScale = document.getElementById('benchmark-scale');
-      const benchmarkScales = {
-        '5': 'Shared scale · 0–129.898 s',
-        '10': 'Shared scale · 0–376.942 s',
-        '15': 'Shared scale · 0–746.885 s'
-      };
-      const setBenchmarkDuration = (duration, moveFocus = false) => {
-        const activeTab = benchmarkTabs.find((tab) => tab.dataset.benchmarkDurationControl === duration);
-        if (!activeTab || !benchmarkPanel || !benchmarkScale) return;
-        benchmarkTabs.forEach((tab) => {
-          const active = tab === activeTab;
-          tab.setAttribute('aria-selected', String(active));
-          tab.tabIndex = active ? 0 : -1;
-        });
-        benchmarkCells.forEach((cell) => {
-          cell.hidden = cell.dataset.benchmarkDuration !== duration;
-        });
-        benchmarkScale.textContent = benchmarkScales[duration];
-        benchmarkPanel.setAttribute('aria-labelledby', activeTab.id);
-        if (moveFocus) activeTab.focus();
-      };
-
-      benchmarkTabs.forEach((tab, index) => {
-        tab.addEventListener('click', () => setBenchmarkDuration(tab.dataset.benchmarkDurationControl));
-        tab.addEventListener('keydown', (event) => {
-          let nextIndex = null;
-          if (event.key === 'ArrowLeft') nextIndex = (index - 1 + benchmarkTabs.length) % benchmarkTabs.length;
-          if (event.key === 'ArrowRight') nextIndex = (index + 1) % benchmarkTabs.length;
-          if (event.key === 'Home') nextIndex = 0;
-          if (event.key === 'End') nextIndex = benchmarkTabs.length - 1;
-          if (nextIndex === null) return;
-          event.preventDefault();
-          setBenchmarkDuration(benchmarkTabs[nextIndex].dataset.benchmarkDurationControl, true);
-        });
-      });
-
 
       const comparisonLab = document.getElementById('comparison-lab');
       if (comparisonLab) {

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -1358,25 +1358,46 @@
     .matrix-measure.ours > strong { color: var(--acid); }
 
     .matrix-speedup {
-      display: flex;
-      justify-content: space-between;
-      gap: 12px;
-      margin-top: 13px;
-      padding-top: 11px;
-      border-top: 1px dashed var(--line);
-      color: var(--dim);
-      font-family: "SFMono-Regular", Consolas, monospace;
-      font-size: 10px;
-      font-weight: 700;
-      letter-spacing: .065em;
-      text-transform: uppercase;
+      position: relative;
+      z-index: 2;
+      grid-column: 2;
+      grid-row: 1;
+      align-self: center;
+      height: 2px;
+      margin-right: 12px;
+      margin-left: max(calc(var(--w) + 14px), 44px);
+      background: var(--acid);
+      pointer-events: none;
     }
 
-    .matrix-speedup strong {
+    .matrix-speedup::before {
+      position: absolute;
+      top: 50%;
+      left: 0;
+      width: 0;
+      height: 0;
+      border-top: 6px solid transparent;
+      border-right: 11px solid var(--acid);
+      border-bottom: 6px solid transparent;
+      transform: translate(-100%, -50%);
+      content: "";
+    }
+
+    .matrix-speedup > strong {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      padding: 0 8px;
+      background: var(--surface);
+      box-shadow: 0 0 0 5px var(--surface);
       color: var(--acid);
-      font-size: clamp(20px, 1.8vw, 26px);
+      font-family: "SFMono-Regular", Consolas, monospace;
+      font-size: clamp(12px, 1.2vw, 16px);
+      font-weight: 800;
       line-height: 1;
-      letter-spacing: -.035em;
+      letter-spacing: -.025em;
+      text-transform: none;
       white-space: nowrap;
     }
 
@@ -1450,6 +1471,7 @@
       }
 
       .matrix-cell { padding: 14px 18px 19px; }
+      .matrix-speedup > strong span { display: none; }
       .matrix-measure > strong { font-size: 20px; }
 
       .matrix-measure {
@@ -4997,7 +5019,7 @@
             <span class="section-kicker">Scaling benchmark · 1 / 4 / 8× NVIDIA B300</span>
             <h2 id="performance-title">Latency across GPU counts.</h2>
           </div>
-          <p>Choose an output length, then compare 1, 4, and 8 B300 GPUs on one shared latency scale.</p>
+          <p>Choose an output length, then compare Sol-H3 directly with Base H3 across 8, 4, and 1 B300 GPUs.</p>
         </header>
 
         <article class="benchmark-console benchmark-console-wide reveal" aria-labelledby="latency-title" aria-describedby="benchmark-method">
@@ -5012,7 +5034,7 @@
                 <button class="duration-tab" id="benchmark-duration-10" type="button" role="tab" aria-selected="false" tabindex="-1" data-benchmark-duration-control="10" aria-controls="latency-panel">10s</button>
                 <button class="duration-tab" id="benchmark-duration-15" type="button" role="tab" aria-selected="false" tabindex="-1" data-benchmark-duration-control="15" aria-controls="latency-panel">15s</button>
               </div>
-              <span class="benchmark-scale" id="benchmark-scale">Shared scale · 0–129.898 s</span>
+              <span class="benchmark-scale" id="benchmark-scale">Base H3 = 100% · exact seconds shown</span>
             </div>
           </header>
 
@@ -5032,23 +5054,20 @@
                   <th scope="row"><span class="matrix-gpu"><strong>8×</strong><small>NVIDIA B300</small></span></th>
                   <td data-duration="5s · 124 frames" data-benchmark-duration="5">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 14.049%;"><span>Base H3<small>Dense</small></span><strong>18.250 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 1.273%;"><span>Sol-H3<small>Ours</small></span><strong>1.653 s</strong></div>
-                      <div class="matrix-speedup"><span>vs Base H3</span><strong>11.04×</strong></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>18.250 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 9.058%;"><span>Sol-H3<small>Ours</small></span><strong>1.653 s</strong><span class="matrix-speedup" aria-label="11.04 times faster than Base H3"><strong>11.04×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                   <td data-duration="10s · 243 frames" data-benchmark-duration="10" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 13.440%;"><span>Base H3<small>Dense</small></span><strong>50.660 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 0.990%;"><span>Sol-H3<small>Ours</small></span><strong>3.732 s</strong></div>
-                      <div class="matrix-speedup"><span>vs Base H3</span><strong>13.57×</strong></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>50.660 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 7.367%;"><span>Sol-H3<small>Ours</small></span><strong>3.732 s</strong><span class="matrix-speedup" aria-label="13.57 times faster than Base H3"><strong>13.57×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                   <td data-duration="15s · 362 frames" data-benchmark-duration="15" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 13.324%;"><span>Base H3<small>Dense</small></span><strong>99.513 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 0.885%;"><span>Sol-H3<small>Ours</small></span><strong>6.612 s</strong></div>
-                      <div class="matrix-speedup"><span>vs Base H3</span><strong>15.05×</strong></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>99.513 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 6.644%;"><span>Sol-H3<small>Ours</small></span><strong>6.612 s</strong><span class="matrix-speedup" aria-label="15.05 times faster than Base H3"><strong>15.05×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                 </tr>
@@ -5056,23 +5075,20 @@
                   <th scope="row"><span class="matrix-gpu"><strong>4×</strong><small>NVIDIA B300</small></span></th>
                   <td data-duration="5s · 124 frames" data-benchmark-duration="5">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 27.197%;"><span>Base H3<small>Dense</small></span><strong>35.328 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 2.246%;"><span>Sol-H3<small>Ours</small></span><strong>2.918 s</strong></div>
-                      <div class="matrix-speedup"><span>vs Base H3</span><strong>12.11×</strong></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>35.328 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 8.260%;"><span>Sol-H3<small>Ours</small></span><strong>2.918 s</strong><span class="matrix-speedup" aria-label="12.11 times faster than Base H3"><strong>12.11×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                   <td data-duration="10s · 243 frames" data-benchmark-duration="10" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 26.646%;"><span>Base H3<small>Dense</small></span><strong>100.440 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 1.855%;"><span>Sol-H3<small>Ours</small></span><strong>6.993 s</strong></div>
-                      <div class="matrix-speedup"><span>vs Base H3</span><strong>14.36×</strong></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>100.440 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 6.962%;"><span>Sol-H3<small>Ours</small></span><strong>6.993 s</strong><span class="matrix-speedup" aria-label="14.36 times faster than Base H3"><strong>14.36×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                   <td data-duration="15s · 362 frames" data-benchmark-duration="15" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 26.099%;"><span>Base H3<small>Dense</small></span><strong>194.930 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 1.679%;"><span>Sol-H3<small>Ours</small></span><strong>12.542 s</strong></div>
-                      <div class="matrix-speedup"><span>vs Base H3</span><strong>15.54×</strong></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>194.930 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 6.434%;"><span>Sol-H3<small>Ours</small></span><strong>12.542 s</strong><span class="matrix-speedup" aria-label="15.54 times faster than Base H3"><strong>15.54×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                 </tr>
@@ -5081,22 +5097,19 @@
                   <td data-duration="5s · 124 frames" data-benchmark-duration="5">
                     <div class="matrix-cell">
                       <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>129.898 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 10.581%;"><span>Sol-H3<small>Ours</small></span><strong>13.745 s</strong></div>
-                      <div class="matrix-speedup"><span>vs Base H3</span><strong>9.45×</strong></div>
+                      <div class="matrix-measure ours" style="--w: 10.581%;"><span>Sol-H3<small>Ours</small></span><strong>13.745 s</strong><span class="matrix-speedup" aria-label="9.45 times faster than Base H3"><strong>9.45×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                   <td data-duration="10s · 243 frames" data-benchmark-duration="10" hidden>
                     <div class="matrix-cell">
                       <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>376.942 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 10.032%;"><span>Sol-H3<small>Ours</small></span><strong>37.813 s</strong></div>
-                      <div class="matrix-speedup"><span>vs Base H3</span><strong>9.97×</strong></div>
+                      <div class="matrix-measure ours" style="--w: 10.032%;"><span>Sol-H3<small>Ours</small></span><strong>37.813 s</strong><span class="matrix-speedup" aria-label="9.97 times faster than Base H3"><strong>9.97×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                   <td data-duration="15s · 362 frames" data-benchmark-duration="15" hidden>
                     <div class="matrix-cell">
                       <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>746.885 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 6.997%;"><span>Sol-H3<small>Ours</small></span><strong>52.260 s</strong></div>
-                      <div class="matrix-speedup"><span>vs Base H3</span><strong>14.29×</strong></div>
+                      <div class="matrix-measure ours" style="--w: 6.997%;"><span>Sol-H3<small>Ours</small></span><strong>52.260 s</strong><span class="matrix-speedup" aria-label="14.29 times faster than Base H3"><strong>14.29×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                 </tr>
@@ -5118,11 +5131,7 @@
         const cells = [...document.querySelectorAll('[data-benchmark-duration]')];
         const panel = document.getElementById('latency-panel');
         const scale = document.getElementById('benchmark-scale');
-        const scales = {
-          '5': 'Shared scale · 0–129.898 s',
-          '10': 'Shared scale · 0–376.942 s',
-          '15': 'Shared scale · 0–746.885 s'
-        };
+        const scaleLabel = 'Base H3 = 100% · exact seconds shown';
 
         const selectDuration = (duration, moveFocus = false) => {
           const activeTab = tabs.find((tab) => tab.dataset.benchmarkDurationControl === duration);
@@ -5136,7 +5145,7 @@
           cells.forEach((cell) => {
             cell.hidden = cell.dataset.benchmarkDuration !== duration;
           });
-          scale.textContent = scales[duration];
+          scale.textContent = scaleLabel;
           panel.setAttribute('aria-labelledby', activeTab.id);
           if (moveFocus) activeTab.focus();
         };

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -2884,11 +2884,39 @@
 
     .tech-card.span-6 { grid-column: span 6; }
     .tech-card.span-12 { grid-column: span 12; }
-    .tech-card { min-height: 315px; }
+    .tech-card { min-height: 290px; }
     .tech-label { font-size: 12px; }
     .tech-card h3 { max-width: 620px; font-size: clamp(29px, 2.8vw, 40px); }
-    .tech-card > p { max-width: 72%; font-size: 17px; line-height: 1.65; }
-    .tech-viz { opacity: .55; }
+    .tech-viz { opacity: .48; }
+    .tech-summary {
+      position: relative;
+      z-index: 2;
+      display: flex;
+      width: fit-content;
+      max-width: 68%;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 9px;
+      margin-top: 25px;
+      color: var(--fog);
+      text-decoration: none;
+    }
+    .tech-summary strong {
+      color: var(--fog);
+      font-family: "SFMono-Regular", Consolas, monospace;
+      font-size: 13px;
+      line-height: 1.6;
+      letter-spacing: .015em;
+    }
+    .tech-summary span {
+      color: var(--acid);
+      font-family: "SFMono-Regular", Consolas, monospace;
+      font-size: 12px;
+      font-weight: 800;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+    }
+    .tech-summary:hover span { color: var(--white); }
 
 
     .release-contract { display: flex; flex-wrap: wrap; margin-top: 16px; border: 1px solid var(--line); border-radius: 12px; overflow: hidden; background: rgba(255, 255, 255, .018); }
@@ -2908,8 +2936,9 @@
       display: grid;
       grid-template-columns: minmax(130px, .34fr) minmax(0, 1.35fr) minmax(230px, .62fr);
       gap: clamp(24px, 4vw, 58px);
-      align-items: center;
+      align-items: start;
       padding: clamp(30px, 4vw, 46px) 0;
+      scroll-margin-top: calc(var(--header-h) + 18px);
       border-bottom: 1px solid var(--line);
     }
 
@@ -2952,53 +2981,73 @@
       letter-spacing: -.04em;
     }
 
-    .detail-copy p {
-      max-width: 790px;
-      margin: 15px 0 0;
+    .detail-explanation {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: clamp(18px, 2.6vw, 32px);
+      margin-top: 22px;
+    }
+
+    .detail-part {
+      padding-left: 15px;
+      border-left: 1px solid var(--line-bright);
+    }
+
+    .detail-part > span,
+    .detail-evidence > span {
+      color: var(--acid);
+      font-family: "SFMono-Regular", Consolas, monospace;
+      font-size: 12px;
+      font-weight: 800;
+      letter-spacing: .09em;
+      text-transform: uppercase;
+    }
+
+    .detail-row.featured .detail-part > span,
+    .detail-row.featured .detail-evidence > span { color: var(--mint); }
+
+    .detail-part p {
+      margin: 8px 0 0;
       color: var(--muted);
-      font-size: 17px;
-      line-height: 1.68;
+      font-size: 16px;
+      line-height: 1.66;
     }
 
     .detail-copy strong { color: var(--fog); }
 
-    .detail-path {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      justify-content: flex-start;
-      gap: 8px;
-      color: var(--dim);
-      font-family: "SFMono-Regular", Consolas, monospace;
-      font-size: 12px;
-      line-height: 1.35;
+    .detail-evidence {
+      align-self: start;
+      padding: 4px 0 4px 24px;
+      border-left: 1px solid var(--line);
     }
 
-    .detail-path span {
-      padding: 9px 11px;
-      border: 1px solid var(--line);
-      border-radius: 7px;
-      background: var(--surface);
-      color: var(--fog);
-      white-space: nowrap;
-    }
-
-    .detail-path b {
-      flex-basis: 100%;
-      margin-top: 5px;
+    .detail-evidence strong {
+      display: block;
+      margin-top: 12px;
       color: var(--acid);
-      font-size: 13px;
-      letter-spacing: .02em;
+      font-size: clamp(28px, 3vw, 42px);
+      line-height: 1;
+      letter-spacing: -.045em;
     }
 
-    .detail-row.featured .detail-path b { color: var(--mint); }
+    .detail-row.featured .detail-evidence strong { color: var(--mint); }
 
-    @media (max-width: 980px) {
+    .detail-evidence small {
+      display: block;
+      max-width: 230px;
+      margin-top: 10px;
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.5;
+    }
+
+    @media (max-width: 1120px) {
       .detail-row { grid-template-columns: 110px minmax(0, 1fr); }
-      .detail-path { grid-column: 2; }
+      .detail-evidence { grid-column: 2; }
     }
 
     @media (max-width: 720px) {
+      .tech-summary { max-width: 100%; }
       .detail-row {
         grid-template-columns: 1fr;
         gap: 18px;
@@ -3011,8 +3060,14 @@
       }
       .detail-marker strong { font-size: 22px; }
       .detail-marker span { margin-top: 0; }
-      .detail-copy p { font-size: 16px; }
-      .detail-path { grid-column: auto; }
+      .detail-explanation { grid-template-columns: 1fr; gap: 18px; }
+      .detail-part p { font-size: 16px; }
+      .detail-evidence {
+        grid-column: auto;
+        padding: 19px 0 0;
+        border-top: 1px solid var(--line);
+        border-left: 0;
+      }
     }
 
     .finale { min-height: 650px; }
@@ -4878,42 +4933,57 @@
             <span class="section-kicker">Six optimizations · one runtime</span>
             <h2 id="stack-title">How Sol-H3 gets faster.</h2>
           </div>
-          <p>Six optimizations work together in one runtime. These cards give the overview; the main implementation details follow below.</p>
+          <p>Use these six cards as a map of the runtime. Each one links to its implementation note below.</p>
         </header>
 
         <div class="bento">
           <article class="tech-card span-6 reveal" data-index="01">
             <span class="tech-label">GPU kernels</span>
             <h3>Fuse repeated operations</h3>
-            <p>Fuses normalization, RoPE, modulation, and MLP work so intermediate tensors stay on chip instead of repeatedly moving through GPU memory.</p>
+            <a class="tech-summary" href="#detail-kernels">
+              <strong>Norm · RoPE · MLP</strong>
+              <span>Read implementation ↓</span>
+            </a>
             <div class="tech-viz fusion-viz" aria-hidden="true"><div class="fusion-stack"><i></i><i></i><i></i><i></i></div><span class="fusion-arrow"></span><span class="fusion-one"></span></div>
           </article>
 
           <article class="tech-card span-6 reveal" data-index="02">
             <span class="tech-label">Multi-GPU communication</span>
             <h3>Faster 8-GPU data exchange</h3>
-            <p>Combines Ulysses layout changes with 8-GPU all-to-all communication and supports both BF16 and lower-precision transport profiles.</p>
+            <a class="tech-summary" href="#detail-communication">
+              <strong>Pack · all-to-all · merge</strong>
+              <span>Read implementation ↓</span>
+            </a>
             <div class="tech-viz ulysses-viz" aria-hidden="true"><i style="--n:0"></i><i style="--n:1"></i><i style="--n:2"></i><i style="--n:3"></i><i style="--n:4"></i><i style="--n:5"></i><i style="--n:6"></i><i style="--n:7"></i></div>
           </article>
 
           <article class="tech-card span-6 reveal" data-index="03">
             <span class="tech-label">Sparse-attention setup</span>
             <h3>Fuse the setup work</h3>
-            <p>Builds key/value summaries, thresholds, masks, and compact block metadata together instead of launching a chain of small setup kernels.</p>
-            <div class="tech-viz route-viz" aria-hidden="true"><span><i style="--w:100%"></i><b>1.206 ms</b></span><span><i style="--w:24%"></i><b>0.285 ms</b></span></div>
+            <a class="tech-summary" href="#detail-setup">
+              <strong>K/V summaries · threshold · metadata</strong>
+              <span>Read implementation ↓</span>
+            </a>
+            <div class="tech-viz route-viz" aria-hidden="true"><span><i style="--w:100%"></i><b>Before</b></span><span><i style="--w:24%"></i><b>Fused</b></span></div>
           </article>
 
           <article class="tech-card span-6 reveal" data-index="04">
             <span class="tech-label">Sol-Attn</span>
             <h3>Sparsify on the fly</h3>
-            <p>Uses query-dependent thresholds to compute important blocks exactly and approximate the rest as attention runs—without a learned router or retraining.</p>
+            <a class="tech-summary" href="#detail-sol-attn">
+              <strong>Query-dependent · one-pass · training-free</strong>
+              <span>Read implementation ↓</span>
+            </a>
             <div class="tech-viz prefix-viz" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i><i></i></div>
           </article>
 
           <article class="tech-card span-6 reveal" data-index="05">
             <span class="tech-label">Video decoding</span>
             <h3>Parallel VAE decoding</h3>
-            <p>Splits video decoding into spatial tiles, distributes them across eight GPUs, and batches compiled decoder calls for higher throughput.</p>
+            <a class="tech-summary" href="#detail-vae">
+              <strong>Tile parallel · batch · compile</strong>
+              <span>Read implementation ↓</span>
+            </a>
             <div class="tech-viz tile-viz" aria-hidden="true">
               <i style="--p:1"></i><i style="--p:2"></i><i style="--p:3"></i><i style="--p:4"></i><i style="--p:5"></i><i style="--p:6"></i><i style="--p:7"></i>
               <i style="--p:2"></i><i style="--p:3"></i><i style="--p:4"></i><i style="--p:5"></i><i style="--p:6"></i><i style="--p:7"></i><i style="--p:8"></i>
@@ -4925,7 +4995,10 @@
           <article class="tech-card span-6 reveal" data-index="06">
             <span class="tech-label">Conditioning</span>
             <h3>Precompute AdaLN</h3>
-            <p>Precomputes and caches adaptive layer-normalization values before denoising, reducing memory use and repeated indexing work at every step.</p>
+            <a class="tech-summary" href="#detail-adaln">
+              <strong>Precompute · cache · direct lookup</strong>
+              <span>Read implementation ↓</span>
+            </a>
             <div class="tech-viz adaln-viz" aria-hidden="true">
               <i style="--p:1"></i><i style="--p:5"></i><i style="--p:2"></i><i style="--p:7"></i><i style="--p:4"></i><i style="--p:9"></i>
               <i style="--p:6"></i><i style="--p:2"></i><i style="--p:8"></i><i style="--p:3"></i><i style="--p:10"></i><i style="--p:4"></i>
@@ -4954,7 +5027,7 @@
             <span class="section-kicker">Six implementation notes</span>
             <h2 id="details-title">What each optimization does.</h2>
           </div>
-          <p>Each overview card above expands here into one concise implementation note.</p>
+          <p>How each part works, where the time is saved, and the evidence behind it.</p>
         </header>
 
         <div class="detail-list">
@@ -4962,55 +5035,72 @@
             <div class="detail-marker"><strong>01</strong><span>GPU kernels</span></div>
             <div class="detail-copy">
               <h3>Move less data between operations.</h3>
-              <p>RMSNorm/modulation, partial RoPE, and SwiGLU move wide tensors but do relatively little math, so GPU-memory bandwidth is often the limit. Fusing neighboring operations keeps intermediates in registers instead of writing and rereading them, avoiding about <strong>178 GB of traffic per GPU per evaluation</strong> across 50 transformer blocks.</p>
+              <div class="detail-explanation">
+                <div class="detail-part"><span>Mechanism</span><p>Sol-H3 fuses three repeated chains: residual + RMSNorm + modulation, QKNorm + partial RoPE, and SwiGLU. Their intermediate tensors stay in registers or on chip instead of returning to GPU memory between operations.</p></div>
+                <div class="detail-part"><span>Why it is faster</span><p>These operations touch wide tensors but do relatively little math, so memory traffic is often the limit. Fewer reads, writes, and launches save traffic across all 50 transformer blocks.</p></div>
+              </div>
             </div>
-            <div class="detail-path" aria-hidden="true"><span>Read once</span><i>→</i><span>Fused work</span><i>→</i><span>Write once</span><b>≈178 GB less traffic</b></div>
+            <aside class="detail-evidence"><span>Evidence</span><strong>≈178 GB</strong><small>less intermediate traffic per GPU per evaluation</small></aside>
           </article>
 
           <article class="detail-row reveal" id="detail-communication">
             <div class="detail-marker"><strong>02</strong><span>8-GPU exchange</span></div>
             <div class="detail-copy">
               <h3>Pack, exchange, and merge directly.</h3>
-              <p>Ulysses changes sequence shards into head shards before attention, then changes them back. Sol-H3 writes Q/K/V directly into the all-to-all send layout and returns attention output directly into merged-head order. The fastest profile uses one scale per 32 INT8 QKV values and clamps FP8 output to E4M3’s ±448 range; <strong>BF16 transport remains available</strong>.</p>
+              <div class="detail-explanation">
+                <div class="detail-part"><span>Mechanism</span><p>Ulysses changes sequence shards into head shards before attention, then changes them back. Sol-H3 writes normalized and RoPE-applied Q/K, together with V, directly in destination-major order; one packed all-to-all sends them, and the return is decoded directly into merged-head order.</p></div>
+                <div class="detail-part"><span>Why it is faster</span><p>This removes separate stack, permute, and contiguous copies. The fastest profile uses one scale per 32 INT8 QKV values and E4M3 FP8 output clamped to ±448; BF16 transport remains available.</p></div>
+              </div>
             </div>
-            <div class="detail-path" aria-hidden="true"><span>Pack</span><i>→</i><span>All-to-all</span><i>→</i><span>Merge</span><b>8 GPUs · fewer copies</b></div>
+            <aside class="detail-evidence"><span>Fastest profile</span><strong>51.6%</strong><small>of the BF16 attention communication payload</small></aside>
           </article>
 
           <article class="detail-row reveal" id="detail-setup">
             <div class="detail-marker"><strong>03</strong><span>Sparse setup</span></div>
             <div class="detail-copy">
               <h3>Build the sparse plan in fewer passes.</h3>
-              <p>Before block-sparse attention, Sol-H3 needs key centroids, value sums, query thresholds, a selection mask, and compact block metadata. It builds each key/value summary pair together, reuses the pooled query produced during thresholding, and emits the mask and metadata in one compaction step. Setup falls from <strong>1.206 to 0.285 ms (−76.4%)</strong>.</p>
+              <div class="detail-explanation">
+                <div class="detail-part"><span>Mechanism</span><p>One preprocessing kernel computes each key centroid and value sum together. Thresholding also returns the pooled query for reuse; the final compaction step applies threshold, local-band, and exact-prefix rules while emitting the mask and compact block lists.</p></div>
+                <div class="detail-part"><span>Why it is faster</span><p>The cuDNN block-sparse path receives everything it needs without separately materializing each setup stage. This metadata path is separate from the native one-pass Sol-Attn kernel below; reuse and fusion reduce its temporary traffic and launch overhead.</p></div>
+              </div>
             </div>
-            <div class="detail-path" aria-hidden="true"><span>K/V summaries</span><i>→</i><span>Threshold</span><i>→</i><span>Mask + metadata</span><b>1.206 → 0.285 ms</b></div>
+            <aside class="detail-evidence"><span>Measured setup</span><strong>0.285 ms</strong><small>from 1.206 ms · 76.4% lower</small></aside>
           </article>
 
           <article class="detail-row featured reveal" id="detail-sol-attn">
             <div class="detail-marker"><strong>04</strong><span>Sol-Attn</span></div>
             <div class="detail-copy">
               <h3>Select blocks while attention runs.</h3>
-              <p>For each 64-token query block, Sol-Attn compares lightweight query–key scores with a threshold derived from that query’s own score distribution. Important blocks run exact attention; skipped blocks keep a low-cost correction built from pooled keys and value sums.</p>
-              <p>The same score tile is consumed immediately inside online softmax, so there is <strong>no separate router, full score map, or learned routing model</strong>. Sol-Attn works with existing weights and needs no retraining.</p>
+              <div class="detail-explanation">
+                <div class="detail-part"><span>Mechanism</span><p>Each 64-token query block sets its own threshold: mean + β × standard deviation over lightweight query–key scores. Blocks above it run exact attention; skipped blocks contribute a low-cost approximation using pooled keys and value sums.</p></div>
+                <div class="detail-part"><span>Why it is faster</span><p>Sol-Attn consumes each score tile inside online softmax: the same tile selects exact blocks and updates the approximation. It writes no separate router output, full score map, or routing-index tensor, and needs no retraining.</p></div>
+              </div>
             </div>
-            <div class="detail-path" aria-hidden="true"><span>Pooled Q/K</span><i>→</i><span>Per-query threshold</span><i>→</i><span>Exact + approximation</span><b>Training-free · one pass</b></div>
+            <aside class="detail-evidence"><span>Key property</span><strong>One pass</strong><small>query-dependent · training-free sparsification</small></aside>
           </article>
 
           <article class="detail-row reveal" id="detail-vae">
             <div class="detail-marker"><strong>05</strong><span>VAE decoding</span></div>
             <div class="detail-copy">
               <h3>Decode spatial tiles in parallel.</h3>
-              <p>For a 5s output, seven temporal clips each contain 28 spatial tiles. Sol-H3 spreads them across eight GPUs (<strong>7.55 → 1.16 s</strong>), then batches each GPU’s four tiles into one decoder call (<strong>→ 0.602 s</strong>). An optional global mode balances all 196 tiles and decodes/gathers once; it stays optional because the larger batch shows small measured rounding drift.</p>
+              <div class="detail-explanation">
+                <div class="detail-part"><span>Mechanism</span><p>A 5s output has seven temporal clips, each split into a 4 × 7 grid of 28 equal spatial tiles. Sol-H3 distributes them over eight GPUs and batches each GPU’s four tiles into one compiled decoder call.</p></div>
+                <div class="detail-part"><span>Why it is faster</span><p>Tile parallelism reduces work per GPU; batching replaces many small decoder launches. Optional global mode balances all 196 tiles and gathers once, but remains optional because the larger compiled batch shows small measured rounding drift.</p></div>
+              </div>
             </div>
-            <div class="detail-path" aria-hidden="true"><span>28 tiles / clip</span><i>→</i><span>8 GPUs</span><i>→</i><span>Batched decode</span><b>7.55 → 1.16 → 0.602 s</b></div>
+            <aside class="detail-evidence"><span>5s VAE decode</span><strong>0.602 s</strong><small>7.55 → 1.16 s with tiles · then 0.602 s with batching</small></aside>
           </article>
 
           <article class="detail-row reveal" id="detail-adaln">
             <div class="detail-marker"><strong>06</strong><span>AdaLN cache</span></div>
             <div class="detail-copy">
               <h3>Compute conditioning once, then reuse it.</h3>
-              <p>Sol-H3 precomputes all adaptive layer-normalization values for the denoising trajectory and reads each block’s values directly from a cache. This frees about <strong>24 GB per GPU</strong> and avoids roughly <strong>26 GB of GPU-memory reads per step</strong>. Direct lookup replaces two index selections across 50 blocks and four denoising steps—about 400 small GPU launches—without changing the output.</p>
+              <div class="detail-explanation">
+                <div class="detail-part"><span>Mechanism</span><p>All AdaLN values are knowable before denoising. Sol-H3 projects every block-and-step value up front, caches the full trajectory, and releases the projection weights before the denoising loop.</p></div>
+                <div class="detail-part"><span>Why it is faster</span><p>Each block reads its cached slice directly instead of running two index selections. Across 50 blocks and four steps, that removes about 400 small launches and avoids roughly 26 GB of GPU-memory reads per step without changing output.</p></div>
+              </div>
             </div>
-            <div class="detail-path" aria-hidden="true"><span>Precompute</span><i>→</i><span>Cache</span><i>→</i><span>Direct lookup</span><b>≈24 GB freed · ≈400 launches removed</b></div>
+            <aside class="detail-evidence"><span>Memory released</span><strong>≈24 GB</strong><small>per GPU · plus ≈400 indexing launches removed</small></aside>
           </article>
         </div>
       </div>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -1225,6 +1225,13 @@
 
     .latency-matrix thead th:first-child { width: 138px; }
 
+    .matrix-duration {
+      display: flex;
+      align-items: baseline;
+      flex-wrap: wrap;
+      gap: 8px 18px;
+    }
+
     .matrix-duration strong {
       display: block;
       color: var(--white);
@@ -1236,23 +1243,15 @@
     }
 
     .matrix-duration small {
-      display: block;
-      margin-top: 8px;
+      display: inline;
+      margin-top: 0;
+      white-space: nowrap;
       color: var(--muted);
       font-size: 11px;
       letter-spacing: .045em;
       text-transform: uppercase;
     }
 
-    .matrix-duration .matrix-specs {
-      display: block;
-      margin-top: 9px;
-      color: var(--dim);
-      font-size: 10px;
-      font-weight: 650;
-      letter-spacing: .04em;
-      text-transform: none;
-    }
 
     .latency-matrix tbody th,
     .latency-matrix tbody td { border-top: 1px solid var(--line); }
@@ -5027,9 +5026,9 @@
               <thead>
                 <tr>
                   <th scope="col">GPU count</th>
-                  <th scope="col" data-benchmark-duration="5"><span class="matrix-duration"><strong>5s</strong><small>124 frames</small><span class="matrix-specs">1344×768 · 24 FPS · stereo audio</span></span></th>
-                  <th scope="col" data-benchmark-duration="10" hidden><span class="matrix-duration"><strong>10s</strong><small>243 frames</small><span class="matrix-specs">1344×768 · 24 FPS · stereo audio</span></span></th>
-                  <th scope="col" data-benchmark-duration="15" hidden><span class="matrix-duration"><strong>15s</strong><small>362 frames</small><span class="matrix-specs">1344×768 · 24 FPS · stereo audio</span></span></th>
+                  <th scope="col" data-benchmark-duration="5"><span class="matrix-duration"><strong>5s</strong><small>124 frames · 1344×768 · 24 FPS · stereo audio</small></span></th>
+                  <th scope="col" data-benchmark-duration="10" hidden><span class="matrix-duration"><strong>10s</strong><small>243 frames · 1344×768 · 24 FPS · stereo audio</small></span></th>
+                  <th scope="col" data-benchmark-duration="15" hidden><span class="matrix-duration"><strong>15s</strong><small>362 frames · 1344×768 · 24 FPS · stereo audio</small></span></th>
                 </tr>
               </thead>
               <tbody>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -1366,7 +1366,7 @@
       height: 2px;
       margin-right: 12px;
       margin-left: max(calc(var(--w) + 14px), 44px);
-      background: var(--acid);
+      background: var(--red);
       pointer-events: none;
     }
 
@@ -1377,7 +1377,7 @@
       width: 0;
       height: 0;
       border-top: 6px solid transparent;
-      border-right: 11px solid var(--acid);
+      border-right: 11px solid var(--red);
       border-bottom: 6px solid transparent;
       transform: translate(-100%, -50%);
       content: "";
@@ -1385,13 +1385,10 @@
 
     .matrix-speedup > strong {
       position: absolute;
-      top: 50%;
+      bottom: 8px;
       left: 50%;
-      transform: translate(-50%, -50%);
-      padding: 0 8px;
-      background: var(--surface);
-      box-shadow: 0 0 0 5px var(--surface);
-      color: var(--acid);
+      transform: translateX(-50%);
+      color: var(--red);
       font-family: "SFMono-Regular", Consolas, monospace;
       font-size: clamp(12px, 1.2vw, 16px);
       font-weight: 800;

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -1118,7 +1118,7 @@
     /* Two-dimensional Base H3 / Sol-H3 scaling matrix. */
     .latency-head {
       display: flex;
-      padding-bottom: 27px;
+      padding-bottom: 20px;
       align-items: flex-end;
       justify-content: space-between;
       gap: 24px;
@@ -1188,7 +1188,7 @@
     .latency-matrix tr > *:last-child { border-right: 0; }
 
     .latency-matrix thead th {
-      padding: 18px 20px;
+      padding: 14px 17px;
       background: rgba(255, 255, 255, .018);
       color: var(--muted);
       font-family: "SFMono-Regular", Consolas, monospace;
@@ -1223,7 +1223,7 @@
     .latency-matrix tbody td { border-top: 1px solid var(--line); }
 
     .latency-matrix tbody th {
-      padding: 24px 20px;
+      padding: 17px 16px;
       background: rgba(255, 255, 255, .012);
     }
 
@@ -1238,7 +1238,7 @@
 
     .matrix-gpu small {
       display: block;
-      margin-top: 9px;
+      margin-top: 6px;
       color: var(--muted);
       font-family: "SFMono-Regular", Consolas, monospace;
       font-size: 11px;
@@ -1248,7 +1248,7 @@
       white-space: nowrap;
     }
 
-    .matrix-cell { padding: 20px; }
+    .matrix-cell { padding: 15px 17px; }
 
     .matrix-measure {
       display: grid;
@@ -1258,8 +1258,8 @@
     }
 
     .matrix-measure + .matrix-measure {
-      margin-top: 14px;
-      padding-top: 14px;
+      margin-top: 10px;
+      padding-top: 10px;
       border-top: 1px solid var(--line);
     }
 
@@ -1271,8 +1271,8 @@
     }
 
     .matrix-measure > span small {
-      display: block;
-      margin-top: 4px;
+      display: inline-block;
+      margin: 0 0 0 7px;
       color: var(--dim);
       font-family: "SFMono-Regular", Consolas, monospace;
       font-size: 10px;
@@ -1301,8 +1301,8 @@
       display: flex;
       justify-content: space-between;
       gap: 12px;
-      margin-top: 13px;
-      padding-top: 11px;
+      margin-top: 9px;
+      padding-top: 7px;
       border-top: 1px dashed var(--line);
       color: var(--dim);
       font-family: "SFMono-Regular", Consolas, monospace;
@@ -1334,7 +1334,7 @@
       .latency-matrix tbody th {
         display: block;
         width: auto;
-        padding: 21px 22px;
+        padding: 16px 19px;
         border-right: 0;
         border-top: 0;
         border-bottom: 1px solid var(--line);
@@ -1359,7 +1359,7 @@
 
       .latency-matrix tbody td::before {
         content: attr(data-duration);
-        padding: 21px 18px;
+        padding: 16px 17px;
         border-right: 1px solid var(--line);
         color: var(--fog);
         font-family: "SFMono-Regular", Consolas, monospace;
@@ -1371,18 +1371,18 @@
         white-space: pre-line;
       }
 
-      .matrix-cell { padding: 18px 20px; }
+      .matrix-cell { padding: 14px 18px; }
     }
 
     @media (max-width: 520px) {
       .latency-matrix tbody td { grid-template-columns: 1fr; }
 
       .latency-matrix tbody td::before {
-        padding: 15px 18px 0;
+        padding: 12px 18px 0;
         border-right: 0;
       }
 
-      .matrix-cell { padding: 14px 18px 19px; }
+      .matrix-cell { padding: 12px 18px 16px; }
       .matrix-measure > strong { font-size: 20px; }
     }
 
@@ -2959,7 +2959,7 @@
     .section-index, .section-kicker { font-size: 12px; }
     .section-head > p { font-size: 18px; line-height: 1.62; }
 
-    .benchmark-console-wide { min-height: 0; padding: clamp(30px, 4.5vw, 58px); }
+    .benchmark-console-wide { min-height: 0; padding: clamp(26px, 3.4vw, 42px); }
     .console-label { font-size: 12px; }
     .console-subtitle { margin: 10px 0 0; }
     .duration-tab { min-width: 70px; min-height: 40px; font-size: 13px; }

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -5,17 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#050705">
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f5f8f1">
-  <meta name="description" content="Sol-H3 accelerates MiniMax-H3 video generation with native audio, producing five seconds of 1344×768 video in 1.669 seconds—3.00× realtime on 8× NVIDIA B300 GPUs.">
+  <meta name="description" content="Sol-H3 accelerates MiniMax-H3 video generation with native audio, delivering up to 19.89× speedup over Base H3 across 5s, 10s, and 15s outputs on 8× NVIDIA B300 GPUs.">
   <meta property="og:type" content="article">
   <meta property="og:title" content="Sol-H3: Speed-of-Light MiniMax-H3 on an 8× NVIDIA B300 Blackwell System">
-  <meta property="og:description" content="Five seconds of world. 1.669 seconds to infer. MiniMax-H3 video with native audio at 3.00× realtime on 8 NVIDIA B300 GPUs.">
+  <meta property="og:description" content="Five seconds of world in 1.669 seconds. Across 5s–15s outputs, Sol-H3 is 18.38×–19.89× faster than Base H3 on 8× NVIDIA B300 GPUs.">
   <meta property="og:url" content="https://nvlabs.github.io/Sana/Sol-Engine/Sol-H3/">
   <meta property="og:image" content="https://nvlabs.github.io/Sana/Sol-Engine/Sol-H3/sol-h3-poster.jpg">
   <meta property="og:image:width" content="1280">
   <meta property="og:image:height" content="732">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Sol-H3: Speed-of-Light MiniMax-H3 on an 8× NVIDIA B300 Blackwell System">
-  <meta name="twitter:description" content="Five seconds of world in 1.669 seconds—MiniMax-H3 video with native audio at 3.00× realtime on 8× NVIDIA B300.">
+  <meta name="twitter:description" content="Five seconds of world in 1.669 seconds. Sol-H3 delivers up to 19.89× speedup over Base H3 on 8× NVIDIA B300 GPUs.">
   <meta name="twitter:image" content="https://nvlabs.github.io/Sana/Sol-Engine/Sol-H3/sol-h3-poster.jpg">
   <link rel="canonical" href="https://nvlabs.github.io/Sana/Sol-Engine/Sol-H3/">
   <title>Sol-H3: Speed-of-Light MiniMax-H3 on an 8× NVIDIA B300 Blackwell System | NVIDIA Research</title>
@@ -1113,6 +1113,169 @@
       text-underline-offset: 3px;
     }
     .method-note a:hover { color: var(--acid); }
+
+    /* Static Base H3 vs. Sol-H3 latency comparison. */
+    .latency-head {
+      display: flex;
+      padding-bottom: 27px;
+      border-bottom: 1px solid var(--line);
+      align-items: flex-end;
+      justify-content: space-between;
+      gap: 24px;
+    }
+    .latency-head h3 {
+      margin: 9px 0 0;
+      color: var(--white);
+      font-size: clamp(29px, 3.2vw, 46px);
+      font-weight: 840;
+      line-height: 1;
+      letter-spacing: -.045em;
+    }
+    .latency-direction {
+      display: inline-flex;
+      align-items: center;
+      gap: 9px;
+      color: var(--muted);
+      font-family: "SFMono-Regular", Consolas, monospace;
+      font-size: 12px;
+      font-weight: 750;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+    .latency-direction::before {
+      content: "";
+      width: 20px;
+      height: 1px;
+      background: var(--acid);
+      box-shadow: 0 0 10px rgba(167, 255, 46, .45);
+    }
+    .latency-group {
+      display: grid;
+      grid-template-columns: 96px minmax(0, 1fr) 142px;
+      gap: clamp(22px, 3vw, 42px);
+      padding: 33px 0;
+      align-items: center;
+    }
+    .latency-group + .latency-group { border-top: 1px solid var(--line); }
+    .latency-group:last-child { padding-bottom: 0; }
+    .latency-duration strong,
+    .latency-gain strong {
+      display: block;
+      color: var(--white);
+      font-weight: 870;
+      line-height: .9;
+      letter-spacing: -.055em;
+      font-variant-numeric: tabular-nums;
+      white-space: nowrap;
+    }
+    .latency-duration strong { font-size: clamp(38px, 4vw, 54px); }
+    .latency-duration span,
+    .latency-gain span {
+      display: block;
+      margin-top: 9px;
+      color: var(--muted);
+      font-family: "SFMono-Regular", Consolas, monospace;
+      font-size: 12px;
+      font-weight: 750;
+      letter-spacing: .1em;
+      text-transform: uppercase;
+    }
+    .latency-row {
+      display: grid;
+      grid-template-columns: 108px minmax(0, 1fr) 88px;
+      gap: 13px;
+      align-items: center;
+    }
+    .latency-row + .latency-row { margin-top: 12px; }
+    .latency-model,
+    .latency-number {
+      color: var(--muted);
+      font-family: "SFMono-Regular", Consolas, monospace;
+      font-size: 12px;
+      font-weight: 750;
+      font-variant-numeric: tabular-nums;
+      white-space: nowrap;
+    }
+    .latency-model small {
+      display: block;
+      color: var(--dim);
+      font-size: 10px;
+      font-weight: 650;
+      letter-spacing: .06em;
+      text-transform: uppercase;
+    }
+    .latency-number { color: var(--fog); text-align: right; }
+    .latency-row.ours .latency-model,
+    .latency-row.ours .latency-number { color: var(--white); }
+    .latency-track {
+      height: 18px;
+      overflow: hidden;
+      border-radius: 3px;
+      background: rgba(255, 255, 255, .045);
+    }
+    .latency-fill {
+      display: block;
+      width: max(var(--w), 8px);
+      height: 100%;
+      border-radius: inherit;
+    }
+    .latency-fill.base { background: var(--dim); }
+    .latency-fill.sol {
+      position: relative;
+      overflow: hidden;
+      background: linear-gradient(90deg, var(--green), var(--acid));
+      box-shadow: 0 0 18px rgba(167, 255, 46, .16);
+    }
+    .latency-fill.sol::after {
+      content: "";
+      position: absolute;
+      top: 0;
+      right: 0;
+      width: 2px;
+      height: 100%;
+      background: rgba(255, 255, 255, .9);
+      box-shadow: 0 0 10px 2px rgba(255, 255, 255, .45);
+    }
+    .latency-settings {
+      display: block;
+      margin-top: 13px;
+      color: var(--muted);
+      font-family: "SFMono-Regular", Consolas, monospace;
+      font-size: 12px;
+      line-height: 1.5;
+      letter-spacing: .025em;
+    }
+    .latency-gain {
+      padding-left: clamp(20px, 2.5vw, 34px);
+      border-left: 1px solid var(--line);
+      text-align: right;
+    }
+    .latency-gain strong { color: var(--acid); font-size: clamp(30px, 3vw, 42px); }
+
+    @media (max-width: 720px) {
+      .latency-head { align-items: flex-start; flex-direction: column; }
+      .latency-group {
+        grid-template-columns: 1fr auto;
+        gap: 20px 16px;
+        padding: 27px 0;
+      }
+      .latency-duration { display: flex; align-items: baseline; gap: 9px; }
+      .latency-duration strong { font-size: 40px; }
+      .latency-duration span { margin-top: 0; }
+      .latency-comparison { grid-column: 1 / -1; grid-row: 2; }
+      .latency-gain { grid-column: 2; grid-row: 1; padding-left: 0; border-left: 0; }
+      .latency-gain strong { font-size: 31px; }
+      .latency-gain span { margin-top: 6px; }
+      .latency-row { grid-template-columns: 92px minmax(0, 1fr) 78px; gap: 9px; }
+    }
+
+    @media (max-width: 420px) {
+      .latency-row { grid-template-columns: 82px minmax(0, 1fr) 72px; gap: 7px; }
+      .latency-model, .latency-number, .latency-settings { font-size: 11px; }
+      .latency-model small { font-size: 9px; }
+    }
+
 
     .architecture {
       background:
@@ -4050,8 +4213,8 @@
       .terminal-code,
       .sound-toggle { color: #fff; }
 
-      .duration-tabs { background: rgba(25, 40, 18, .055); }
-      .time-track,
+      .latency-track { background: rgba(23, 37, 17, .075); }
+      .latency-fill.base { background: rgba(23, 37, 17, .36); }
       .fusion-stack i,
       .attn-bar i,
       .lane-track { background: rgba(23, 37, 17, .075); }
@@ -4345,60 +4508,81 @@
         <header class="section-head reveal">
           <div class="section-index">01</div>
           <div>
-            <span class="section-kicker">Audited · 2026-09-04</span>
-            <h2 id="performance-title">Faster than playback.</h2>
+            <span class="section-kicker">Measured · 8× NVIDIA B300</span>
+            <h2 id="performance-title">Base H3 vs. Sol-H3.</h2>
           </div>
-          <p>On one 8× NVIDIA B300 system, Sol-H3 generates MiniMax-H3 video with native audio at up to 3.00× realtime.</p>
+          <p>Across 5s, 10s, and 15s outputs, Sol-H3 delivers 18.38×–19.89× speedup over the Base H3 dense baseline on the same system.</p>
         </header>
 
-        <article class="benchmark-console benchmark-console-wide reveal" aria-labelledby="console-title">
-          <div class="console-head">
+        <article class="benchmark-console benchmark-console-wide reveal" aria-labelledby="latency-title" aria-describedby="benchmark-method">
+          <header class="latency-head">
             <div>
-              <div class="console-label">Ours · Sol-H3 · fastest measured profile</div>
-              <span id="console-title" class="section-kicker console-subtitle">Choose output length</span>
+              <div class="console-label">Measured request latency</div>
+              <h3 id="latency-title">Latency by output length.</h3>
             </div>
-            <div class="duration-tabs" role="tablist" aria-label="Video duration">
-              <button class="duration-tab" type="button" role="tab" aria-selected="true" data-duration="5">5s</button>
-              <button class="duration-tab" type="button" role="tab" aria-selected="false" data-duration="10">10s</button>
-              <button class="duration-tab" type="button" role="tab" aria-selected="false" data-duration="15">15s</button>
-            </div>
-          </div>
+            <span class="latency-direction">Lower is better</span>
+          </header>
 
-          <div class="console-readout" aria-live="polite">
-            <div class="readout-big">
-              <b><span id="readout-latency">1.669</span> s</b>
-              <small>Sol-H3 median request latency</small>
-            </div>
-            <div class="readout-meta">
-              <div><b id="readout-frames">124</b><small>Frames</small></div>
-              <div><b id="readout-rate">3.00×</b><small>Realtime</small></div>
-              <div><b>8×</b><small>NVIDIA B300</small></div>
-              <div><b>3</b><small>Measured requests</small></div>
-            </div>
-          </div>
+          <div class="latency-groups">
+            <section class="latency-group" aria-labelledby="latency-5s">
+              <div class="latency-duration"><strong id="latency-5s">5s</strong><span>output</span></div>
+              <div class="latency-comparison">
+                <div class="latency-row">
+                  <span class="latency-model">Base H3<small>Dense</small></span>
+                  <span class="latency-track" aria-hidden="true"><i class="latency-fill base" style="--w: 100%"></i></span>
+                  <strong class="latency-number">30.673 s</strong>
+                </div>
+                <div class="latency-row ours">
+                  <span class="latency-model">Sol-H3<small>Ours</small></span>
+                  <span class="latency-track" aria-hidden="true"><i class="latency-fill sol" style="--w: 5.441%"></i></span>
+                  <strong class="latency-number">1.669 s</strong>
+                </div>
+                <small class="latency-settings">124 frames · 1344×768 · 24 FPS · native audio · 8× NVIDIA B300</small>
+              </div>
+              <div class="latency-gain"><strong>18.38×</strong><span>speedup</span></div>
+            </section>
 
-          <div class="time-chart" aria-label="Nominal output duration and measured Sol-H3 inference latency">
-            <div class="time-row">
-              <span class="time-label">Video</span>
-              <div class="time-track"><div class="time-fill output" id="output-bar" style="--w:100%"></div></div>
-              <span class="time-number" id="clip-time">5.00 s</span>
-            </div>
-            <div class="time-row">
-              <span class="time-label">Ours · Sol-H3</span>
-              <div class="time-track"><div class="time-fill sol" id="sol-bar" style="--w:33.38%"></div></div>
-              <span class="time-number" id="sol-time">1.669 s</span>
-            </div>
-          </div>
+            <section class="latency-group" aria-labelledby="latency-10s">
+              <div class="latency-duration"><strong id="latency-10s">10s</strong><span>output</span></div>
+              <div class="latency-comparison">
+                <div class="latency-row">
+                  <span class="latency-model">Base H3<small>Dense</small></span>
+                  <span class="latency-track" aria-hidden="true"><i class="latency-fill base" style="--w: 100%"></i></span>
+                  <strong class="latency-number">71.316 s</strong>
+                </div>
+                <div class="latency-row ours">
+                  <span class="latency-model">Sol-H3<small>Ours</small></span>
+                  <span class="latency-track" aria-hidden="true"><i class="latency-fill sol" style="--w: 5.241%"></i></span>
+                  <strong class="latency-number">3.738 s</strong>
+                </div>
+                <small class="latency-settings">243 frames · 1344×768 · 24 FPS · native audio · 8× NVIDIA B300</small>
+              </div>
+              <div class="latency-gain"><strong>19.08×</strong><span>speedup</span></div>
+            </section>
 
-          <div class="console-foot">
-            <span><strong>Included</strong> · prompt encode → denoise → video/audio decode</span>
-            <span id="console-status">3.00× realtime · warm median</span>
+            <section class="latency-group" aria-labelledby="latency-15s">
+              <div class="latency-duration"><strong id="latency-15s">15s</strong><span>output</span></div>
+              <div class="latency-comparison">
+                <div class="latency-row">
+                  <span class="latency-model">Base H3<small>Dense</small></span>
+                  <span class="latency-track" aria-hidden="true"><i class="latency-fill base" style="--w: 100%"></i></span>
+                  <strong class="latency-number">131.647 s</strong>
+                </div>
+                <div class="latency-row ours">
+                  <span class="latency-model">Sol-H3<small>Ours</small></span>
+                  <span class="latency-track" aria-hidden="true"><i class="latency-fill sol" style="--w: 5.028%"></i></span>
+                  <strong class="latency-number">6.619 s</strong>
+                </div>
+                <small class="latency-settings">362 frames · 1344×768 · 24 FPS · native audio · 8× NVIDIA B300</small>
+              </div>
+              <div class="latency-gain"><strong>19.89×</strong><span>speedup</span></div>
+            </section>
           </div>
         </article>
 
         <div class="method-note reveal">
           <strong>Measured scope</strong>
-          <span>Each output length uses one warmup and the median of three measured requests on one 8× NVIDIA B300 system. Timing includes prompt encoding, diffusion denoising, VAE video decoding, and native audio. Final MP4 file encoding is excluded.</span>
+          <span id="benchmark-method">Base H3 and Sol-H3 use the same 8× NVIDIA B300 system and 1344×768, 24 FPS output settings, with one warmup and the median of three measured requests. Timing includes prompt encoding, diffusion denoising, VAE video decoding, and native audio; final MP4 encoding is excluded. Speedup = Base H3 latency ÷ Sol-H3 latency.</span>
         </div>
       </div>
     </section>
@@ -4891,53 +5075,6 @@
         });
       }, { rootMargin: '-25% 0px -60% 0px', threshold: 0 });
       navSections.forEach((section) => navObserver.observe(section));
-
-      const benchmarks = {
-        5: {
-          frames: 124,
-          output: 5,
-          sol: 1.669
-        },
-        10: {
-          frames: 243,
-          output: 10,
-          sol: 3.738,
-          rateLabel: '2.67'
-        },
-        15: {
-          frames: 362,
-          output: 15,
-          sol: 6.619
-        }
-      };
-      const tabs = [...document.querySelectorAll('.duration-tab')];
-      const fields = {
-        latency: document.getElementById('readout-latency'),
-        frames: document.getElementById('readout-frames'),
-        rate: document.getElementById('readout-rate'),
-        outputBar: document.getElementById('output-bar'),
-        solBar: document.getElementById('sol-bar'),
-        clipTime: document.getElementById('clip-time'),
-        solTime: document.getElementById('sol-time'),
-        status: document.getElementById('console-status')
-      };
-
-      const selectBenchmark = (duration) => {
-        const data = benchmarks[duration];
-        const rate = data.rateLabel ?? (data.output / data.sol).toFixed(2);
-        tabs.forEach((tab) => tab.setAttribute('aria-selected', String(Number(tab.dataset.duration) === duration)));
-        fields.latency.textContent = data.sol.toFixed(3);
-        fields.frames.textContent = data.frames;
-        fields.rate.textContent = `${rate}×`;
-        const chartMax = Math.max(data.output, data.sol);
-        fields.outputBar.style.setProperty('--w', `${data.output / chartMax * 100}%`);
-        fields.solBar.style.setProperty('--w', `${data.sol / chartMax * 100}%`);
-        fields.clipTime.textContent = `${data.output.toFixed(2)} s`;
-        fields.solTime.textContent = `${data.sol.toFixed(3)} s`;
-        fields.status.textContent = `${rate}× realtime · warm median`;
-      };
-      tabs.forEach((tab) => tab.addEventListener('click', () => selectBenchmark(Number(tab.dataset.duration))));
-      selectBenchmark(5);
 
       const comparisonLab = document.getElementById('comparison-lab');
       if (comparisonLab) {

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -915,7 +915,7 @@
       padding: 3px;
       border: 1px solid var(--line);
       border-radius: 9px;
-      background: rgba(0, 0, 0, .25);
+      background: var(--surface-2);
     }
 
     .duration-tab {
@@ -934,6 +934,24 @@
 
     .duration-tab:hover { color: var(--white); }
     .duration-tab[aria-selected="true"] { background: var(--acid); color: #071000; }
+
+    .benchmark-duration-control {
+      display: grid;
+      justify-items: end;
+      gap: 8px;
+    }
+
+    .benchmark-scale {
+      color: var(--muted);
+      font-family: "SFMono-Regular", Consolas, monospace;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: .055em;
+      text-transform: uppercase;
+    }
+
+    .latency-matrix [hidden] { display: none !important; }
+    .latency-matrix [data-benchmark-duration]:not([hidden]) { border-right: 0; }
 
     .console-readout {
       display: grid;
@@ -1252,9 +1270,30 @@
 
     .matrix-measure {
       display: grid;
-      grid-template-columns: minmax(0, 1fr) auto;
+      grid-template-columns: 108px minmax(0, 1fr) 110px;
       gap: 12px;
       align-items: center;
+      --w: 100%;
+    }
+
+    .matrix-measure > span {
+      grid-column: 1;
+      grid-row: 1;
+    }
+
+    .matrix-measure::before {
+      content: "";
+      grid-column: 2;
+      grid-row: 1;
+      width: 100%;
+      height: 18px;
+      border-radius: 3px;
+      background: linear-gradient(90deg, var(--dim) 0 var(--w), var(--line) var(--w) 100%);
+    }
+
+    .matrix-measure.ours::before {
+      background: linear-gradient(90deg, var(--green) 0, var(--acid) var(--w), var(--line) var(--w) 100%);
+      box-shadow: 0 0 18px rgba(167, 255, 46, .1);
     }
 
     .matrix-measure + .matrix-measure {
@@ -1282,11 +1321,14 @@
     }
 
     .matrix-measure > strong {
+      grid-column: 3;
+      grid-row: 1;
       color: var(--white);
       font-size: clamp(19px, 2vw, 26px);
       line-height: 1;
       letter-spacing: -.025em;
       font-variant-numeric: tabular-nums;
+      text-align: right;
       white-space: nowrap;
     }
 
@@ -1327,6 +1369,7 @@
         align-items: flex-start;
         flex-direction: column;
       }
+      .benchmark-duration-control { justify-items: start; }
 
       .latency-matrix,
       .latency-matrix tbody,
@@ -1392,6 +1435,11 @@
 
       .matrix-cell { padding: 14px 18px 19px; }
       .matrix-measure > strong { font-size: 20px; }
+
+      .matrix-measure {
+        grid-template-columns: 82px minmax(0, 1fr) 76px;
+        gap: 8px;
+      }
     }
 
 
@@ -4937,98 +4985,105 @@
             <span class="section-kicker">Scaling benchmark · 1 / 4 / 8× NVIDIA B300</span>
             <h2 id="performance-title">Latency across GPU counts.</h2>
           </div>
-          <p>Read every 5s, 10s, and 15s result across 1, 4, and 8 B300 GPUs at a glance.</p>
+          <p>Choose an output length, then compare 1, 4, and 8 B300 GPUs on one shared latency scale.</p>
         </header>
 
         <article class="benchmark-console benchmark-console-wide reveal" aria-labelledby="latency-title" aria-describedby="benchmark-method">
           <header class="latency-head">
             <div>
               <div class="console-label">Measured generation time · seconds</div>
-              <h3 id="latency-title">Video length × GPU count.</h3>
+              <h3 id="latency-title">GPU scaling by output length.</h3>
             </div>
-            <span class="latency-direction">Base H3 Dense · Sol-H3</span>
+            <div class="benchmark-duration-control">
+              <div class="duration-tabs" role="tablist" aria-label="Choose output length">
+                <button class="duration-tab" id="benchmark-duration-5" type="button" role="tab" aria-selected="true" tabindex="0" data-benchmark-duration-control="5" aria-controls="latency-panel">5s</button>
+                <button class="duration-tab" id="benchmark-duration-10" type="button" role="tab" aria-selected="false" tabindex="-1" data-benchmark-duration-control="10" aria-controls="latency-panel">10s</button>
+                <button class="duration-tab" id="benchmark-duration-15" type="button" role="tab" aria-selected="false" tabindex="-1" data-benchmark-duration-control="15" aria-controls="latency-panel">15s</button>
+              </div>
+              <span class="benchmark-scale" id="benchmark-scale">Shared scale · 0–129.898 s</span>
+            </div>
           </header>
 
-          <div class="matrix-shell">
-            <table class="latency-matrix">
+          <div class="matrix-shell" id="latency-panel" role="tabpanel" aria-labelledby="benchmark-duration-5" aria-live="polite">
+            <table class="latency-matrix" id="latency-matrix">
               <caption class="matrix-caption">Measured Base H3 Dense and Sol-H3 latency for 5, 10, and 15 second outputs on one, four, and eight NVIDIA B300 GPUs.</caption>
               <thead>
                 <tr>
                   <th scope="col">GPU count</th>
-                  <th scope="col"><span class="matrix-duration"><strong>5s</strong><small>124 frames</small></span></th>
-                  <th scope="col"><span class="matrix-duration"><strong>10s</strong><small>243 frames</small></span></th>
-                  <th scope="col"><span class="matrix-duration"><strong>15s</strong><small>362 frames</small></span></th>
+                  <th scope="col" data-benchmark-duration="5"><span class="matrix-duration"><strong>5s</strong><small>124 frames</small></span></th>
+                  <th scope="col" data-benchmark-duration="10" hidden><span class="matrix-duration"><strong>10s</strong><small>243 frames</small></span></th>
+                  <th scope="col" data-benchmark-duration="15" hidden><span class="matrix-duration"><strong>15s</strong><small>362 frames</small></span></th>
                 </tr>
               </thead>
               <tbody>
                 <tr>
                   <th scope="row"><span class="matrix-gpu"><strong>1×</strong><small>NVIDIA B300</small></span></th>
-                  <td data-duration="5s · 124 frames">
+                  <td data-duration="5s · 124 frames" data-benchmark-duration="5">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>129.898 s</strong></div>
-                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours</small></span><strong>13.745 s</strong></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>129.898 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 10.581%;"><span>Sol-H3<small>Ours</small></span><strong>13.745 s</strong></div>
                       <div class="matrix-speedup"><span>vs Base H3</span><strong>9.45×</strong></div>
                     </div>
                   </td>
-                  <td data-duration="10s · 243 frames">
+                  <td data-duration="10s · 243 frames" data-benchmark-duration="10" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>376.942 s</strong></div>
-                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours</small></span><strong>37.813 s</strong></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>376.942 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 10.032%;"><span>Sol-H3<small>Ours</small></span><strong>37.813 s</strong></div>
                       <div class="matrix-speedup"><span>vs Base H3</span><strong>9.97×</strong></div>
                     </div>
                   </td>
-                  <td data-duration="15s · 362 frames">
+                  <td data-duration="15s · 362 frames" data-benchmark-duration="15" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>746.885 s</strong></div>
-                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours</small></span><strong>52.260 s</strong></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>746.885 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 6.997%;"><span>Sol-H3<small>Ours</small></span><strong>52.260 s</strong></div>
                       <div class="matrix-speedup"><span>vs Base H3</span><strong>14.29×</strong></div>
                     </div>
                   </td>
                 </tr>
                 <tr>
                   <th scope="row"><span class="matrix-gpu"><strong>4×</strong><small>NVIDIA B300</small></span></th>
-                  <td data-duration="5s · 124 frames">
+                  <td data-duration="5s · 124 frames" data-benchmark-duration="5">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>35.328 s</strong></div>
-                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours</small></span><strong>2.918 s</strong></div>
+                      <div class="matrix-measure base" style="--w: 27.197%;"><span>Base H3<small>Dense</small></span><strong>35.328 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 2.246%;"><span>Sol-H3<small>Ours</small></span><strong>2.918 s</strong></div>
                       <div class="matrix-speedup"><span>vs Base H3</span><strong>12.11×</strong></div>
                     </div>
                   </td>
-                  <td data-duration="10s · 243 frames">
+                  <td data-duration="10s · 243 frames" data-benchmark-duration="10" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>100.440 s</strong></div>
-                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours</small></span><strong>6.993 s</strong></div>
+                      <div class="matrix-measure base" style="--w: 26.646%;"><span>Base H3<small>Dense</small></span><strong>100.440 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 1.855%;"><span>Sol-H3<small>Ours</small></span><strong>6.993 s</strong></div>
                       <div class="matrix-speedup"><span>vs Base H3</span><strong>14.36×</strong></div>
                     </div>
                   </td>
-                  <td data-duration="15s · 362 frames">
+                  <td data-duration="15s · 362 frames" data-benchmark-duration="15" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>194.930 s</strong></div>
-                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours</small></span><strong>12.542 s</strong></div>
+                      <div class="matrix-measure base" style="--w: 26.099%;"><span>Base H3<small>Dense</small></span><strong>194.930 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 1.679%;"><span>Sol-H3<small>Ours</small></span><strong>12.542 s</strong></div>
                       <div class="matrix-speedup"><span>vs Base H3</span><strong>15.54×</strong></div>
                     </div>
                   </td>
                 </tr>
                 <tr>
                   <th scope="row"><span class="matrix-gpu"><strong>8×</strong><small>NVIDIA B300</small></span></th>
-                  <td data-duration="5s · 124 frames">
+                  <td data-duration="5s · 124 frames" data-benchmark-duration="5">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>18.250 s</strong></div>
-                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours</small></span><strong>1.653 s</strong></div>
+                      <div class="matrix-measure base" style="--w: 14.049%;"><span>Base H3<small>Dense</small></span><strong>18.250 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 1.273%;"><span>Sol-H3<small>Ours</small></span><strong>1.653 s</strong></div>
                       <div class="matrix-speedup"><span>vs Base H3</span><strong>11.04×</strong></div>
                     </div>
                   </td>
-                  <td data-duration="10s · 243 frames">
+                  <td data-duration="10s · 243 frames" data-benchmark-duration="10" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>50.660 s</strong></div>
-                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours</small></span><strong>3.732 s</strong></div>
+                      <div class="matrix-measure base" style="--w: 13.440%;"><span>Base H3<small>Dense</small></span><strong>50.660 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 0.990%;"><span>Sol-H3<small>Ours</small></span><strong>3.732 s</strong></div>
                       <div class="matrix-speedup"><span>vs Base H3</span><strong>13.57×</strong></div>
                     </div>
                   </td>
-                  <td data-duration="15s · 362 frames">
+                  <td data-duration="15s · 362 frames" data-benchmark-duration="15" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>99.513 s</strong></div>
-                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours</small></span><strong>6.612 s</strong></div>
+                      <div class="matrix-measure base" style="--w: 13.324%;"><span>Base H3<small>Dense</small></span><strong>99.513 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 0.885%;"><span>Sol-H3<small>Ours</small></span><strong>6.612 s</strong></div>
                       <div class="matrix-speedup"><span>vs Base H3</span><strong>15.05×</strong></div>
                     </div>
                   </td>
@@ -5609,6 +5664,46 @@
         });
       }, { rootMargin: '-25% 0px -60% 0px', threshold: 0 });
       navSections.forEach((section) => navObserver.observe(section));
+
+      const benchmarkTabs = [...document.querySelectorAll('[data-benchmark-duration-control]')];
+      const benchmarkCells = [...document.querySelectorAll('[data-benchmark-duration]')];
+      const benchmarkPanel = document.getElementById('latency-panel');
+      const benchmarkScale = document.getElementById('benchmark-scale');
+      const benchmarkScales = {
+        '5': 'Shared scale · 0–129.898 s',
+        '10': 'Shared scale · 0–376.942 s',
+        '15': 'Shared scale · 0–746.885 s'
+      };
+      const setBenchmarkDuration = (duration, moveFocus = false) => {
+        const activeTab = benchmarkTabs.find((tab) => tab.dataset.benchmarkDurationControl === duration);
+        if (!activeTab || !benchmarkPanel || !benchmarkScale) return;
+        benchmarkTabs.forEach((tab) => {
+          const active = tab === activeTab;
+          tab.setAttribute('aria-selected', String(active));
+          tab.tabIndex = active ? 0 : -1;
+        });
+        benchmarkCells.forEach((cell) => {
+          cell.hidden = cell.dataset.benchmarkDuration !== duration;
+        });
+        benchmarkScale.textContent = benchmarkScales[duration];
+        benchmarkPanel.setAttribute('aria-labelledby', activeTab.id);
+        if (moveFocus) activeTab.focus();
+      };
+
+      benchmarkTabs.forEach((tab, index) => {
+        tab.addEventListener('click', () => setBenchmarkDuration(tab.dataset.benchmarkDurationControl));
+        tab.addEventListener('keydown', (event) => {
+          let nextIndex = null;
+          if (event.key === 'ArrowLeft') nextIndex = (index - 1 + benchmarkTabs.length) % benchmarkTabs.length;
+          if (event.key === 'ArrowRight') nextIndex = (index + 1) % benchmarkTabs.length;
+          if (event.key === 'Home') nextIndex = 0;
+          if (event.key === 'End') nextIndex = benchmarkTabs.length - 1;
+          if (nextIndex === null) return;
+          event.preventDefault();
+          setBenchmarkDuration(benchmarkTabs[nextIndex].dataset.benchmarkDurationControl, true);
+        });
+      });
+
 
       const comparisonLab = document.getElementById('comparison-lab');
       if (comparisonLab) {

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -4953,22 +4953,22 @@
                   <th scope="row"><span class="matrix-gpu"><strong>1×</strong><small>NVIDIA B300</small></span></th>
                   <td data-duration="5s · 124 frames">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense · 49× DiT</small></span><strong>129.898 s</strong></div>
-                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours · Dense · 4× DiT</small></span><strong>13.745 s</strong></div>
+                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>129.898 s</strong></div>
+                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours</small></span><strong>13.745 s</strong></div>
                       <div class="matrix-speedup"><span>vs Base H3</span><strong>9.45×</strong></div>
                     </div>
                   </td>
                   <td data-duration="10s · 243 frames">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense · 49× DiT</small></span><strong>376.942 s</strong></div>
-                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours · Dense · 4× DiT</small></span><strong>37.813 s</strong></div>
+                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>376.942 s</strong></div>
+                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours</small></span><strong>37.813 s</strong></div>
                       <div class="matrix-speedup"><span>vs Base H3</span><strong>9.97×</strong></div>
                     </div>
                   </td>
                   <td data-duration="15s · 362 frames">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense · 49× DiT</small></span><strong>746.885 s</strong></div>
-                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours · Dense · 4× DiT</small></span><strong>52.260 s</strong></div>
+                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>746.885 s</strong></div>
+                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours</small></span><strong>52.260 s</strong></div>
                       <div class="matrix-speedup"><span>vs Base H3</span><strong>14.29×</strong></div>
                     </div>
                   </td>
@@ -4977,22 +4977,22 @@
                   <th scope="row"><span class="matrix-gpu"><strong>4×</strong><small>NVIDIA B300</small></span></th>
                   <td data-duration="5s · 124 frames">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense · 49× DiT</small></span><strong>35.328 s</strong></div>
-                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours · SOL · 4× DiT</small></span><strong>2.918 s</strong></div>
+                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>35.328 s</strong></div>
+                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours</small></span><strong>2.918 s</strong></div>
                       <div class="matrix-speedup"><span>vs Base H3</span><strong>12.11×</strong></div>
                     </div>
                   </td>
                   <td data-duration="10s · 243 frames">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense · 49× DiT</small></span><strong>100.440 s</strong></div>
-                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours · SOL · 4× DiT</small></span><strong>6.993 s</strong></div>
+                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>100.440 s</strong></div>
+                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours</small></span><strong>6.993 s</strong></div>
                       <div class="matrix-speedup"><span>vs Base H3</span><strong>14.36×</strong></div>
                     </div>
                   </td>
                   <td data-duration="15s · 362 frames">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense · 49× DiT</small></span><strong>194.930 s</strong></div>
-                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours · SOL · 4× DiT</small></span><strong>12.542 s</strong></div>
+                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>194.930 s</strong></div>
+                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours</small></span><strong>12.542 s</strong></div>
                       <div class="matrix-speedup"><span>vs Base H3</span><strong>15.54×</strong></div>
                     </div>
                   </td>
@@ -5001,22 +5001,22 @@
                   <th scope="row"><span class="matrix-gpu"><strong>8×</strong><small>NVIDIA B300</small></span></th>
                   <td data-duration="5s · 124 frames">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense · 49× DiT</small></span><strong>18.250 s</strong></div>
-                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours · SOL · 4× DiT</small></span><strong>1.653 s</strong></div>
+                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>18.250 s</strong></div>
+                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours</small></span><strong>1.653 s</strong></div>
                       <div class="matrix-speedup"><span>vs Base H3</span><strong>11.04×</strong></div>
                     </div>
                   </td>
                   <td data-duration="10s · 243 frames">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense · 49× DiT</small></span><strong>50.660 s</strong></div>
-                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours · SOL · 4× DiT</small></span><strong>3.732 s</strong></div>
+                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>50.660 s</strong></div>
+                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours</small></span><strong>3.732 s</strong></div>
                       <div class="matrix-speedup"><span>vs Base H3</span><strong>13.57×</strong></div>
                     </div>
                   </td>
                   <td data-duration="15s · 362 frames">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense · 49× DiT</small></span><strong>99.513 s</strong></div>
-                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours · SOL · 4× DiT</small></span><strong>6.612 s</strong></div>
+                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>99.513 s</strong></div>
+                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours</small></span><strong>6.612 s</strong></div>
                       <div class="matrix-speedup"><span>vs Base H3</span><strong>15.05×</strong></div>
                     </div>
                   </td>
@@ -5028,7 +5028,7 @@
 
         <div class="method-note reveal">
           <strong>Measured scope</strong>
-          <span id="benchmark-method">All runs use 1344×768, 24 FPS, the same prompt and seed 20260903, and reference-free T2V with stereo audio. Base H3 uses dense attention with a 50-point schedule and 49 DiT evaluations; Sol-H3 uses four DiT evaluations, with Dense attention on 1× B300 and SOL on 4× / 8× B300. Each value is the median of three measured runs after one warmup. Timing includes text encoding, DiT, and video/audio VAE decoding; model loading, compilation warmup, and final MP4 encoding are not timed.</span>
+          <span id="benchmark-method">All runs use 1344×768, 24 FPS, the same prompt and seed 20260903, and reference-free T2V with stereo audio. Sol-H3 uses Dense attention on 1× B300 and SOL on 4× / 8× B300. Each value is the median of three measured runs after one warmup. Timing includes text encoding, DiT, and video/audio VAE decoding; model loading, compilation warmup, and final MP4 encoding are not timed.</span>
         </div>
       </div>
     </section>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -4961,9 +4961,9 @@
               Sol-Engine page
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M7 17 17 7M8 7h9v9"/></svg>
             </a>
-            <a class="button" href="#real-time-interactive">
+            <a class="button" href="https://www.reactor.inc/sandbox?model=fast-h3" target="_blank" rel="noopener noreferrer">
               Real-time demo
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M12 5v14M6 13l6 6 6-6"/></svg>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M7 17 17 7M8 7h9v9"/></svg>
             </a>
           </div>
         </div>
@@ -5000,9 +5000,9 @@
             </a>
           </div>
           <div class="collaborator-logos">
-            <a class="collaborator-logo partner-reactor" href="https://www.reactor.inc/" target="_blank" rel="noopener noreferrer" aria-label="Reactor — online demo coming soon">
+            <a class="collaborator-logo partner-reactor" href="https://www.reactor.inc/sandbox?model=fast-h3" target="_blank" rel="noopener noreferrer" aria-label="Reactor — open the Sol-H3 online demo">
               <span class="partner-lockup"><span class="partner-logo-box"><img src="assets/partner-reactor.png" alt=""></span><span class="partner-name">reactor</span></span>
-              <span class="partner-role">Online demo · coming</span>
+              <span class="partner-role">Online demo · live</span>
             </a>
             <a class="collaborator-logo partner-humanize" href="https://github.com/humanfia/humanize2" target="_blank" rel="noopener noreferrer" aria-label="Humanize — operator optimization workflow">
               <span class="partner-lockup"><span class="partner-logo-box"><img src="assets/partner-humanize.svg" alt=""></span><span class="partner-name">Humanize</span></span>
@@ -5543,7 +5543,7 @@
           </div>
           <ul class="acknowledgement-list">
             <li><a class="ack-entity" href="https://huggingface.co/MiniMaxAI/MiniMax-H3" target="_blank" rel="noopener noreferrer">MiniMax</a><span class="ack-role">MiniMax-H3 open weights and code.</span></li>
-            <li><a class="ack-entity" href="https://www.reactor.inc/" target="_blank" rel="noopener noreferrer">Reactor</a><span class="ack-role">Forthcoming online demo and deployment collaboration.</span></li>
+            <li><a class="ack-entity" href="https://www.reactor.inc/sandbox?model=fast-h3" target="_blank" rel="noopener noreferrer">Reactor</a><span class="ack-role">Hosted online demo and deployment collaboration.</span></li>
             <li><span class="ack-entity"><a href="https://github.com/humanfia/humanize2" target="_blank" rel="noopener noreferrer">Humanize</a> + <a href="https://github.com/mit-han-lab/kernel-design-agents" target="_blank" rel="noopener noreferrer">KDA</a></span><span class="ack-role">Operator and fused-kernel optimization on top of Sol-Engine.</span></li>
             <li><a class="ack-entity" href="https://github.com/ModelTC/LightX2V" target="_blank" rel="noopener noreferrer">LightX2V</a><span class="ack-role">Open MiniMax-H3 Turbo LoRAs and the Ref2VA workflow used by Sol-Engine.</span></li>
             <li><a class="ack-entity" href="https://openvdn.github.io/h3-vda-blog.html" target="_blank" rel="noopener noreferrer">Video DeltaNet · UC Berkeley</a><span class="ack-role">Complementary hybrid-attention work for MiniMax-H3.</span></li>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -2,22 +2,26 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <script>document.documentElement.classList.add('js');</script>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#050705">
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f5f8f1">
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
-  <meta name="description" content="Sol-H3 accelerates MiniMax-H3 video generation with native audio, delivering up to 15.05× speedup over Base H3 across 5s, 10s, and 15s outputs on 8× NVIDIA B300 GPUs.">
+  <link rel="preload" as="image" href="sol-h3-poster.jpg?v=v6" fetchpriority="high">
+  <meta name="description" content="Sol-H3 generates a 5s MiniMax-H3 T2VA output in a 1.653s median on 8× NVIDIA B300, reaching up to 15.05× lower latency as a four-forward profile versus 49-forward Base H3.">
   <meta property="og:type" content="article">
   <meta property="og:title" content="Sol-H3: Speed-of-Light MiniMax-H3 on an 8× NVIDIA B300 Blackwell System">
-  <meta property="og:description" content="Five seconds of world in 1.653 seconds. Across 5s–15s outputs, Sol-H3 is 11.04×–15.05× faster than Base H3 on 8× NVIDIA B300 GPUs.">
+  <meta property="og:description" content="A 5s MiniMax-H3 T2VA output in a 1.653s median. The four-forward Sol-H3 profile reaches up to 15.05× lower latency than 49-forward Base H3 on 8× NVIDIA B300.">
   <meta property="og:url" content="https://nvlabs.github.io/Sana/Sol-Engine/Sol-H3/">
   <meta property="og:image" content="https://nvlabs.github.io/Sana/Sol-Engine/Sol-H3/sol-h3-poster.jpg">
-  <meta property="og:image:width" content="1280">
-  <meta property="og:image:height" content="732">
+  <meta property="og:image:width" content="1344">
+  <meta property="og:image:height" content="768">
+  <meta property="og:image:alt" content="Sol-H3: Speed-of-Light MiniMax-H3 on an 8× NVIDIA B300 Blackwell system">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Sol-H3: Speed-of-Light MiniMax-H3 on an 8× NVIDIA B300 Blackwell System">
-  <meta name="twitter:description" content="Five seconds of world in 1.653 seconds. Sol-H3 delivers up to 15.05× speedup over Base H3 on 8× NVIDIA B300 GPUs.">
+  <meta name="twitter:description" content="A 5s MiniMax-H3 T2VA output in a 1.653s median. The four-forward Sol-H3 profile reaches up to 15.05× lower latency than 49-forward Base H3 on 8× NVIDIA B300.">
   <meta name="twitter:image" content="https://nvlabs.github.io/Sana/Sol-Engine/Sol-H3/sol-h3-poster.jpg">
+  <meta name="twitter:image:alt" content="Sol-H3: Speed-of-Light MiniMax-H3 on an 8× NVIDIA B300 Blackwell system">
   <link rel="canonical" href="https://nvlabs.github.io/Sana/Sol-Engine/Sol-H3/">
   <title>Sol-H3: Speed-of-Light MiniMax-H3 on an 8× NVIDIA B300 Blackwell System | NVIDIA Research</title>
   <style>
@@ -1319,9 +1323,9 @@
     .matrix-measure > span:first-child small {
       display: block;
       margin-top: 4px;
-      color: var(--dim);
+      color: var(--muted);
       font-family: "SFMono-Regular", Consolas, monospace;
-      font-size: 10px;
+      font-size: 11px;
       font-weight: 700;
       letter-spacing: .07em;
       text-transform: uppercase;
@@ -1457,8 +1461,26 @@
       .matrix-measure > strong { font-size: 20px; }
 
       .matrix-measure {
-        grid-template-columns: 82px minmax(0, 1fr) 76px;
-        gap: 8px;
+        grid-template-columns: minmax(0, 1fr) max-content;
+        grid-template-rows: auto auto auto;
+        gap: 8px 12px;
+      }
+      .matrix-measure > span:first-child {
+        grid-column: 1;
+        grid-row: 1;
+      }
+      .matrix-measure > strong {
+        grid-column: 2;
+        grid-row: 1;
+      }
+      .matrix-measure::before {
+        grid-column: 1 / -1;
+        grid-row: 2;
+      }
+      .matrix-measure > .matrix-speedup {
+        grid-column: 1 / -1;
+        grid-row: 3;
+        margin-left: min(max(calc(var(--w) - 8px), 0px), calc(100% - 82px));
       }
     }
 
@@ -2353,7 +2375,7 @@
     }
 
     .comparison-case-topline span + span {
-      color: var(--dim);
+      color: var(--muted);
     }
 
     .comparison-case-heading h3 {
@@ -2374,7 +2396,7 @@
 
     .comparison-picker { min-width: min(100%, 390px); }
 
-    .comparison-picker > label {
+    .comparison-picker-label {
       display: block;
       margin-bottom: 8px;
       color: var(--muted);
@@ -2559,6 +2581,18 @@
     }
 
     .comparison-media[data-state="ready"] .comparison-placeholder { display: none; }
+    .comparison-media[data-state="error"] video { visibility: visible; }
+    .comparison-media[data-state="error"] .comparison-placeholder {
+      align-content: end;
+      background: linear-gradient(to top, rgba(2, 4, 2, .92), rgba(2, 4, 2, .22) 60%, transparent);
+    }
+    .comparison-media[data-state="error"] .render-orbit {
+      border-color: rgba(255, 101, 76, .62);
+    }
+    .comparison-media[data-state="error"] .render-orbit::after {
+      background: var(--red);
+      box-shadow: 0 0 13px rgba(255, 101, 76, .7);
+    }
 
     .render-orbit {
       position: relative;
@@ -2856,20 +2890,20 @@
       border-top: 1px solid var(--line);
       justify-content: space-between;
       gap: 30px;
-      color: var(--dim);
+      color: var(--muted);
       font-family: "SFMono-Regular", Consolas, monospace;
       font-size: 8px;
       letter-spacing: .08em;
       text-transform: uppercase;
     }
 
-    .reveal {
+    .js .reveal {
       opacity: 0;
       transform: translateY(28px);
       transition: opacity .8s var(--ease), transform .8s var(--ease);
     }
 
-    .reveal.in-view { opacity: 1; transform: translateY(0); }
+    .js .reveal.in-view { opacity: 1; transform: translateY(0); }
 
     @keyframes status-pulse {
       0%, 100% { opacity: .45; transform: scale(.85); }
@@ -3244,7 +3278,7 @@
 
     .detail-marker {
       align-self: start;
-      color: var(--dim);
+      color: var(--muted);
       font-family: "SFMono-Regular", Consolas, monospace;
       text-transform: uppercase;
     }
@@ -3563,7 +3597,7 @@
       align-items: baseline;
       justify-content: space-between;
       gap: 18px;
-      color: var(--dim);
+      color: var(--muted);
       font-family: "SFMono-Regular", Consolas, monospace;
       font-size: 13px;
       font-weight: 760;
@@ -4169,7 +4203,7 @@
       overflow-wrap: anywhere;
     }
     .footer-bottom a {
-      color: var(--dim);
+      color: var(--muted);
       text-decoration-color: rgba(167, 255, 46, .3);
       text-underline-offset: 3px;
     }
@@ -4882,7 +4916,7 @@
       <div class="nav-links" id="nav-links">
         <a href="#performance">Performance</a>
         <a href="#compare">Showcase</a>
-        <a href="#architecture">Dual core</a>
+        <a href="#architecture">System</a>
         <a href="#stack">Acceleration</a>
         <a href="#future">Future</a>
       </div>
@@ -4891,7 +4925,7 @@
         <svg class="theme-icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.42 1.42M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.42-1.42M17.66 6.34l1.41-1.41"/></svg>
       </button>
       <a class="nav-cta" href="https://github.com/NVlabs/Sana/tree/sol-engine/models/minimax_h3/Sol-H3" target="_blank" rel="noopener noreferrer">
-        <span>Codebase</span>
+        <span>Sol-H3 Code</span>
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M7 17 17 7M8 7h9v9"/></svg>
       </a>
     </nav>
@@ -4916,15 +4950,15 @@
           </div>
           <p class="hero-dek">
             <strong>Sol-H3 generates MiniMax-H3 video with native audio faster than playback on one 8× NVIDIA B300 system.</strong>
-            Sol-Engine × Sol-Attn unifies sparse attention, fused kernels, fast multi-GPU communication, parallel video decoding, and more in one runtime.
+            Sol-Engine × Sol-Attn unifies sparse attention, fused kernels, fast multi-GPU communication, parallel video decoding, and other serving optimizations in one runtime.
           </p>
           <div class="hero-actions">
             <a class="button primary" href="https://github.com/NVlabs/Sana/tree/sol-engine/models/minimax_h3/Sol-H3" target="_blank" rel="noopener noreferrer">
               Sol-H3 code
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M7 17 17 7M8 7h9v9"/></svg>
             </a>
-            <a class="button" href="#future">
-              Demo · coming soon
+            <a class="button" href="#real-time-interactive">
+              Real-time interactive
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M12 5v14M6 13l6 6 6-6"/></svg>
             </a>
           </div>
@@ -4932,7 +4966,7 @@
 
           <div class="hero-visual" aria-label="Full-frame Sol-Engine generation preview">
           <div class="video-terminal">
-            <video id="hero-video" poster="sol-h3-poster.jpg?v=v6" autoplay muted loop controls playsinline preload="metadata" crossorigin="anonymous" aria-label="Sol-Engine generated video preview with playback and seek controls">
+            <video id="hero-video" poster="sol-h3-poster.jpg?v=v6" muted loop controls playsinline preload="metadata" crossorigin="anonymous" aria-label="Sol-Engine generated video preview with playback and seek controls">
               <source src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/main/Sol-Engine/Sol-H3/blog-assets/hero/sol-h3-niu-lai-promo-official-ref2va50-b300-audited-ack-hq.mp4?v=v6" type="video/mp4">
               Your browser does not support this MP4 preview.
             </video>
@@ -4942,13 +4976,13 @@
             </div>
           </div>
           <div class="video-credit">
-            <span class="video-credit-copy">Featured sample · Sol-Engine uses <a href="https://huggingface.co/lightx2v/Minimax-h3-Turbo" target="_blank" rel="noopener noreferrer">LightX2V</a>’s Ref2VA Turbo 8-step LoRA with MiniMax-H3.</span>
+            <span class="video-credit-copy">Featured sample · MiniMax-H3 Base Ref2VA at 50 steps, generated through Sol-Engine on 8× NVIDIA B300.</span>
           </div>
           </div>
         </div>
 
         <aside class="collaborator-rail" aria-label="Sol-H3 team and research engineering collaborators">
-          <div class="collaborator-heading"><strong>Team &amp; collaborators</strong><span>Engine · model · online demo · operator tooling</span></div>
+          <div class="collaborator-heading"><strong>Team &amp; collaborators</strong><span>Engine · online demo · operator tooling · related research</span></div>
           <div class="owner-tier">
             <a class="owner-lockup" href="https://nvlabs.github.io/Sana/Sol-Engine/" target="_blank" rel="noopener noreferrer">
               <span class="owner-brandline">
@@ -4980,12 +5014,12 @@
             </a>
           </div>
           <a class="license-strip" href="https://github.com/NVlabs/Sana/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">
-            <strong>Deployment-friendly · Apache 2.0</strong>
-            <span>A permissive license for research, cloud platforms, and production services.</span>
+            <strong>Sol-H3 code · Apache 2.0</strong>
+            <span>Permissive code license; model weights and third-party components retain their own terms.</span>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M7 17 17 7M8 7h9v9"/></svg>
           </a>
           <p class="collaboration-statement">
-            One engine supports <strong>Text-to-Video, Image-to-Video, and Reference-to-Video</strong>. Built by <strong>NVIDIA Research’s Efficient AI Team and Singapore Lab</strong>. <a href="https://www.reactor.inc/" target="_blank" rel="noopener noreferrer">Reactor</a> is collaborating on the online demo. <a href="https://github.com/humanfia/humanize2" target="_blank" rel="noopener noreferrer">Humanize</a> and <a href="https://github.com/mit-han-lab/kernel-design-agents" target="_blank" rel="noopener noreferrer">KDA</a> helped tune GPU kernels on Sol-Engine. Compatible MiniMax-H3 few-step LoRAs can plug into the same Sol-H3 engine.
+            One engine supports <strong>Text-to-Video, first-frame Image-to-Video, and Reference-to-Video-and-Audio (Ref2VA)</strong>. Compatible MiniMax-H3 few-step LoRAs plug into the same Sol-H3 runtime.
           </p>
         </aside>
       </div>
@@ -4997,7 +5031,7 @@
         <header class="section-head reveal">
           <div class="section-index">01</div>
           <div>
-            <span class="section-kicker">Scaling benchmark · 1 / 4 / 8× NVIDIA B300</span>
+            <span class="section-kicker">Benchmark · 8 / 4 / 1× NVIDIA B300</span>
             <h2 id="performance-title">Latency across GPU counts.</h2>
           </div>
           <p>Choose an output length, then compare Sol-H3 directly with Base H3 across 8, 4, and 1 B300 GPUs.</p>
@@ -5007,7 +5041,7 @@
           <header class="latency-head">
             <div>
               <div class="console-label">Measured generation time · seconds</div>
-              <h3 id="latency-title">GPU scaling by output length.</h3>
+              <h3 id="latency-title">Generation time across GPU counts.</h3>
             </div>
             <div class="benchmark-duration-control">
               <div class="duration-tabs" role="tablist" aria-label="Choose output length">
@@ -5020,7 +5054,7 @@
 
           <div class="matrix-shell" id="latency-panel" role="tabpanel" aria-labelledby="benchmark-duration-5" aria-live="polite">
             <table class="latency-matrix" id="latency-matrix">
-              <caption class="matrix-caption">Measured Base H3 Dense and Sol-H3 latency for 5, 10, and 15 second outputs on one, four, and eight NVIDIA B300 GPUs.</caption>
+              <caption class="matrix-caption">Measured latency for 50-step Base H3 Dense and four-step Sol-H3 at 5, 10, and 15 second output lengths on one, four, and eight NVIDIA B300 GPUs.</caption>
               <thead>
                 <tr>
                   <th scope="col">GPU count</th>
@@ -5100,7 +5134,7 @@
 
         <div class="method-note reveal">
           <strong>Measured scope</strong>
-          <span id="benchmark-method">All runs use 1344×768, 24 FPS, the same prompt and seed 20260903, and reference-free T2V with stereo audio. In this benchmark, Sol-H3 uses Dense attention on 1× B300 and the SOL sparse-attention path on 4× / 8× B300. Each value is the median of three measured runs after one warmup. Timing includes text encoding, DiT, and video/audio VAE decoding; model loading, compilation warmup, and final MP4 encoding are not timed.</span>
+          <span id="benchmark-method">All runs use 1344×768, 24 FPS, the same prompt and seed 20260903, and reference-free T2VA with stereo audio. The complete profiles differ: Base H3 uses 50 scheduler points (49 DiT forwards), while Sol-H3 uses four DiT forwards—not an attention-only runtime change. Sol-H3 uses Dense attention on 1× B300 and SOL with INT8 QKV / FP8 output transport on 4× / 8× B300. Each value is the median of three measured runs after one warmup. Timing includes text encoding, DiT denoising, and video/audio VAE decoding; model loading, compilation warmup, and final MP4 encoding are excluded.</span>
         </div>
       </div>
     </section>
@@ -5161,11 +5195,11 @@
                 <span>Generated with Sol-H3</span>
               </div>
               <h3 id="comparison-showcase-title">Selected examples.</h3>
-              <p>Use the arrows to move through the next two videos. Each prompt is available below its example.</p>
+              <p>Browse two videos at a time with the arrows; each video includes its exact prompt.</p>
             </div>
             <div class="comparison-picker">
-              <label>Browse examples</label>
-              <div class="comparison-picker-row">
+              <span class="comparison-picker-label" id="comparison-picker-label">Browse examples</span>
+              <div class="comparison-picker-row" role="group" aria-labelledby="comparison-picker-label">
                 <button class="comparison-nav-button" id="comparison-prev" type="button" aria-label="Previous two examples">←</button>
                 <div class="comparison-window-status" aria-live="polite">
                   <strong id="comparison-window-label">Preparing examples</strong>
@@ -5191,9 +5225,9 @@
                 <span id="comparison-left-shots">Shots —</span>
                 <span id="comparison-left-seed">Seed —</span>
               </div>
-              <div class="comparison-media" id="comparison-left-media" data-state="pending">
+              <div class="comparison-media" id="comparison-left-media" data-state="loading">
                 <video id="comparison-left-video" controls playsinline preload="none" aria-label="First Sol-H3 showcase video"></video>
-                <div class="comparison-placeholder">
+                <div class="comparison-placeholder" role="status" aria-live="polite">
                   <span class="render-orbit" aria-hidden="true"></span>
                   <strong id="comparison-left-state">Preparing video</strong>
                   <code id="comparison-left-file">—</code>
@@ -5224,9 +5258,9 @@
                 <span id="comparison-right-shots">Shots —</span>
                 <span id="comparison-right-seed">Seed —</span>
               </div>
-              <div class="comparison-media" id="comparison-right-media" data-state="pending">
+              <div class="comparison-media" id="comparison-right-media" data-state="loading">
                 <video id="comparison-right-video" controls playsinline preload="none" aria-label="Second Sol-H3 showcase video"></video>
-                <div class="comparison-placeholder">
+                <div class="comparison-placeholder" role="status" aria-live="polite">
                   <span class="render-orbit" aria-hidden="true"></span>
                   <strong id="comparison-right-state">Preparing video</strong>
                   <code id="comparison-right-file">—</code>
@@ -5252,7 +5286,7 @@
 
         <div class="method-note reveal">
           <strong>Showcase profile</strong>
-          <span>Each ten-second sample is generated by Sol-H3 at 1344×768 with native audio, using <a href="https://haoailab.com/blogs/fasth3-preview/" target="_blank" rel="noopener noreferrer">FastH3 Preview v1</a>’s default four-step Dense/Data-Free adapter.</span>
+          <span>Each ten-second sample is generated by Sol-H3 at 1344×768 with native audio, using Sol-H3’s four-step Dense/Data-Free adapter from <a href="https://haoailab.com/blogs/fasth3-preview/" target="_blank" rel="noopener noreferrer">FastH3 Preview v1</a>.</span>
         </div>
       </div>
     </section>
@@ -5326,8 +5360,8 @@
               <div class="detail-copy">
                 <h3>Select blocks while attention runs.</h3>
                 <div class="detail-explanation">
-                  <div class="detail-part"><span>Mechanism</span><p>Each 64-token query block sets its own threshold: mean + β × standard deviation over lightweight query–key scores. Blocks above it run exact attention; skipped blocks contribute a low-cost approximation using pooled keys and value sums.</p></div>
-                  <div class="detail-part"><span>Why it is faster</span><p>Sol-Attn consumes each score tile inside online softmax: the same tile selects exact blocks and updates the approximation. It writes no separate router output, full score map, or routing-index tensor, and needs no retraining.</p></div>
+                  <div class="detail-part"><span>Mechanism</span><p>Each 64-token query block sets its own threshold: mean + τ × standard deviation over lightweight query–key scores. Selected blocks use exact attention; skipped blocks receive an approximate correction from pooled K/V summaries.</p></div>
+                  <div class="detail-part"><span>Why it is faster</span><p>Routing, sparse attention, and approximate correction share one online-softmax pass. Sol-Attn writes no separate router output, full score map, or routing-index tensor, and needs no retraining.</p></div>
                 </div>
               </div>
               <aside class="detail-evidence"><span>Video generation</span><strong>Up to 2.1×</strong><small>end-to-end versus each model's dense-attention pipeline</small><a class="evidence-link" href="https://nvlabs.github.io/Sana/Sol-Attn/#comparison" target="_blank" rel="noopener noreferrer">Models &amp; settings ↗</a></aside>
@@ -5350,7 +5384,7 @@
                   <div class="detail-part"><span>Why it is faster</span><p>These operations touch wide tensors but do relatively little math, so memory traffic is often the limit. Fewer reads, writes, and launches save traffic across all 50 transformer blocks.</p></div>
                 </div>
               </div>
-              <aside class="detail-evidence"><span>Evidence</span><strong>≈178 GB</strong><small>less intermediate traffic per GPU per evaluation</small></aside>
+              <aside class="detail-evidence"><span>Estimated traffic avoided</span><strong>≈178 GB</strong><small>per GPU per DiT evaluation</small></aside>
             </article>
           </div>
 
@@ -5366,8 +5400,8 @@
               <div class="detail-copy">
                 <h3>Pack, exchange, and merge directly.</h3>
                 <div class="detail-explanation">
-                  <div class="detail-part"><span>Mechanism</span><p>Ulysses changes sequence shards into head shards before attention, then changes them back. Sol-H3 writes normalized and RoPE-applied Q/K, together with V, directly in destination-major order; one packed all-to-all sends them, and the return is decoded directly into merged-head order.</p></div>
-                  <div class="detail-part"><span>Why it is faster</span><p>This removes separate stack, permute, and contiguous copies. The fastest profile uses one scale per 32 INT8 QKV values and E4M3 FP8 output clamped to ±448; BF16 transport remains available.</p></div>
+                  <div class="detail-part"><span>Mechanism</span><p>Ulysses redistributes sequence shards by attention head, then restores the original layout. Sol-H3 packs Q/K/V directly for the destination GPU, performs one all-to-all exchange, and merges returned heads without extra full-tensor layout copies.</p></div>
+                  <div class="detail-part"><span>Why it is faster</span><p>This removes separate stack, permute, and contiguous copies. The fastest profile sends QKV in INT8 and attention output in FP8; BF16 transport remains available when higher numerical fidelity is preferred.</p></div>
                 </div>
               </div>
               <aside class="detail-evidence"><span>Fastest profile</span><strong>51.6%</strong><small>of the BF16 attention communication payload</small></aside>
@@ -5387,7 +5421,7 @@
                 <h3>Build the sparse plan in fewer passes.</h3>
                 <div class="detail-explanation">
                   <div class="detail-part"><span>Mechanism</span><p>One preprocessing kernel computes each key centroid and value sum together. Thresholding also returns the pooled query for reuse; the final compaction step applies threshold, local-band, and exact-prefix rules while emitting the mask and compact block lists.</p></div>
-                  <div class="detail-part"><span>Why it is faster</span><p>The cuDNN block-sparse path receives everything it needs without separately materializing each setup stage. This metadata path is separate from the native one-pass Sol-Attn kernel below; reuse and fusion reduce its temporary traffic and launch overhead.</p></div>
+                  <div class="detail-part"><span>Why it is faster</span><p>The default SOL path feeds its fused K/V summaries, mask, and block list directly into cuDNN block-sparse attention. The optional native Sol-Attn kernel combines routing and sparse attention in one pass. Both reduce temporary traffic and launch overhead.</p></div>
                 </div>
               </div>
               <aside class="detail-evidence"><span>Measured setup</span><strong>0.285 ms</strong><small>from 1.206 ms · 76.4% lower</small></aside>
@@ -5411,11 +5445,11 @@
               <div class="detail-copy">
                 <h3>Decode spatial tiles in parallel.</h3>
                 <div class="detail-explanation">
-                  <div class="detail-part"><span>Mechanism</span><p>A 5s output has seven temporal clips, each split into a 4 × 7 grid of 28 equal spatial tiles. Sol-H3 distributes them over eight GPUs and batches each GPU’s four tiles into one compiled decoder call.</p></div>
-                  <div class="detail-part"><span>Why it is faster</span><p>Tile parallelism reduces work per GPU; batching replaces many small decoder launches. Optional global mode balances all 196 tiles and gathers once, but remains optional because the larger compiled batch shows small measured rounding drift.</p></div>
+                  <div class="detail-part"><span>Mechanism</span><p>A 5s output has seven temporal clips and 196 equal spatial tiles. The default path distributes the full tile set over eight GPUs, batches each GPU’s share into one compiled decoder call, and gathers once.</p></div>
+                  <div class="detail-part"><span>Why it is faster</span><p>Tile sharding cuts the work per GPU, while global batching replaces seven per-clip decode-and-gather rounds with one. A per-clip path remains available when matching the initial output exactly matters.</p></div>
                 </div>
               </div>
-              <aside class="detail-evidence"><span>5s VAE decode</span><strong>0.602 s</strong><small>7.55 → 1.16 s with tiles · then 0.602 s with batching</small></aside>
+              <aside class="detail-evidence"><span>5s per-clip VAE A/B</span><strong>0.602 s</strong><small>7.55 → 1.16 s with tile sharding · then 0.602 s with batching</small></aside>
             </article>
           </div>
 
@@ -5445,7 +5479,7 @@
         </div>
 
         <div class="release-contract reveal" aria-label="Measured Sol-H3 profile">
-          <span>Audited T2V</span>
+          <span>Measured T2VA</span>
           <span>5 / 10 / 15 seconds</span>
           <span>1344×768 · 24 FPS</span>
           <span>INT8 QKV · FP8 attention output</span>
@@ -5474,11 +5508,11 @@
             <span class="future-flow">Generate → decode → stream</span>
           </article>
 
-          <article class="future-card reveal" data-index="02">
+          <article class="future-card reveal" id="real-time-interactive" data-index="02">
             <span class="future-status">Coming next</span>
-            <span class="future-label">Interactive access</span>
-            <h3>Real-time interactive demo</h3>
-            <p>With Reactor, let users update a prompt or reference input and see the next generated segment respond without restarting the session.</p>
+            <span class="future-label">Interactive generation</span>
+            <h3>Real-time interactive</h3>
+            <p>Update a prompt or reference input and see the next generated segment respond without restarting the session.</p>
             <span class="future-flow">New input → next video segment</span>
           </article>
         </div>
@@ -5509,13 +5543,13 @@
             <li><span class="ack-entity"><a href="https://github.com/humanfia/humanize2" target="_blank" rel="noopener noreferrer">Humanize</a> + <a href="https://github.com/mit-han-lab/kernel-design-agents" target="_blank" rel="noopener noreferrer">KDA</a></span><span class="ack-role">Operator and fused-kernel optimization on top of Sol-Engine.</span></li>
             <li><a class="ack-entity" href="https://github.com/ModelTC/LightX2V" target="_blank" rel="noopener noreferrer">LightX2V</a><span class="ack-role">Open MiniMax-H3 Turbo LoRAs and the Ref2VA workflow used by Sol-Engine.</span></li>
             <li><a class="ack-entity" href="https://openvdn.github.io/h3-vda-blog.html" target="_blank" rel="noopener noreferrer">Video DeltaNet · UC Berkeley</a><span class="ack-role">Complementary hybrid-attention work for MiniMax-H3.</span></li>
-            <li><a class="ack-entity" href="https://haoailab.com/blogs/fasth3-preview/" target="_blank" rel="noopener noreferrer">Hao AI Lab @ UCSD</a><span class="ack-role">Default FastH3 four-step model.</span></li>
+            <li><a class="ack-entity" href="https://haoailab.com/blogs/fasth3-preview/" target="_blank" rel="noopener noreferrer">Hao AI Lab @ UCSD</a><span class="ack-role">FastH3 four-step adapter used by default in Sol-H3.</span></li>
           </ul>
         </article>
 
         <article class="publication-panel citation-panel reveal" aria-labelledby="citations-title">
           <div class="citation-copy">
-            <span class="publication-label">Research use</span>
+            <span class="publication-label">How to cite</span>
             <h2 id="citations-title">Citations</h2>
             <p>If Sol-H3 helps your work, please cite this release together with the underlying <a href="https://arxiv.org/abs/2606.23743" target="_blank" rel="noopener noreferrer">Sol-Engine</a> and <a href="https://arxiv.org/abs/2607.24027" target="_blank" rel="noopener noreferrer">Sol-Attn</a> papers.</p>
           </div>
@@ -5569,7 +5603,7 @@
       <div class="footer-grid">
         <div class="footer-brand">
           <a class="brand" href="#top"><span class="brand-mark" aria-hidden="true"></span><span>Sol-H3</span></a>
-          <p>A high-performance inference framework for video diffusion models.</p>
+          <p>A high-performance MiniMax-H3 inference stack.</p>
           <div class="footer-affiliation">NVIDIA Research<br>Efficient AI Team &amp; Singapore Lab</div>
         </div>
         <div class="references">
@@ -5578,8 +5612,8 @@
             <li><span>01</span><div><a href="https://arxiv.org/abs/2606.23743" target="_blank" rel="noopener noreferrer">Sol Video Inference Engine: Agent-Native Full-Stack Acceleration</a> — paper and <a href="https://nvlabs.github.io/Sana/Sol-Engine/" target="_blank" rel="noopener noreferrer">project page</a>.</div></li>
             <li><span>02</span><div><a href="https://arxiv.org/abs/2607.24027" target="_blank" rel="noopener noreferrer">Sol-Attn: Accelerating Video Generation Inference via On-the-Fly Attention Sparsification</a>.</div></li>
             <li><span>03</span><div><a href="https://huggingface.co/MiniMaxAI/MiniMax-H3" target="_blank" rel="noopener noreferrer">MiniMax-H3</a> — official open-weight base model.</div></li>
-            <li><span>04</span><div><a href="https://haoailab.com/blogs/fasth3-preview/" target="_blank" rel="noopener noreferrer">FastH3 Preview v1</a> — the default four-step MiniMax-H3 model used by Sol-H3.</div></li>
-            <li><span>05</span><div><a href="https://openvdn.github.io/h3-vda-blog.html" target="_blank" rel="noopener noreferrer">Video DeltaNet on MiniMax H3</a> — a complementary near-lossless hybrid-attention approach.</div></li>
+            <li><span>04</span><div><a href="https://haoailab.com/blogs/fasth3-preview/" target="_blank" rel="noopener noreferrer">FastH3 Preview v1</a> — the four-step adapter used by default in Sol-H3.</div></li>
+            <li><span>05</span><div><a href="https://openvdn.github.io/h3-vda-blog.html" target="_blank" rel="noopener noreferrer">Video DeltaNet on MiniMax-H3</a> — a complementary near-lossless hybrid-attention approach.</div></li>
             <li><span>06</span><div><a href="https://github.com/ModelTC/LightX2V" target="_blank" rel="noopener noreferrer">LightX2V</a> — open MiniMax-H3 Turbo LoRAs and Ref2VA support used by Sol-Engine.</div></li>
           </ol>
         </div>
@@ -5642,15 +5676,20 @@
       onScroll();
       addEventListener('scroll', onScroll, { passive: true });
 
-      const revealObserver = new IntersectionObserver((entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            entry.target.classList.add('in-view');
-            revealObserver.unobserve(entry.target);
-          }
-        });
-      }, { threshold: .11, rootMargin: '0px 0px -5% 0px' });
-      document.querySelectorAll('.reveal').forEach((el) => revealObserver.observe(el));
+      const revealItems = [...document.querySelectorAll('.reveal')];
+      if ('IntersectionObserver' in window) {
+        const revealObserver = new IntersectionObserver((entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              entry.target.classList.add('in-view');
+              revealObserver.unobserve(entry.target);
+            }
+          });
+        }, { threshold: .11, rootMargin: '0px 0px -5% 0px' });
+        revealItems.forEach((el) => revealObserver.observe(el));
+      } else {
+        revealItems.forEach((el) => el.classList.add('in-view'));
+      }
 
       if (!reduceMotion && matchMedia('(hover: hover) and (pointer: fine)').matches) {
         document.querySelectorAll('.tech-card').forEach((card) => {
@@ -5737,6 +5776,7 @@
         const resolveMediaPath = (path) => comparisonMediaBase ? new URL(path, comparisonMediaBase).href : path;
         const resetVideo = (target) => {
           target.video.pause();
+          target.video.onloadedmetadata = null;
           target.video.onerror = null;
           target.video.removeAttribute('src');
           target.video.removeAttribute('poster');
@@ -5758,16 +5798,24 @@
             target.state.textContent = 'Awaiting video upload';
             return;
           }
-          target.root.dataset.state = 'ready';
-          target.state.textContent = 'Ready to play';
+          target.root.dataset.state = 'loading';
+          target.state.textContent = 'Loading preview';
           target.video.dataset.expected = resolvedVideo;
           target.video.poster = resolvedPoster;
+          target.video.onloadedmetadata = () => {
+            if (target.video.dataset.expected !== resolvedVideo) return;
+            target.root.dataset.state = 'ready';
+            target.state.textContent = 'Ready to play';
+          };
           target.video.onerror = () => {
             if (target.video.dataset.expected !== resolvedVideo) return;
+            target.root.dataset.state = 'error';
+            target.state.textContent = 'Video unavailable';
+            target.file.textContent = 'Poster shown · try again later';
             target.video.title = 'Playback is unavailable in this browser; the full-resolution poster remains visible.';
           };
           target.video.src = resolvedVideo;
-          target.video.preload = 'none';
+          target.video.preload = 'metadata';
           target.video.load();
         };
         const renderSlot = (caseData, target, displayIndex) => {
@@ -5852,8 +5900,14 @@
             showcaseFields.count.textContent = 'Showcase unavailable';
             showcaseFields.label.textContent = 'Check manifest';
             showcaseFields.window.textContent = 'Unable to load examples';
-            slots.left.prompt.textContent = error.message;
-            slots.right.prompt.textContent = error.message;
+            Object.values(slots).forEach((target) => {
+              resetVideo(target);
+              target.root.dataset.state = 'error';
+              target.state.textContent = 'Showcase unavailable';
+              target.file.textContent = 'Please try again later';
+              target.prompt.textContent = error.message;
+              target.video.title = error.message;
+            });
           });
       }
 

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -2894,6 +2894,126 @@
     .release-contract { display: flex; flex-wrap: wrap; margin-top: 16px; border: 1px solid var(--line); border-radius: 12px; overflow: hidden; background: rgba(255, 255, 255, .018); }
     .release-contract span { flex: 1 1 190px; padding: 18px 20px; border-right: 1px solid var(--line); color: var(--fog); font-family: "SFMono-Regular", Consolas, monospace; font-size: 13px; font-weight: 700; text-align: center; }
     .release-contract span:last-child { border-right: 0; }
+    /* Expanded implementation notes: readable rows, separate from overview cards. */
+    .technical-details {
+      border-block: 1px solid var(--line);
+      background:
+        radial-gradient(circle at 82% 16%, rgba(114, 245, 186, .045), transparent 28rem),
+        rgba(255, 255, 255, .008);
+    }
+
+    .detail-list { border-top: 1px solid var(--line); }
+
+    .detail-row {
+      display: grid;
+      grid-template-columns: minmax(130px, .34fr) minmax(0, 1.35fr) minmax(230px, .62fr);
+      gap: clamp(24px, 4vw, 58px);
+      align-items: center;
+      padding: clamp(30px, 4vw, 46px) 0;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .detail-row.featured {
+      border-block-color: rgba(114, 245, 186, .34);
+      background: linear-gradient(90deg, rgba(114, 245, 186, .045), transparent 68%);
+    }
+    .detail-row.featured .detail-copy h3 { color: var(--mint); }
+
+    .detail-marker {
+      align-self: start;
+      color: var(--dim);
+      font-family: "SFMono-Regular", Consolas, monospace;
+      text-transform: uppercase;
+    }
+
+    .detail-marker strong {
+      display: block;
+      color: var(--acid);
+      font-size: 25px;
+      line-height: 1;
+      letter-spacing: -.05em;
+    }
+
+    .detail-row.featured .detail-marker strong { color: var(--mint); }
+
+    .detail-marker span {
+      display: block;
+      margin-top: 11px;
+      font-size: 12px;
+      font-weight: 800;
+      letter-spacing: .1em;
+    }
+
+    .detail-copy h3 {
+      margin: 0;
+      color: var(--white);
+      font-size: clamp(27px, 2.7vw, 39px);
+      line-height: 1.06;
+      letter-spacing: -.04em;
+    }
+
+    .detail-copy p {
+      max-width: 790px;
+      margin: 15px 0 0;
+      color: var(--muted);
+      font-size: 17px;
+      line-height: 1.68;
+    }
+
+    .detail-copy strong { color: var(--fog); }
+
+    .detail-path {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: flex-start;
+      gap: 8px;
+      color: var(--dim);
+      font-family: "SFMono-Regular", Consolas, monospace;
+      font-size: 12px;
+      line-height: 1.35;
+    }
+
+    .detail-path span {
+      padding: 9px 11px;
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      background: var(--surface);
+      color: var(--fog);
+      white-space: nowrap;
+    }
+
+    .detail-path b {
+      flex-basis: 100%;
+      margin-top: 5px;
+      color: var(--acid);
+      font-size: 13px;
+      letter-spacing: .02em;
+    }
+
+    .detail-row.featured .detail-path b { color: var(--mint); }
+
+    @media (max-width: 980px) {
+      .detail-row { grid-template-columns: 110px minmax(0, 1fr); }
+      .detail-path { grid-column: 2; }
+    }
+
+    @media (max-width: 720px) {
+      .detail-row {
+        grid-template-columns: 1fr;
+        gap: 18px;
+        padding: 31px 0;
+      }
+      .detail-marker {
+        display: flex;
+        align-items: baseline;
+        gap: 12px;
+      }
+      .detail-marker strong { font-size: 22px; }
+      .detail-marker span { margin-top: 0; }
+      .detail-copy p { font-size: 16px; }
+      .detail-path { grid-column: auto; }
+    }
 
     .finale { min-height: 650px; }
     .finale-actions { margin-top: 38px; }
@@ -4743,7 +4863,7 @@
             <article class="core-block attention">
               <span>02 · Sol-Attn</span>
               <h3>Select the blocks that matter.</h3>
-              <p>Sol-Attn forms lightweight proxy scores from pooled query and key blocks. A threshold computed for each query block can keep a different number of important key/value blocks. <strong>Selected blocks run exact attention; skipped blocks retain a low-cost approximation from the same score tile.</strong> Because every decision comes from the live Q/K/V tensors, Sol-Attn needs no learned router or retraining.</p>
+              <p>Sol-Attn uses a query-dependent threshold to keep important attention blocks exact and cheaply approximate the rest. It works directly from the model’s Q/K/V tensors, so existing weights need no retraining.</p>
             </article>
           </div>
         </div>
@@ -4758,42 +4878,42 @@
             <span class="section-kicker">Six optimizations · one runtime</span>
             <h2 id="stack-title">How Sol-H3 gets faster.</h2>
           </div>
-          <p>Sol-H3 speeds up attention, GPU kernels, multi-GPU communication, and video decoding. The benchmark uses its fastest configuration.</p>
+          <p>Six optimizations work together in one runtime. These cards give the overview; the main implementation details follow below.</p>
         </header>
 
         <div class="bento">
           <article class="tech-card span-6 reveal" data-index="01">
             <span class="tech-label">GPU kernels</span>
             <h3>Fuse repeated operations</h3>
-            <p>RMSNorm/modulation, partial RoPE, and SwiGLU do little math relative to the wide tensors they repeatedly move, so memory bandwidth—not compute—is the limit. Sol-H3 fuses neighboring work and keeps intermediates in registers instead of writing them to HBM and reading them back. Across 50 blocks, this avoids about 178 GB of intermediate traffic per GPU per evaluation. <a href="https://github.com/humanfia/humanize2" target="_blank" rel="noopener noreferrer">Humanize</a> and <a href="https://github.com/mit-han-lab/kernel-design-agents" target="_blank" rel="noopener noreferrer">KDA</a> supported this tuning.</p>
+            <p>Fuses normalization, RoPE, modulation, and MLP work so intermediate tensors stay on chip instead of repeatedly moving through GPU memory.</p>
             <div class="tech-viz fusion-viz" aria-hidden="true"><div class="fusion-stack"><i></i><i></i><i></i><i></i></div><span class="fusion-arrow"></span><span class="fusion-one"></span></div>
           </article>
 
           <article class="tech-card span-6 reveal" data-index="02">
             <span class="tech-label">Multi-GPU communication</span>
             <h3>Faster 8-GPU data exchange</h3>
-            <p>Ulysses swaps sequence shards for head shards before attention, then reverses the exchange. Sol-H3 writes Q/K/V straight into the all-to-all send layout and decodes the return into merged-head order, removing intermediate copies. Its fastest profile scales every 32 QKV values separately and clamps E4M3 FP8 returns to ±448, nearly halving the payload; BF16 remains available for higher fidelity.</p>
+            <p>Combines Ulysses layout changes with 8-GPU all-to-all communication and supports both BF16 and lower-precision transport profiles.</p>
             <div class="tech-viz ulysses-viz" aria-hidden="true"><i style="--n:0"></i><i style="--n:1"></i><i style="--n:2"></i><i style="--n:3"></i><i style="--n:4"></i><i style="--n:5"></i><i style="--n:6"></i><i style="--n:7"></i></div>
           </article>
 
           <article class="tech-card span-6 reveal" data-index="03">
             <span class="tech-label">Sparse-attention setup</span>
             <h3>Fuse the setup work</h3>
-            <p>For Sol-H3’s cuDNN block-sparse path, setup means building key centroids, value sums, query thresholds, the selection mask, and compact block metadata. One kernel builds each key/value summary pair; the threshold kernel returns the pooled query for reuse; another applies the routing rules and packs the metadata. Together this cuts setup from 1.206 to 0.285 ms (−76.4%).</p>
+            <p>Builds key/value summaries, thresholds, masks, and compact block metadata together instead of launching a chain of small setup kernels.</p>
             <div class="tech-viz route-viz" aria-hidden="true"><span><i style="--w:100%"></i><b>1.206 ms</b></span><span><i style="--w:24%"></i><b>0.285 ms</b></span></div>
           </article>
 
           <article class="tech-card span-6 reveal" data-index="04">
             <span class="tech-label">Sol-Attn</span>
             <h3>Sparsify on the fly</h3>
-            <p>Inside its native kernel, Sol-Attn scans pooled-key chunks within online softmax. The same token-to-block score tile selects important blocks and approximates the rest; only selected blocks enter the exact inner loop. Scores are consumed immediately, so no separate routing pass, full proxy map, or routing-index tensor is written to GPU memory.</p>
+            <p>Uses query-dependent thresholds to compute important blocks exactly and approximate the rest as attention runs—without a learned router or retraining.</p>
             <div class="tech-viz prefix-viz" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i><i></i></div>
           </article>
 
           <article class="tech-card span-6 reveal" data-index="05">
             <span class="tech-label">Video decoding</span>
             <h3>Parallel VAE decoding</h3>
-            <p>At 5s, the VAE splits seven temporal clips into 28 equal spatial tiles each. Tile parallelism spreads them across eight GPUs (7.55 → 1.16 s); per-clip batching combines each GPU’s four tiles into one decoder call (→ 0.602 s). Global mode balances all 196 tiles and runs decode/gather once instead of seven; it remains optional because the larger compiled batch causes a small measured rounding drift.</p>
+            <p>Splits video decoding into spatial tiles, distributes them across eight GPUs, and batches compiled decoder calls for higher throughput.</p>
             <div class="tech-viz tile-viz" aria-hidden="true">
               <i style="--p:1"></i><i style="--p:2"></i><i style="--p:3"></i><i style="--p:4"></i><i style="--p:5"></i><i style="--p:6"></i><i style="--p:7"></i>
               <i style="--p:2"></i><i style="--p:3"></i><i style="--p:4"></i><i style="--p:5"></i><i style="--p:6"></i><i style="--p:7"></i><i style="--p:8"></i>
@@ -4805,7 +4925,7 @@
           <article class="tech-card span-6 reveal" data-index="06">
             <span class="tech-label">Conditioning</span>
             <h3>Precompute AdaLN</h3>
-            <p>Sol-H3 computes adaptive layer-normalization (AdaLN) values before denoising and reuses them from a cache at every step. This frees about 24 GB per GPU and avoids roughly 26 GB of GPU-memory reads per step without changing the output. Direct table lookup also removes about 400 tiny GPU indexing launches from a four-step request.</p>
+            <p>Precomputes and caches adaptive layer-normalization values before denoising, reducing memory use and repeated indexing work at every step.</p>
             <div class="tech-viz adaln-viz" aria-hidden="true">
               <i style="--p:1"></i><i style="--p:5"></i><i style="--p:2"></i><i style="--p:7"></i><i style="--p:4"></i><i style="--p:9"></i>
               <i style="--p:6"></i><i style="--p:2"></i><i style="--p:8"></i><i style="--p:3"></i><i style="--p:10"></i><i style="--p:4"></i>
@@ -4826,10 +4946,80 @@
       </div>
     </section>
 
-    <section class="future-plan" id="future" aria-labelledby="future-title">
+    <section class="section technical-details" id="details" aria-labelledby="details-title">
       <div class="wide-shell">
         <header class="section-head reveal">
           <div class="section-index">05</div>
+          <div>
+            <span class="section-kicker">Six implementation notes</span>
+            <h2 id="details-title">What each optimization does.</h2>
+          </div>
+          <p>Each overview card above expands here into one concise implementation note.</p>
+        </header>
+
+        <div class="detail-list">
+          <article class="detail-row reveal" id="detail-kernels">
+            <div class="detail-marker"><strong>01</strong><span>GPU kernels</span></div>
+            <div class="detail-copy">
+              <h3>Move less data between operations.</h3>
+              <p>RMSNorm/modulation, partial RoPE, and SwiGLU move wide tensors but do relatively little math, so GPU-memory bandwidth is often the limit. Fusing neighboring operations keeps intermediates in registers instead of writing and rereading them, avoiding about <strong>178 GB of traffic per GPU per evaluation</strong> across 50 transformer blocks.</p>
+            </div>
+            <div class="detail-path" aria-hidden="true"><span>Read once</span><i>→</i><span>Fused work</span><i>→</i><span>Write once</span><b>≈178 GB less traffic</b></div>
+          </article>
+
+          <article class="detail-row reveal" id="detail-communication">
+            <div class="detail-marker"><strong>02</strong><span>8-GPU exchange</span></div>
+            <div class="detail-copy">
+              <h3>Pack, exchange, and merge directly.</h3>
+              <p>Ulysses changes sequence shards into head shards before attention, then changes them back. Sol-H3 writes Q/K/V directly into the all-to-all send layout and returns attention output directly into merged-head order. The fastest profile uses one scale per 32 INT8 QKV values and clamps FP8 output to E4M3’s ±448 range; <strong>BF16 transport remains available</strong>.</p>
+            </div>
+            <div class="detail-path" aria-hidden="true"><span>Pack</span><i>→</i><span>All-to-all</span><i>→</i><span>Merge</span><b>8 GPUs · fewer copies</b></div>
+          </article>
+
+          <article class="detail-row reveal" id="detail-setup">
+            <div class="detail-marker"><strong>03</strong><span>Sparse setup</span></div>
+            <div class="detail-copy">
+              <h3>Build the sparse plan in fewer passes.</h3>
+              <p>Before block-sparse attention, Sol-H3 needs key centroids, value sums, query thresholds, a selection mask, and compact block metadata. It builds each key/value summary pair together, reuses the pooled query produced during thresholding, and emits the mask and metadata in one compaction step. Setup falls from <strong>1.206 to 0.285 ms (−76.4%)</strong>.</p>
+            </div>
+            <div class="detail-path" aria-hidden="true"><span>K/V summaries</span><i>→</i><span>Threshold</span><i>→</i><span>Mask + metadata</span><b>1.206 → 0.285 ms</b></div>
+          </article>
+
+          <article class="detail-row featured reveal" id="detail-sol-attn">
+            <div class="detail-marker"><strong>04</strong><span>Sol-Attn</span></div>
+            <div class="detail-copy">
+              <h3>Select blocks while attention runs.</h3>
+              <p>For each 64-token query block, Sol-Attn compares lightweight query–key scores with a threshold derived from that query’s own score distribution. Important blocks run exact attention; skipped blocks keep a low-cost correction built from pooled keys and value sums.</p>
+              <p>The same score tile is consumed immediately inside online softmax, so there is <strong>no separate router, full score map, or learned routing model</strong>. Sol-Attn works with existing weights and needs no retraining.</p>
+            </div>
+            <div class="detail-path" aria-hidden="true"><span>Pooled Q/K</span><i>→</i><span>Per-query threshold</span><i>→</i><span>Exact + approximation</span><b>Training-free · one pass</b></div>
+          </article>
+
+          <article class="detail-row reveal" id="detail-vae">
+            <div class="detail-marker"><strong>05</strong><span>VAE decoding</span></div>
+            <div class="detail-copy">
+              <h3>Decode spatial tiles in parallel.</h3>
+              <p>For a 5s output, seven temporal clips each contain 28 spatial tiles. Sol-H3 spreads them across eight GPUs (<strong>7.55 → 1.16 s</strong>), then batches each GPU’s four tiles into one decoder call (<strong>→ 0.602 s</strong>). An optional global mode balances all 196 tiles and decodes/gathers once; it stays optional because the larger batch shows small measured rounding drift.</p>
+            </div>
+            <div class="detail-path" aria-hidden="true"><span>28 tiles / clip</span><i>→</i><span>8 GPUs</span><i>→</i><span>Batched decode</span><b>7.55 → 1.16 → 0.602 s</b></div>
+          </article>
+
+          <article class="detail-row reveal" id="detail-adaln">
+            <div class="detail-marker"><strong>06</strong><span>AdaLN cache</span></div>
+            <div class="detail-copy">
+              <h3>Compute conditioning once, then reuse it.</h3>
+              <p>Sol-H3 precomputes all adaptive layer-normalization values for the denoising trajectory and reads each block’s values directly from a cache. This frees about <strong>24 GB per GPU</strong> and avoids roughly <strong>26 GB of GPU-memory reads per step</strong>. Direct lookup replaces two index selections across 50 blocks and four denoising steps—about 400 small GPU launches—without changing the output.</p>
+            </div>
+            <div class="detail-path" aria-hidden="true"><span>Precompute</span><i>→</i><span>Cache</span><i>→</i><span>Direct lookup</span><b>≈24 GB freed · ≈400 launches removed</b></div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="future-plan" id="future" aria-labelledby="future-title">
+      <div class="wide-shell">
+        <header class="section-head reveal">
+          <div class="section-index">06</div>
           <div>
             <span class="section-kicker">Future Plan</span>
             <h2 id="future-title">Where Sol-H3 goes next.</h2>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -1312,8 +1312,6 @@
       box-shadow: 0 0 18px rgba(167, 255, 46, .1);
     }
 
-    .matrix-measure.ours { padding-bottom: 24px; }
-
     .matrix-measure + .matrix-measure {
       margin-top: 14px;
       padding-top: 14px;
@@ -1360,49 +1358,30 @@
     .matrix-measure.ours > strong { color: var(--acid); }
 
     .matrix-measure > .matrix-speedup {
-      position: relative;
       z-index: 2;
       grid-column: 2;
-      grid-row: 1;
-      align-self: center;
-      height: 1px;
-      margin-right: 12px;
-      margin-left: max(calc(var(--w) + 14px), 44px);
-      background: var(--red);
-      border-radius: 999px;
-      box-shadow: 0 0 10px rgba(255, 101, 76, .2);
+      grid-row: 2;
+      justify-self: start;
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      margin-top: 7px;
+      margin-left: max(calc(var(--w) - 8px), 0px);
       pointer-events: none;
     }
 
-    .matrix-speedup::before {
-      position: absolute;
-      top: 50%;
-      left: 1px;
-      width: 8px;
-      height: 8px;
-      border-bottom: 2px solid var(--red);
-      border-left: 2px solid var(--red);
-      transform: translate(-35%, -50%) rotate(45deg);
-      content: "";
+    .matrix-speedup svg {
+      width: 25px;
+      height: 16px;
+      flex: 0 0 auto;
+      fill: none;
+      stroke: var(--red);
+      stroke-width: 1.8;
+      stroke-linecap: round;
+      stroke-linejoin: round;
     }
 
-
-    .matrix-speedup::after {
-      position: absolute;
-      top: 50%;
-      right: 0;
-      width: 2px;
-      height: 8px;
-      border-radius: 999px;
-      background: var(--red);
-      transform: translateY(-50%);
-      content: "";
-    }
     .matrix-speedup > strong {
-      position: absolute;
-      top: 10px;
-      left: 50%;
-      transform: translateX(-50%);
       color: var(--red);
       font-family: "SFMono-Regular", Consolas, monospace;
       font-size: clamp(12px, 1.2vw, 16px);
@@ -5067,19 +5046,19 @@
                   <td data-duration="5s · 124 frames" data-benchmark-duration="5">
                     <div class="matrix-cell">
                       <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>18.250 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 9.058%;"><span>Sol-H3<small>Ours</small></span><strong>1.653 s</strong><span class="matrix-speedup" aria-label="11.04 times faster than Base H3"><strong>11.04×<span> faster</span></strong></span></div>
+                      <div class="matrix-measure ours" style="--w: 9.058%;"><span>Sol-H3<small>Ours</small></span><strong>1.653 s</strong><span class="matrix-speedup" aria-label="11.04 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>11.04×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                   <td data-duration="10s · 243 frames" data-benchmark-duration="10" hidden>
                     <div class="matrix-cell">
                       <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>50.660 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 7.367%;"><span>Sol-H3<small>Ours</small></span><strong>3.732 s</strong><span class="matrix-speedup" aria-label="13.57 times faster than Base H3"><strong>13.57×<span> faster</span></strong></span></div>
+                      <div class="matrix-measure ours" style="--w: 7.367%;"><span>Sol-H3<small>Ours</small></span><strong>3.732 s</strong><span class="matrix-speedup" aria-label="13.57 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>13.57×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                   <td data-duration="15s · 362 frames" data-benchmark-duration="15" hidden>
                     <div class="matrix-cell">
                       <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>99.513 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 6.644%;"><span>Sol-H3<small>Ours</small></span><strong>6.612 s</strong><span class="matrix-speedup" aria-label="15.05 times faster than Base H3"><strong>15.05×<span> faster</span></strong></span></div>
+                      <div class="matrix-measure ours" style="--w: 6.644%;"><span>Sol-H3<small>Ours</small></span><strong>6.612 s</strong><span class="matrix-speedup" aria-label="15.05 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>15.05×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                 </tr>
@@ -5088,19 +5067,19 @@
                   <td data-duration="5s · 124 frames" data-benchmark-duration="5">
                     <div class="matrix-cell">
                       <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>35.328 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 8.260%;"><span>Sol-H3<small>Ours</small></span><strong>2.918 s</strong><span class="matrix-speedup" aria-label="12.11 times faster than Base H3"><strong>12.11×<span> faster</span></strong></span></div>
+                      <div class="matrix-measure ours" style="--w: 8.260%;"><span>Sol-H3<small>Ours</small></span><strong>2.918 s</strong><span class="matrix-speedup" aria-label="12.11 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>12.11×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                   <td data-duration="10s · 243 frames" data-benchmark-duration="10" hidden>
                     <div class="matrix-cell">
                       <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>100.440 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 6.962%;"><span>Sol-H3<small>Ours</small></span><strong>6.993 s</strong><span class="matrix-speedup" aria-label="14.36 times faster than Base H3"><strong>14.36×<span> faster</span></strong></span></div>
+                      <div class="matrix-measure ours" style="--w: 6.962%;"><span>Sol-H3<small>Ours</small></span><strong>6.993 s</strong><span class="matrix-speedup" aria-label="14.36 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>14.36×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                   <td data-duration="15s · 362 frames" data-benchmark-duration="15" hidden>
                     <div class="matrix-cell">
                       <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>194.930 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 6.434%;"><span>Sol-H3<small>Ours</small></span><strong>12.542 s</strong><span class="matrix-speedup" aria-label="15.54 times faster than Base H3"><strong>15.54×<span> faster</span></strong></span></div>
+                      <div class="matrix-measure ours" style="--w: 6.434%;"><span>Sol-H3<small>Ours</small></span><strong>12.542 s</strong><span class="matrix-speedup" aria-label="15.54 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>15.54×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                 </tr>
@@ -5109,19 +5088,19 @@
                   <td data-duration="5s · 124 frames" data-benchmark-duration="5">
                     <div class="matrix-cell">
                       <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>129.898 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 10.581%;"><span>Sol-H3<small>Ours</small></span><strong>13.745 s</strong><span class="matrix-speedup" aria-label="9.45 times faster than Base H3"><strong>9.45×<span> faster</span></strong></span></div>
+                      <div class="matrix-measure ours" style="--w: 10.581%;"><span>Sol-H3<small>Ours</small></span><strong>13.745 s</strong><span class="matrix-speedup" aria-label="9.45 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>9.45×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                   <td data-duration="10s · 243 frames" data-benchmark-duration="10" hidden>
                     <div class="matrix-cell">
                       <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>376.942 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 10.032%;"><span>Sol-H3<small>Ours</small></span><strong>37.813 s</strong><span class="matrix-speedup" aria-label="9.97 times faster than Base H3"><strong>9.97×<span> faster</span></strong></span></div>
+                      <div class="matrix-measure ours" style="--w: 10.032%;"><span>Sol-H3<small>Ours</small></span><strong>37.813 s</strong><span class="matrix-speedup" aria-label="9.97 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>9.97×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                   <td data-duration="15s · 362 frames" data-benchmark-duration="15" hidden>
                     <div class="matrix-cell">
                       <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>746.885 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 6.997%;"><span>Sol-H3<small>Ours</small></span><strong>52.260 s</strong><span class="matrix-speedup" aria-label="14.29 times faster than Base H3"><strong>14.29×<span> faster</span></strong></span></div>
+                      <div class="matrix-measure ours" style="--w: 6.997%;"><span>Sol-H3<small>Ours</small></span><strong>52.260 s</strong><span class="matrix-speedup" aria-label="14.29 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>14.29×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                 </tr>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -916,6 +916,8 @@
       border: 1px solid var(--line);
       border-radius: 9px;
       background: var(--surface-2);
+      box-shadow: 0 8px 28px rgba(0, 0, 0, .12);
+      backdrop-filter: blur(14px);
     }
 
     .duration-tab {
@@ -930,10 +932,15 @@
       font-weight: 800;
       letter-spacing: .08em;
       cursor: pointer;
+      transition: color 140ms ease, background 140ms ease, box-shadow 140ms ease;
     }
 
     .duration-tab:hover { color: var(--white); }
-    .duration-tab[aria-selected="true"] { background: var(--acid); color: #071000; }
+    .duration-tab:focus-visible {
+      outline: 2px solid var(--acid);
+      outline-offset: 3px;
+    }
+    .duration-tab[aria-selected="true"] { background: var(--acid); color: #071000; box-shadow: 0 3px 14px rgba(118, 185, 0, .22); }
 
     .benchmark-duration-control {
       display: grid;
@@ -1235,6 +1242,16 @@
       font-size: 11px;
       letter-spacing: .045em;
       text-transform: uppercase;
+    }
+
+    .matrix-duration .matrix-specs {
+      display: block;
+      margin-top: 9px;
+      color: var(--dim);
+      font-size: 10px;
+      font-weight: 650;
+      letter-spacing: .04em;
+      text-transform: none;
     }
 
     .latency-matrix tbody th,
@@ -5010,33 +5027,33 @@
               <thead>
                 <tr>
                   <th scope="col">GPU count</th>
-                  <th scope="col" data-benchmark-duration="5"><span class="matrix-duration"><strong>5s</strong><small>124 frames</small></span></th>
-                  <th scope="col" data-benchmark-duration="10" hidden><span class="matrix-duration"><strong>10s</strong><small>243 frames</small></span></th>
-                  <th scope="col" data-benchmark-duration="15" hidden><span class="matrix-duration"><strong>15s</strong><small>362 frames</small></span></th>
+                  <th scope="col" data-benchmark-duration="5"><span class="matrix-duration"><strong>5s</strong><small>124 frames</small><span class="matrix-specs">1344×768 · 24 FPS · stereo audio</span></span></th>
+                  <th scope="col" data-benchmark-duration="10" hidden><span class="matrix-duration"><strong>10s</strong><small>243 frames</small><span class="matrix-specs">1344×768 · 24 FPS · stereo audio</span></span></th>
+                  <th scope="col" data-benchmark-duration="15" hidden><span class="matrix-duration"><strong>15s</strong><small>362 frames</small><span class="matrix-specs">1344×768 · 24 FPS · stereo audio</span></span></th>
                 </tr>
               </thead>
               <tbody>
                 <tr>
-                  <th scope="row"><span class="matrix-gpu"><strong>1×</strong><small>NVIDIA B300</small></span></th>
+                  <th scope="row"><span class="matrix-gpu"><strong>8×</strong><small>NVIDIA B300</small></span></th>
                   <td data-duration="5s · 124 frames" data-benchmark-duration="5">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>129.898 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 10.581%;"><span>Sol-H3<small>Ours</small></span><strong>13.745 s</strong></div>
-                      <div class="matrix-speedup"><span>vs Base H3</span><strong>9.45×</strong></div>
+                      <div class="matrix-measure base" style="--w: 14.049%;"><span>Base H3<small>Dense</small></span><strong>18.250 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 1.273%;"><span>Sol-H3<small>Ours</small></span><strong>1.653 s</strong></div>
+                      <div class="matrix-speedup"><span>vs Base H3</span><strong>11.04×</strong></div>
                     </div>
                   </td>
                   <td data-duration="10s · 243 frames" data-benchmark-duration="10" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>376.942 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 10.032%;"><span>Sol-H3<small>Ours</small></span><strong>37.813 s</strong></div>
-                      <div class="matrix-speedup"><span>vs Base H3</span><strong>9.97×</strong></div>
+                      <div class="matrix-measure base" style="--w: 13.440%;"><span>Base H3<small>Dense</small></span><strong>50.660 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 0.990%;"><span>Sol-H3<small>Ours</small></span><strong>3.732 s</strong></div>
+                      <div class="matrix-speedup"><span>vs Base H3</span><strong>13.57×</strong></div>
                     </div>
                   </td>
                   <td data-duration="15s · 362 frames" data-benchmark-duration="15" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>746.885 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 6.997%;"><span>Sol-H3<small>Ours</small></span><strong>52.260 s</strong></div>
-                      <div class="matrix-speedup"><span>vs Base H3</span><strong>14.29×</strong></div>
+                      <div class="matrix-measure base" style="--w: 13.324%;"><span>Base H3<small>Dense</small></span><strong>99.513 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 0.885%;"><span>Sol-H3<small>Ours</small></span><strong>6.612 s</strong></div>
+                      <div class="matrix-speedup"><span>vs Base H3</span><strong>15.05×</strong></div>
                     </div>
                   </td>
                 </tr>
@@ -5065,26 +5082,26 @@
                   </td>
                 </tr>
                 <tr>
-                  <th scope="row"><span class="matrix-gpu"><strong>8×</strong><small>NVIDIA B300</small></span></th>
+                  <th scope="row"><span class="matrix-gpu"><strong>1×</strong><small>NVIDIA B300</small></span></th>
                   <td data-duration="5s · 124 frames" data-benchmark-duration="5">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 14.049%;"><span>Base H3<small>Dense</small></span><strong>18.250 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 1.273%;"><span>Sol-H3<small>Ours</small></span><strong>1.653 s</strong></div>
-                      <div class="matrix-speedup"><span>vs Base H3</span><strong>11.04×</strong></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>129.898 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 10.581%;"><span>Sol-H3<small>Ours</small></span><strong>13.745 s</strong></div>
+                      <div class="matrix-speedup"><span>vs Base H3</span><strong>9.45×</strong></div>
                     </div>
                   </td>
                   <td data-duration="10s · 243 frames" data-benchmark-duration="10" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 13.440%;"><span>Base H3<small>Dense</small></span><strong>50.660 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 0.990%;"><span>Sol-H3<small>Ours</small></span><strong>3.732 s</strong></div>
-                      <div class="matrix-speedup"><span>vs Base H3</span><strong>13.57×</strong></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>376.942 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 10.032%;"><span>Sol-H3<small>Ours</small></span><strong>37.813 s</strong></div>
+                      <div class="matrix-speedup"><span>vs Base H3</span><strong>9.97×</strong></div>
                     </div>
                   </td>
                   <td data-duration="15s · 362 frames" data-benchmark-duration="15" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 13.324%;"><span>Base H3<small>Dense</small></span><strong>99.513 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 0.885%;"><span>Sol-H3<small>Ours</small></span><strong>6.612 s</strong></div>
-                      <div class="matrix-speedup"><span>vs Base H3</span><strong>15.05×</strong></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>746.885 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 6.997%;"><span>Sol-H3<small>Ours</small></span><strong>52.260 s</strong></div>
+                      <div class="matrix-speedup"><span>vs Base H3</span><strong>14.29×</strong></div>
                     </div>
                   </td>
                 </tr>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -1115,15 +1115,15 @@
     }
     .method-note a:hover { color: var(--acid); }
 
-    /* Static Base H3 vs. Sol-H3 latency comparison. */
+    /* Two-dimensional Base H3 / Sol-H3 scaling matrix. */
     .latency-head {
       display: flex;
       padding-bottom: 27px;
-      border-bottom: 1px solid var(--line);
       align-items: flex-end;
       justify-content: space-between;
       gap: 24px;
     }
+
     .latency-head h3 {
       margin: 9px 0 0;
       color: var(--white);
@@ -1132,6 +1132,7 @@
       line-height: 1;
       letter-spacing: -.045em;
     }
+
     .latency-direction {
       display: inline-flex;
       align-items: center;
@@ -1144,6 +1145,7 @@
       text-transform: uppercase;
       white-space: nowrap;
     }
+
     .latency-direction::before {
       content: "";
       width: 20px;
@@ -1151,132 +1153,237 @@
       background: var(--acid);
       box-shadow: 0 0 10px rgba(167, 255, 46, .45);
     }
-    .latency-group {
-      display: grid;
-      grid-template-columns: 96px minmax(0, 1fr) 142px;
-      gap: clamp(22px, 3vw, 42px);
-      padding: 33px 0;
-      align-items: center;
+
+    .matrix-shell {
+      overflow: hidden;
+      border: 1px solid var(--line);
+      border-radius: 13px;
+      background: rgba(255, 255, 255, .012);
     }
-    .latency-group + .latency-group { border-top: 1px solid var(--line); }
-    .latency-group:last-child { padding-bottom: 0; }
-    .latency-duration strong,
-    .latency-gain strong {
-      display: block;
-      color: var(--white);
-      font-weight: 870;
-      line-height: .9;
-      letter-spacing: -.055em;
-      font-variant-numeric: tabular-nums;
+
+    .latency-matrix {
+      width: 100%;
+      border-collapse: separate;
+      border-spacing: 0;
+      table-layout: fixed;
+    }
+
+    .matrix-caption {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
       white-space: nowrap;
     }
-    .latency-duration strong { font-size: clamp(38px, 4vw, 54px); }
-    .latency-duration span,
-    .latency-gain span {
+
+    .latency-matrix th,
+    .latency-matrix td {
+      border-right: 1px solid var(--line);
+      text-align: left;
+      vertical-align: top;
+    }
+
+    .latency-matrix tr > *:last-child { border-right: 0; }
+
+    .latency-matrix thead th {
+      padding: 18px 20px;
+      background: rgba(255, 255, 255, .018);
+      color: var(--muted);
+      font-family: "SFMono-Regular", Consolas, monospace;
+      font-size: 12px;
+      font-weight: 750;
+      letter-spacing: .07em;
+      text-transform: uppercase;
+    }
+
+    .latency-matrix thead th:first-child { width: 138px; }
+
+    .matrix-duration strong {
+      display: block;
+      color: var(--white);
+      font-family: var(--sans, inherit);
+      font-size: clamp(24px, 2.5vw, 34px);
+      line-height: 1;
+      letter-spacing: -.04em;
+      text-transform: none;
+    }
+
+    .matrix-duration small {
+      display: block;
+      margin-top: 8px;
+      color: var(--muted);
+      font-size: 11px;
+      letter-spacing: .045em;
+      text-transform: uppercase;
+    }
+
+    .latency-matrix tbody th,
+    .latency-matrix tbody td { border-top: 1px solid var(--line); }
+
+    .latency-matrix tbody th {
+      padding: 24px 20px;
+      background: rgba(255, 255, 255, .012);
+    }
+
+    .matrix-gpu strong {
+      display: block;
+      color: var(--white);
+      font-size: clamp(28px, 3vw, 40px);
+      line-height: .95;
+      letter-spacing: -.045em;
+      white-space: nowrap;
+    }
+
+    .matrix-gpu small {
       display: block;
       margin-top: 9px;
       color: var(--muted);
       font-family: "SFMono-Regular", Consolas, monospace;
-      font-size: 12px;
-      font-weight: 750;
-      letter-spacing: .1em;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: .05em;
       text-transform: uppercase;
+      white-space: nowrap;
     }
-    .latency-row {
+
+    .matrix-cell { padding: 20px; }
+
+    .matrix-measure {
       display: grid;
-      grid-template-columns: 108px minmax(0, 1fr) 88px;
-      gap: 13px;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 12px;
       align-items: center;
     }
-    .latency-row + .latency-row { margin-top: 12px; }
-    .latency-model,
-    .latency-number {
-      color: var(--muted);
+
+    .matrix-measure + .matrix-measure {
+      margin-top: 14px;
+      padding-top: 14px;
+      border-top: 1px solid var(--line);
+    }
+
+    .matrix-measure > span {
+      color: var(--fog);
+      font-size: 14px;
+      font-weight: 760;
+      line-height: 1.2;
+    }
+
+    .matrix-measure > span small {
+      display: block;
+      margin-top: 4px;
+      color: var(--dim);
       font-family: "SFMono-Regular", Consolas, monospace;
-      font-size: 12px;
-      font-weight: 750;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: .07em;
+      text-transform: uppercase;
+    }
+
+    .matrix-measure > strong {
+      color: var(--white);
+      font-size: clamp(19px, 2vw, 26px);
+      line-height: 1;
+      letter-spacing: -.025em;
       font-variant-numeric: tabular-nums;
       white-space: nowrap;
     }
-    .latency-model small {
-      display: block;
+
+    .matrix-measure.pending > span { color: var(--acid); }
+    .matrix-measure.pending > strong {
       color: var(--dim);
+      font-size: 22px;
+      letter-spacing: 0;
+    }
+
+    .matrix-speedup {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      margin-top: 13px;
+      padding-top: 11px;
+      border-top: 1px dashed var(--line);
+      color: var(--dim);
+      font-family: "SFMono-Regular", Consolas, monospace;
       font-size: 10px;
-      font-weight: 650;
-      letter-spacing: .06em;
+      font-weight: 700;
+      letter-spacing: .065em;
       text-transform: uppercase;
     }
-    .latency-number { color: var(--fog); text-align: right; }
-    .latency-row.ours .latency-model,
-    .latency-row.ours .latency-number { color: var(--white); }
-    .latency-track {
-      height: 18px;
-      overflow: hidden;
-      border-radius: 3px;
-      background: rgba(255, 255, 255, .045);
-    }
-    .latency-fill {
-      display: block;
-      width: var(--w);
-      min-width: 1px;
-      height: 100%;
-      border-radius: inherit;
-    }
-    .latency-fill.base { background: var(--dim); }
-    .latency-fill.sol {
-      position: relative;
-      overflow: visible;
-      background: linear-gradient(90deg, var(--green), var(--acid));
-      box-shadow: 0 0 18px rgba(167, 255, 46, .16);
-    }
-    .latency-fill.sol::after {
-      content: "";
-      position: absolute;
-      top: 0;
-      right: 0;
-      width: 3px;
-      height: 100%;
-      transform: translateX(50%);
-      background: rgba(255, 255, 255, .9);
-      box-shadow: 0 0 10px 2px rgba(255, 255, 255, .45);
-    }
-    .latency-settings {
-      display: block;
-      margin-top: 13px;
-      color: var(--muted);
-      font-family: "SFMono-Regular", Consolas, monospace;
-      font-size: 12px;
-      line-height: 1.5;
-      letter-spacing: .025em;
-    }
-    .latency-gain {
-      padding-left: clamp(20px, 2.5vw, 34px);
-      border-left: 1px solid var(--line);
-      text-align: right;
-    }
-    .latency-gain strong { color: var(--acid); font-size: clamp(30px, 3vw, 42px); }
 
-    @media (max-width: 720px) {
-      .latency-head { align-items: flex-start; flex-direction: column; }
-      .latency-group {
-        grid-template-columns: 1fr auto;
-        gap: 20px 16px;
-        padding: 27px 0;
+    .matrix-speedup strong { color: var(--dim); }
+
+    @media (max-width: 900px) {
+      .latency-head {
+        align-items: flex-start;
+        flex-direction: column;
       }
-      .latency-duration { display: flex; align-items: baseline; gap: 9px; }
-      .latency-duration strong { font-size: 40px; }
-      .latency-duration span { margin-top: 0; }
-      .latency-comparison { grid-column: 1 / -1; grid-row: 2; }
-      .latency-gain { grid-column: 2; grid-row: 1; padding-left: 0; border-left: 0; }
-      .latency-gain strong { font-size: 31px; }
-      .latency-gain span { margin-top: 6px; }
-      .latency-row { grid-template-columns: 92px minmax(0, 1fr) 78px; gap: 9px; }
+
+      .latency-matrix,
+      .latency-matrix tbody,
+      .latency-matrix tr {
+        display: block;
+        width: 100%;
+      }
+
+      .latency-matrix thead { display: none; }
+
+      .latency-matrix tbody tr + tr { border-top: 1px solid var(--line-bright); }
+
+      .latency-matrix tbody th {
+        display: block;
+        width: auto;
+        padding: 21px 22px;
+        border-right: 0;
+        border-top: 0;
+        border-bottom: 1px solid var(--line);
+      }
+
+      .matrix-gpu {
+        display: flex;
+        align-items: baseline;
+        gap: 9px;
+      }
+
+      .matrix-gpu small { margin-top: 0; }
+
+      .latency-matrix tbody td {
+        display: grid;
+        grid-template-columns: 128px minmax(0, 1fr);
+        border-top: 0;
+        border-right: 0;
+      }
+
+      .latency-matrix tbody td + td { border-top: 1px solid var(--line); }
+
+      .latency-matrix tbody td::before {
+        content: attr(data-duration);
+        padding: 21px 18px;
+        border-right: 1px solid var(--line);
+        color: var(--fog);
+        font-family: "SFMono-Regular", Consolas, monospace;
+        font-size: 12px;
+        font-weight: 800;
+        line-height: 1.5;
+        letter-spacing: .05em;
+        text-transform: uppercase;
+        white-space: pre-line;
+      }
+
+      .matrix-cell { padding: 18px 20px; }
     }
 
-    @media (max-width: 420px) {
-      .latency-row { grid-template-columns: 82px minmax(0, 1fr) 72px; gap: 7px; }
-      .latency-model, .latency-number, .latency-settings { font-size: 11px; }
-      .latency-model small { font-size: 9px; }
+    @media (max-width: 520px) {
+      .latency-matrix tbody td { grid-template-columns: 1fr; }
+
+      .latency-matrix tbody td::before {
+        padding: 15px 18px 0;
+        border-right: 0;
+      }
+
+      .matrix-cell { padding: 14px 18px 19px; }
+      .matrix-measure > strong { font-size: 20px; }
     }
 
 
@@ -4391,8 +4498,9 @@
       .terminal-code,
       .sound-toggle { color: #fff; }
 
-      .latency-track { background: rgba(23, 37, 17, .075); }
-      .latency-fill.base { background: rgba(23, 37, 17, .36); }
+      .matrix-shell { background: rgba(255, 255, 255, .72); }
+      .latency-matrix thead th,
+      .latency-matrix tbody th { background: rgba(65, 111, 0, .035); }
       .fusion-stack i,
       .attn-bar i,
       .lane-track { background: rgba(23, 37, 17, .075); }
@@ -4686,81 +4794,113 @@
         <header class="section-head reveal">
           <div class="section-index">01</div>
           <div>
-            <span class="section-kicker">Measured · 8× NVIDIA B300</span>
-            <h2 id="performance-title">Base H3 vs. Sol-H3.</h2>
+            <span class="section-kicker">Scaling benchmark · 1 / 4 / 8× NVIDIA B300</span>
+            <h2 id="performance-title">Latency across GPU counts.</h2>
           </div>
-          <p>Across 5s, 10s, and 15s outputs, Sol-H3 delivers 18.38×–19.89× speedup over the Base H3 dense baseline on the same system.</p>
+          <p>Base H3 dense measurements establish the scaling baseline. Matching Sol-H3 latencies and speedups will fill the reserved slots.</p>
         </header>
 
         <article class="benchmark-console benchmark-console-wide reveal" aria-labelledby="latency-title" aria-describedby="benchmark-method">
           <header class="latency-head">
             <div>
               <div class="console-label">Measured request latency · lower is better</div>
-              <h3 id="latency-title">Latency by output length.</h3>
+              <h3 id="latency-title">Video length × GPU count.</h3>
             </div>
-            <span class="latency-direction">Shared scale · 0–131.647 s</span>
+            <span class="latency-direction">Base H3 measured · Sol-H3 pending</span>
           </header>
 
-          <div class="latency-groups">
-            <section class="latency-group" aria-labelledby="latency-5s">
-              <div class="latency-duration"><strong id="latency-5s">5s</strong><span>output</span></div>
-              <div class="latency-comparison">
-                <div class="latency-row">
-                  <span class="latency-model">Base H3<small>Dense</small></span>
-                  <span class="latency-track" aria-hidden="true"><i class="latency-fill base" style="--w: 23.299%"></i></span>
-                  <strong class="latency-number">30.673 s</strong>
-                </div>
-                <div class="latency-row ours">
-                  <span class="latency-model">Sol-H3<small>Ours</small></span>
-                  <span class="latency-track" aria-hidden="true"><i class="latency-fill sol" style="--w: 1.268%"></i></span>
-                  <strong class="latency-number">1.669 s</strong>
-                </div>
-                <small class="latency-settings">124 frames · 1344×768 · 24 FPS · native audio · 8× NVIDIA B300</small>
-              </div>
-              <div class="latency-gain"><strong>18.38×</strong><span>speedup</span></div>
-            </section>
-
-            <section class="latency-group" aria-labelledby="latency-10s">
-              <div class="latency-duration"><strong id="latency-10s">10s</strong><span>output</span></div>
-              <div class="latency-comparison">
-                <div class="latency-row">
-                  <span class="latency-model">Base H3<small>Dense</small></span>
-                  <span class="latency-track" aria-hidden="true"><i class="latency-fill base" style="--w: 54.172%"></i></span>
-                  <strong class="latency-number">71.316 s</strong>
-                </div>
-                <div class="latency-row ours">
-                  <span class="latency-model">Sol-H3<small>Ours</small></span>
-                  <span class="latency-track" aria-hidden="true"><i class="latency-fill sol" style="--w: 2.839%"></i></span>
-                  <strong class="latency-number">3.738 s</strong>
-                </div>
-                <small class="latency-settings">243 frames · 1344×768 · 24 FPS · native audio · 8× NVIDIA B300</small>
-              </div>
-              <div class="latency-gain"><strong>19.08×</strong><span>speedup</span></div>
-            </section>
-
-            <section class="latency-group" aria-labelledby="latency-15s">
-              <div class="latency-duration"><strong id="latency-15s">15s</strong><span>output</span></div>
-              <div class="latency-comparison">
-                <div class="latency-row">
-                  <span class="latency-model">Base H3<small>Dense</small></span>
-                  <span class="latency-track" aria-hidden="true"><i class="latency-fill base" style="--w: 100%"></i></span>
-                  <strong class="latency-number">131.647 s</strong>
-                </div>
-                <div class="latency-row ours">
-                  <span class="latency-model">Sol-H3<small>Ours</small></span>
-                  <span class="latency-track" aria-hidden="true"><i class="latency-fill sol" style="--w: 5.028%"></i></span>
-                  <strong class="latency-number">6.619 s</strong>
-                </div>
-                <small class="latency-settings">362 frames · 1344×768 · 24 FPS · native audio · 8× NVIDIA B300</small>
-              </div>
-              <div class="latency-gain"><strong>19.89×</strong><span>speedup</span></div>
-            </section>
+          <div class="matrix-shell">
+            <table class="latency-matrix">
+              <caption class="matrix-caption">Base H3 and pending Sol-H3 latency for 5, 10, and 15 second outputs on one, four, and eight NVIDIA B300 GPUs.</caption>
+              <thead>
+                <tr>
+                  <th scope="col">GPU count</th>
+                  <th scope="col"><span class="matrix-duration"><strong>5s</strong><small>124 frames</small></span></th>
+                  <th scope="col"><span class="matrix-duration"><strong>10s</strong><small>243 frames</small></span></th>
+                  <th scope="col"><span class="matrix-duration"><strong>15s</strong><small>362 frames</small></span></th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th scope="row"><span class="matrix-gpu"><strong>1×</strong><small>NVIDIA B300</small></span></th>
+                  <td data-duration="5s · 124 frames">
+                    <div class="matrix-cell">
+                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>159.547 s</strong></div>
+                      <div class="matrix-measure pending"><span>Sol-H3<small>Ours</small></span><strong aria-label="Pending">—</strong></div>
+                      <div class="matrix-speedup"><span>Speedup</span><strong aria-label="Pending">—</strong></div>
+                    </div>
+                  </td>
+                  <td data-duration="10s · 243 frames">
+                    <div class="matrix-cell">
+                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>442.533 s</strong></div>
+                      <div class="matrix-measure pending"><span>Sol-H3<small>Ours</small></span><strong aria-label="Pending">—</strong></div>
+                      <div class="matrix-speedup"><span>Speedup</span><strong aria-label="Pending">—</strong></div>
+                    </div>
+                  </td>
+                  <td data-duration="15s · 362 frames">
+                    <div class="matrix-cell">
+                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>847.486 s</strong></div>
+                      <div class="matrix-measure pending"><span>Sol-H3<small>Ours</small></span><strong aria-label="Pending">—</strong></div>
+                      <div class="matrix-speedup"><span>Speedup</span><strong aria-label="Pending">—</strong></div>
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row"><span class="matrix-gpu"><strong>4×</strong><small>NVIDIA B300</small></span></th>
+                  <td data-duration="5s · 124 frames">
+                    <div class="matrix-cell">
+                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>48.552 s</strong></div>
+                      <div class="matrix-measure pending"><span>Sol-H3<small>Ours</small></span><strong aria-label="Pending">—</strong></div>
+                      <div class="matrix-speedup"><span>Speedup</span><strong aria-label="Pending">—</strong></div>
+                    </div>
+                  </td>
+                  <td data-duration="10s · 243 frames">
+                    <div class="matrix-cell">
+                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>127.461 s</strong></div>
+                      <div class="matrix-measure pending"><span>Sol-H3<small>Ours</small></span><strong aria-label="Pending">—</strong></div>
+                      <div class="matrix-speedup"><span>Speedup</span><strong aria-label="Pending">—</strong></div>
+                    </div>
+                  </td>
+                  <td data-duration="15s · 362 frames">
+                    <div class="matrix-cell">
+                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>237.171 s</strong></div>
+                      <div class="matrix-measure pending"><span>Sol-H3<small>Ours</small></span><strong aria-label="Pending">—</strong></div>
+                      <div class="matrix-speedup"><span>Speedup</span><strong aria-label="Pending">—</strong></div>
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row"><span class="matrix-gpu"><strong>8×</strong><small>NVIDIA B300</small></span></th>
+                  <td data-duration="5s · 124 frames">
+                    <div class="matrix-cell">
+                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>30.673 s</strong></div>
+                      <div class="matrix-measure pending"><span>Sol-H3<small>Ours</small></span><strong aria-label="Pending">—</strong></div>
+                      <div class="matrix-speedup"><span>Speedup</span><strong aria-label="Pending">—</strong></div>
+                    </div>
+                  </td>
+                  <td data-duration="10s · 243 frames">
+                    <div class="matrix-cell">
+                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>71.316 s</strong></div>
+                      <div class="matrix-measure pending"><span>Sol-H3<small>Ours</small></span><strong aria-label="Pending">—</strong></div>
+                      <div class="matrix-speedup"><span>Speedup</span><strong aria-label="Pending">—</strong></div>
+                    </div>
+                  </td>
+                  <td data-duration="15s · 362 frames">
+                    <div class="matrix-cell">
+                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>131.647 s</strong></div>
+                      <div class="matrix-measure pending"><span>Sol-H3<small>Ours</small></span><strong aria-label="Pending">—</strong></div>
+                      <div class="matrix-speedup"><span>Speedup</span><strong aria-label="Pending">—</strong></div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </article>
 
         <div class="method-note reveal">
           <strong>Measured scope</strong>
-          <span id="benchmark-method">Base H3 and Sol-H3 use the same 8× NVIDIA B300 system and 1344×768, 24 FPS output settings, with one warmup and the median of three measured requests. Timing includes prompt encoding, diffusion denoising, VAE video decoding, and native audio; final MP4 encoding is excluded. Speedup = Base H3 latency ÷ Sol-H3 latency.</span>
+          <span id="benchmark-method">Base H3 uses dense attention at 1344×768 and 24 FPS with native audio: 124 / 243 / 362 frames for 5s / 10s / 15s outputs. Timing includes prompt encoding, diffusion denoising, VAE video decoding, and native audio; final MP4 encoding is excluded. Sol-H3 cells remain placeholders until matching 1× / 4× / 8× B300 runs are complete.</span>
         </div>
       </div>
     </section>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#050705">
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f5f8f1">
+  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <meta name="description" content="Sol-H3 accelerates MiniMax-H3 video generation with native audio, delivering up to 19.89× speedup over Base H3 across 5s, 10s, and 15s outputs on 8× NVIDIA B300 GPUs.">
   <meta property="og:type" content="article">
   <meta property="og:title" content="Sol-H3: Speed-of-Light MiniMax-H3 on an 8× NVIDIA B300 Blackwell System">
@@ -4517,10 +4518,10 @@
         <article class="benchmark-console benchmark-console-wide reveal" aria-labelledby="latency-title" aria-describedby="benchmark-method">
           <header class="latency-head">
             <div>
-              <div class="console-label">Measured request latency</div>
+              <div class="console-label">Measured request latency · lower is better</div>
               <h3 id="latency-title">Latency by output length.</h3>
             </div>
-            <span class="latency-direction">Lower is better</span>
+            <span class="latency-direction">Each model · 15s = full bar</span>
           </header>
 
           <div class="latency-groups">
@@ -4529,12 +4530,12 @@
               <div class="latency-comparison">
                 <div class="latency-row">
                   <span class="latency-model">Base H3<small>Dense</small></span>
-                  <span class="latency-track" aria-hidden="true"><i class="latency-fill base" style="--w: 100%"></i></span>
+                  <span class="latency-track" aria-hidden="true"><i class="latency-fill base" style="--w: 23.299%"></i></span>
                   <strong class="latency-number">30.673 s</strong>
                 </div>
                 <div class="latency-row ours">
                   <span class="latency-model">Sol-H3<small>Ours</small></span>
-                  <span class="latency-track" aria-hidden="true"><i class="latency-fill sol" style="--w: 5.441%"></i></span>
+                  <span class="latency-track" aria-hidden="true"><i class="latency-fill sol" style="--w: 25.215%"></i></span>
                   <strong class="latency-number">1.669 s</strong>
                 </div>
                 <small class="latency-settings">124 frames · 1344×768 · 24 FPS · native audio · 8× NVIDIA B300</small>
@@ -4547,12 +4548,12 @@
               <div class="latency-comparison">
                 <div class="latency-row">
                   <span class="latency-model">Base H3<small>Dense</small></span>
-                  <span class="latency-track" aria-hidden="true"><i class="latency-fill base" style="--w: 100%"></i></span>
+                  <span class="latency-track" aria-hidden="true"><i class="latency-fill base" style="--w: 54.172%"></i></span>
                   <strong class="latency-number">71.316 s</strong>
                 </div>
                 <div class="latency-row ours">
                   <span class="latency-model">Sol-H3<small>Ours</small></span>
-                  <span class="latency-track" aria-hidden="true"><i class="latency-fill sol" style="--w: 5.241%"></i></span>
+                  <span class="latency-track" aria-hidden="true"><i class="latency-fill sol" style="--w: 56.474%"></i></span>
                   <strong class="latency-number">3.738 s</strong>
                 </div>
                 <small class="latency-settings">243 frames · 1344×768 · 24 FPS · native audio · 8× NVIDIA B300</small>
@@ -4570,7 +4571,7 @@
                 </div>
                 <div class="latency-row ours">
                   <span class="latency-model">Sol-H3<small>Ours</small></span>
-                  <span class="latency-track" aria-hidden="true"><i class="latency-fill sol" style="--w: 5.028%"></i></span>
+                  <span class="latency-track" aria-hidden="true"><i class="latency-fill sol" style="--w: 100%"></i></span>
                   <strong class="latency-number">6.619 s</strong>
                 </div>
                 <small class="latency-settings">362 frames · 1344×768 · 24 FPS · native audio · 8× NVIDIA B300</small>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -5205,7 +5205,7 @@
                   <div class="detail-part"><span>Why it is faster</span><p>Sol-Attn consumes each score tile inside online softmax: the same tile selects exact blocks and updates the approximation. It writes no separate router output, full score map, or routing-index tensor, and needs no retraining.</p></div>
                 </div>
               </div>
-              <aside class="detail-evidence"><span>Key property</span><strong>One pass</strong><small>query-dependent · training-free sparsification</small></aside>
+              <aside class="detail-evidence"><span>Video generation</span><strong>Up to 2.1×</strong><small>end-to-end in the Sol-Attn evaluation · versus dense attention</small></aside>
             </article>
           </div>
 

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -1118,7 +1118,7 @@
     /* Two-dimensional Base H3 / Sol-H3 scaling matrix. */
     .latency-head {
       display: flex;
-      padding-bottom: 20px;
+      padding-bottom: 27px;
       align-items: flex-end;
       justify-content: space-between;
       gap: 24px;
@@ -1188,7 +1188,7 @@
     .latency-matrix tr > *:last-child { border-right: 0; }
 
     .latency-matrix thead th {
-      padding: 14px 17px;
+      padding: 18px 20px;
       background: rgba(255, 255, 255, .018);
       color: var(--muted);
       font-family: "SFMono-Regular", Consolas, monospace;
@@ -1223,7 +1223,7 @@
     .latency-matrix tbody td { border-top: 1px solid var(--line); }
 
     .latency-matrix tbody th {
-      padding: 17px 16px;
+      padding: 24px 20px;
       background: rgba(255, 255, 255, .012);
     }
 
@@ -1238,7 +1238,7 @@
 
     .matrix-gpu small {
       display: block;
-      margin-top: 6px;
+      margin-top: 9px;
       color: var(--muted);
       font-family: "SFMono-Regular", Consolas, monospace;
       font-size: 11px;
@@ -1248,7 +1248,7 @@
       white-space: nowrap;
     }
 
-    .matrix-cell { padding: 15px 17px; }
+    .matrix-cell { padding: 20px; }
 
     .matrix-measure {
       display: grid;
@@ -1258,8 +1258,8 @@
     }
 
     .matrix-measure + .matrix-measure {
-      margin-top: 10px;
-      padding-top: 10px;
+      margin-top: 14px;
+      padding-top: 14px;
       border-top: 1px solid var(--line);
     }
 
@@ -1271,8 +1271,8 @@
     }
 
     .matrix-measure > span small {
-      display: inline-block;
-      margin: 0 0 0 7px;
+      display: block;
+      margin-top: 4px;
       color: var(--dim);
       font-family: "SFMono-Regular", Consolas, monospace;
       font-size: 10px;
@@ -1301,8 +1301,8 @@
       display: flex;
       justify-content: space-between;
       gap: 12px;
-      margin-top: 9px;
-      padding-top: 7px;
+      margin-top: 13px;
+      padding-top: 11px;
       border-top: 1px dashed var(--line);
       color: var(--dim);
       font-family: "SFMono-Regular", Consolas, monospace;
@@ -1334,7 +1334,7 @@
       .latency-matrix tbody th {
         display: block;
         width: auto;
-        padding: 16px 19px;
+        padding: 21px 22px;
         border-right: 0;
         border-top: 0;
         border-bottom: 1px solid var(--line);
@@ -1359,7 +1359,7 @@
 
       .latency-matrix tbody td::before {
         content: attr(data-duration);
-        padding: 16px 17px;
+        padding: 21px 18px;
         border-right: 1px solid var(--line);
         color: var(--fog);
         font-family: "SFMono-Regular", Consolas, monospace;
@@ -1371,18 +1371,18 @@
         white-space: pre-line;
       }
 
-      .matrix-cell { padding: 14px 18px; }
+      .matrix-cell { padding: 18px 20px; }
     }
 
     @media (max-width: 520px) {
       .latency-matrix tbody td { grid-template-columns: 1fr; }
 
       .latency-matrix tbody td::before {
-        padding: 12px 18px 0;
+        padding: 15px 18px 0;
         border-right: 0;
       }
 
-      .matrix-cell { padding: 12px 18px 16px; }
+      .matrix-cell { padding: 14px 18px 19px; }
       .matrix-measure > strong { font-size: 20px; }
     }
 
@@ -2959,7 +2959,7 @@
     .section-index, .section-kicker { font-size: 12px; }
     .section-head > p { font-size: 18px; line-height: 1.62; }
 
-    .benchmark-console-wide { min-height: 0; padding: clamp(26px, 3.4vw, 42px); }
+    .benchmark-console-wide { min-height: 0; padding: clamp(30px, 4.5vw, 58px); }
     .console-label { font-size: 12px; }
     .console-subtitle { margin: 10px 0 0; }
     .duration-tab { min-width: 70px; min-height: 40px; font-size: 13px; }
@@ -2991,7 +2991,7 @@
 
     .tech-card.span-6 { grid-column: span 6; }
     .tech-card.span-12 { grid-column: span 12; }
-    .tech-card { min-height: 290px; }
+    .tech-card { min-height: 245px; padding: clamp(22px, 2.5vw, 30px); }
     .tech-label { font-size: 12px; }
     .tech-card h3 { max-width: 620px; font-size: clamp(29px, 2.8vw, 40px); }
     .tech-viz { opacity: .48; }
@@ -3003,8 +3003,8 @@
       max-width: 68%;
       flex-direction: column;
       align-items: flex-start;
-      gap: 9px;
-      margin-top: 25px;
+      gap: 6px;
+      margin-top: 18px;
       color: var(--fog);
       text-decoration: none;
     }
@@ -3215,7 +3215,7 @@
       .gpu-node { width: 52px; height: 28px; font-size: 9px; }
       .attn-satellite { font-size: 10px; }
       .tech-card.span-6, .tech-card.span-12 { grid-column: auto; }
-      .tech-card { min-height: 370px; }
+      .tech-card { min-height: 300px; }
       .tech-label { font-size: 11px; }
       .tech-card h3 { font-size: clamp(28px, 9vw, 38px); }
       .tech-card > p { max-width: 100%; font-size: 17px; }

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -1312,6 +1312,8 @@
       box-shadow: 0 0 18px rgba(167, 255, 46, .1);
     }
 
+    .matrix-measure.ours { padding-bottom: 24px; }
+
     .matrix-measure + .matrix-measure {
       margin-top: 14px;
       padding-top: 14px;
@@ -1363,29 +1365,42 @@
       grid-column: 2;
       grid-row: 1;
       align-self: center;
-      height: 2px;
+      height: 1px;
       margin-right: 12px;
       margin-left: max(calc(var(--w) + 14px), 44px);
       background: var(--red);
+      border-radius: 999px;
+      box-shadow: 0 0 10px rgba(255, 101, 76, .2);
       pointer-events: none;
     }
 
     .matrix-speedup::before {
       position: absolute;
       top: 50%;
-      left: 0;
-      width: 0;
-      height: 0;
-      border-top: 6px solid transparent;
-      border-right: 11px solid var(--red);
-      border-bottom: 6px solid transparent;
-      transform: translate(-100%, -50%);
+      left: 1px;
+      width: 8px;
+      height: 8px;
+      border-bottom: 2px solid var(--red);
+      border-left: 2px solid var(--red);
+      transform: translate(-35%, -50%) rotate(45deg);
       content: "";
     }
 
+
+    .matrix-speedup::after {
+      position: absolute;
+      top: 50%;
+      right: 0;
+      width: 2px;
+      height: 8px;
+      border-radius: 999px;
+      background: var(--red);
+      transform: translateY(-50%);
+      content: "";
+    }
     .matrix-speedup > strong {
       position: absolute;
-      bottom: 8px;
+      top: 10px;
       left: 50%;
       transform: translateX(-50%);
       color: var(--red);

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -1822,6 +1822,31 @@
       letter-spacing: -.045em;
     }
 
+    .tech-card h3 a {
+      color: inherit;
+      text-decoration: none;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 5px;
+      transition: color .2s ease, text-decoration-color .2s ease;
+    }
+
+    .tech-card h3 a::after {
+      content: "↗";
+      display: inline-block;
+      margin-left: .3em;
+      color: var(--mint);
+      font-family: "SFMono-Regular", Consolas, monospace;
+      font-size: .48em;
+      font-weight: 800;
+      vertical-align: top;
+      transform: translateY(.18em);
+    }
+
+    .tech-card h3 a:hover {
+      color: var(--mint);
+      text-decoration: underline;
+    }
+
     .tech-card > p {
       position: relative;
       z-index: 2;
@@ -5167,7 +5192,7 @@
           <div class="acceleration-pair featured">
             <article class="tech-card reveal" data-index="01">
               <span class="tech-label">Sol-Attn</span>
-              <h3>Sparsify on the fly</h3>
+              <h3><a href="https://nvlabs.github.io/Sana/Sol-Attn/" target="_blank" rel="noopener noreferrer" aria-label="Sparsify on the fly — open the Sol-Attn project page">Sparsify on the fly</a></h3>
               <div class="tech-summary"><strong>Query-dependent · one-pass · training-free</strong></div>
               <div class="tech-viz prefix-viz" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i><i></i></div>
             </article>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -1290,6 +1290,12 @@
       white-space: nowrap;
     }
 
+    .matrix-measure.base > strong {
+      color: var(--fog);
+      font-size: clamp(16px, 1.45vw, 20px);
+      font-weight: 650;
+    }
+
     .matrix-measure.ours > span,
     .matrix-measure.ours > strong { color: var(--acid); }
 
@@ -1308,7 +1314,13 @@
       text-transform: uppercase;
     }
 
-    .matrix-speedup strong { color: var(--acid); font-size: 15px; }
+    .matrix-speedup strong {
+      color: var(--acid);
+      font-size: clamp(20px, 1.8vw, 26px);
+      line-height: 1;
+      letter-spacing: -.035em;
+      white-space: nowrap;
+    }
 
     @media (max-width: 900px) {
       .latency-head {

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -4931,7 +4931,7 @@
         <article class="benchmark-console benchmark-console-wide reveal" aria-labelledby="latency-title" aria-describedby="benchmark-method">
           <header class="latency-head">
             <div>
-              <div class="console-label">Measured request latency · lower is better</div>
+              <div class="console-label">Measured generation time · seconds</div>
               <h3 id="latency-title">Video length × GPU count.</h3>
             </div>
             <span class="latency-direction">Base H3 Dense · Sol-H3</span>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -3029,36 +3029,98 @@
     .release-contract { display: flex; flex-wrap: wrap; margin-top: 16px; border: 1px solid var(--line); border-radius: 12px; overflow: hidden; background: rgba(255, 255, 255, .018); }
     .release-contract span { flex: 1 1 190px; padding: 18px 20px; border-right: 1px solid var(--line); color: var(--fog); font-family: "SFMono-Regular", Consolas, monospace; font-size: 13px; font-weight: 700; text-align: center; }
     .release-contract span:last-child { border-right: 0; }
-    /* Implementation notes continue inside the acceleration chapter. */
-    .implementation-notes {
-      margin-top: clamp(44px, 5vw, 64px);
-      padding-top: clamp(34px, 4vw, 46px);
-      border-top: 1px solid var(--line-bright);
-      scroll-margin-top: calc(var(--header-h) + 18px);
-    }
-
-    .implementation-head {
+    /* Pair each optimization overview directly with its implementation details. */
+    .acceleration-list {
       display: grid;
-      grid-template-columns: minmax(250px, .72fr) minmax(0, 1fr);
-      gap: clamp(24px, 5vw, 72px);
-      align-items: end;
-      margin-bottom: clamp(28px, 4vw, 42px);
+      gap: 14px;
     }
 
-    .implementation-head h3 {
-      margin: 12px 0 0;
-      color: var(--white);
-      font-size: clamp(34px, 4vw, 54px);
-      line-height: 1;
-      letter-spacing: -.045em;
+    .acceleration-pair {
+      display: grid;
+      grid-template-columns: minmax(320px, .72fr) minmax(0, 1.28fr);
+      overflow: hidden;
+      border: 1px solid var(--line);
+      border-radius: 15px;
+      background: var(--surface);
+      transition: border-color .3s ease, background .3s ease, transform .3s var(--ease);
     }
 
-    .implementation-head p {
-      max-width: 650px;
-      margin: 0;
-      color: var(--muted);
-      font-size: 17px;
-      line-height: 1.62;
+    .acceleration-pair:hover {
+      transform: translateY(-2px);
+      border-color: rgba(167, 255, 46, .27);
+      background: var(--surface-2);
+    }
+
+    .acceleration-pair.featured {
+      border-color: rgba(114, 245, 186, .32);
+      background: linear-gradient(115deg, rgba(114, 245, 186, .045), var(--surface) 52%);
+    }
+
+    .acceleration-pair > .tech-card {
+      min-height: 245px;
+      padding: clamp(24px, 2.7vw, 34px);
+      box-shadow: none;
+      border: 0;
+      border-radius: 0;
+      background: transparent;
+    }
+
+    .acceleration-pair > .tech-card:hover {
+      transform: none;
+      border-color: transparent;
+      background: transparent;
+    }
+
+    .acceleration-pair > .detail-row {
+      grid-template-columns: minmax(0, 1fr) minmax(175px, .36fr);
+      gap: clamp(22px, 3vw, 38px);
+      align-items: start;
+      padding: clamp(25px, 3vw, 36px);
+      border: 0;
+      border-left: 1px solid var(--line);
+      background: rgba(255, 255, 255, .008);
+    }
+
+    .acceleration-pair .detail-marker { display: none; }
+    .acceleration-pair .detail-copy h3 { font-size: clamp(25px, 2.2vw, 33px); }
+    .acceleration-pair .detail-explanation {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: clamp(16px, 2vw, 24px);
+      margin-top: 18px;
+    }
+    .acceleration-pair .detail-part p { font-size: 16px; line-height: 1.62; }
+    .acceleration-pair .detail-evidence {
+      grid-column: auto;
+      padding: 3px 0 3px 20px;
+    }
+    .acceleration-pair .detail-evidence strong { font-size: clamp(27px, 2.5vw, 36px); }
+    .acceleration-pair .detail-evidence small { font-size: 12px; }
+    .acceleration-pair.featured .tech-label,
+    .acceleration-pair.featured .detail-copy h3,
+    .acceleration-pair.featured .detail-part > span,
+    .acceleration-pair.featured .detail-evidence > span,
+    .acceleration-pair.featured .detail-evidence strong { color: var(--mint); }
+
+    @media (max-width: 900px) {
+      .acceleration-pair { grid-template-columns: 1fr; }
+      .acceleration-pair > .tech-card { min-height: 235px; }
+      .acceleration-pair > .detail-row {
+        grid-template-columns: minmax(0, 1fr) minmax(170px, .34fr);
+        border-top: 1px solid var(--line);
+        border-left: 0;
+      }
+    }
+
+    @media (max-width: 720px) {
+      .acceleration-pair > .tech-card { min-height: 270px; }
+      .acceleration-pair > .detail-row { grid-template-columns: 1fr; }
+      .acceleration-pair .detail-explanation { grid-template-columns: 1fr; }
+      .acceleration-pair .detail-evidence {
+        grid-column: auto;
+        padding: 18px 0 0;
+        border-top: 1px solid var(--line);
+        border-left: 0;
+      }
     }
 
     .detail-list { border-top: 1px solid var(--line); }
@@ -3179,12 +3241,6 @@
 
     @media (max-width: 720px) {
 
-      .implementation-head {
-        grid-template-columns: 1fr;
-        gap: 12px;
-        margin-bottom: 28px;
-      }
-      .implementation-head p { max-width: 680px; }
       .tech-summary { max-width: 100%; }
       .detail-row {
         grid-template-columns: 1fr;
@@ -5104,99 +5160,17 @@
             <span class="section-kicker">Six optimizations · one runtime</span>
             <h2 id="stack-title">How Sol-H3 gets faster.</h2>
           </div>
-          <p>Use these six cards as a map of the runtime. Each one links to its implementation note below.</p>
+          <p>Each card pairs one optimization with how it works, why it is faster, and the measured evidence.</p>
         </header>
 
-        <div class="bento">
-          <article class="tech-card span-6 reveal" data-index="01">
-            <span class="tech-label">GPU kernels</span>
-            <h3>Fuse repeated operations</h3>
-            <a class="tech-summary" href="#detail-kernels">
-              <strong>Norm · RoPE · MLP</strong>
-              <span>Read implementation ↓</span>
-            </a>
-            <div class="tech-viz fusion-viz" aria-hidden="true"><div class="fusion-stack"><i></i><i></i><i></i><i></i></div><span class="fusion-arrow"></span><span class="fusion-one"></span></div>
-          </article>
-
-          <article class="tech-card span-6 reveal" data-index="02">
-            <span class="tech-label">Multi-GPU communication</span>
-            <h3>Faster 8-GPU data exchange</h3>
-            <a class="tech-summary" href="#detail-communication">
-              <strong>Pack · all-to-all · merge</strong>
-              <span>Read implementation ↓</span>
-            </a>
-            <div class="tech-viz ulysses-viz" aria-hidden="true"><i style="--n:0"></i><i style="--n:1"></i><i style="--n:2"></i><i style="--n:3"></i><i style="--n:4"></i><i style="--n:5"></i><i style="--n:6"></i><i style="--n:7"></i></div>
-          </article>
-
-          <article class="tech-card span-6 reveal" data-index="03">
-            <span class="tech-label">Sparse-attention setup</span>
-            <h3>Fuse the setup work</h3>
-            <a class="tech-summary" href="#detail-setup">
-              <strong>K/V summaries · threshold · metadata</strong>
-              <span>Read implementation ↓</span>
-            </a>
-            <div class="tech-viz route-viz" aria-hidden="true"><span><i style="--w:100%"></i><b>Before</b></span><span><i style="--w:24%"></i><b>Fused</b></span></div>
-          </article>
-
-          <article class="tech-card span-6 reveal" data-index="04">
-            <span class="tech-label">Sol-Attn</span>
-            <h3>Sparsify on the fly</h3>
-            <a class="tech-summary" href="#detail-sol-attn">
-              <strong>Query-dependent · one-pass · training-free</strong>
-              <span>Read implementation ↓</span>
-            </a>
-            <div class="tech-viz prefix-viz" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i><i></i></div>
-          </article>
-
-          <article class="tech-card span-6 reveal" data-index="05">
-            <span class="tech-label">Video decoding</span>
-            <h3>Parallel VAE decoding</h3>
-            <a class="tech-summary" href="#detail-vae">
-              <strong>Tile parallel · batch · compile</strong>
-              <span>Read implementation ↓</span>
-            </a>
-            <div class="tech-viz tile-viz" aria-hidden="true">
-              <i style="--p:1"></i><i style="--p:2"></i><i style="--p:3"></i><i style="--p:4"></i><i style="--p:5"></i><i style="--p:6"></i><i style="--p:7"></i>
-              <i style="--p:2"></i><i style="--p:3"></i><i style="--p:4"></i><i style="--p:5"></i><i style="--p:6"></i><i style="--p:7"></i><i style="--p:8"></i>
-              <i style="--p:3"></i><i style="--p:4"></i><i style="--p:5"></i><i style="--p:6"></i><i style="--p:7"></i><i style="--p:8"></i><i style="--p:9"></i>
-              <i style="--p:4"></i><i style="--p:5"></i><i style="--p:6"></i><i style="--p:7"></i><i style="--p:8"></i><i style="--p:9"></i><i style="--p:10"></i>
-            </div>
-          </article>
-
-          <article class="tech-card span-6 reveal" data-index="06">
-            <span class="tech-label">Conditioning</span>
-            <h3>Precompute AdaLN</h3>
-            <a class="tech-summary" href="#detail-adaln">
-              <strong>Precompute · cache · direct lookup</strong>
-              <span>Read implementation ↓</span>
-            </a>
-            <div class="tech-viz adaln-viz" aria-hidden="true">
-              <i style="--p:1"></i><i style="--p:5"></i><i style="--p:2"></i><i style="--p:7"></i><i style="--p:4"></i><i style="--p:9"></i>
-              <i style="--p:6"></i><i style="--p:2"></i><i style="--p:8"></i><i style="--p:3"></i><i style="--p:10"></i><i style="--p:4"></i>
-              <i style="--p:3"></i><i style="--p:8"></i><i style="--p:4"></i><i style="--p:9"></i><i style="--p:5"></i><i style="--p:10"></i>
-            </div>
-          </article>
-
-        </div>
-
-        <div class="release-contract reveal" aria-label="Measured Sol-H3 profile">
-          <span>Audited T2V</span>
-          <span>5 / 10 / 15 seconds</span>
-          <span>1344×768 · 24 FPS</span>
-          <span>INT8 QKV · FP8 attention output</span>
-          <span>8× NVIDIA B300</span>
-        </div>
-
-        <section class="implementation-notes" id="details" aria-labelledby="details-title">
-          <header class="implementation-head reveal">
-            <div>
-              <span class="section-kicker">Implementation notes</span>
-              <h3 id="details-title">Inside each optimization.</h3>
-            </div>
-            <p>How each part works, where the time is saved, and the measured evidence.</p>
-          </header>
-
-          <div class="detail-list">
+        <div class="acceleration-list">
+          <div class="acceleration-pair">
+            <article class="tech-card reveal" data-index="01">
+              <span class="tech-label">GPU kernels</span>
+              <h3>Fuse repeated operations</h3>
+              <div class="tech-summary"><strong>Norm · RoPE · MLP</strong></div>
+              <div class="tech-viz fusion-viz" aria-hidden="true"><div class="fusion-stack"><i></i><i></i><i></i><i></i></div><span class="fusion-arrow"></span><span class="fusion-one"></span></div>
+            </article>
             <article class="detail-row reveal" id="detail-kernels">
               <div class="detail-marker"><strong>01</strong><span>GPU kernels</span></div>
               <div class="detail-copy">
@@ -5208,7 +5182,15 @@
               </div>
               <aside class="detail-evidence"><span>Evidence</span><strong>≈178 GB</strong><small>less intermediate traffic per GPU per evaluation</small></aside>
             </article>
+          </div>
 
+          <div class="acceleration-pair">
+            <article class="tech-card reveal" data-index="02">
+              <span class="tech-label">Multi-GPU communication</span>
+              <h3>Faster 8-GPU data exchange</h3>
+              <div class="tech-summary"><strong>Pack · all-to-all · merge</strong></div>
+              <div class="tech-viz ulysses-viz" aria-hidden="true"><i style="--n:0"></i><i style="--n:1"></i><i style="--n:2"></i><i style="--n:3"></i><i style="--n:4"></i><i style="--n:5"></i><i style="--n:6"></i><i style="--n:7"></i></div>
+            </article>
             <article class="detail-row reveal" id="detail-communication">
               <div class="detail-marker"><strong>02</strong><span>8-GPU exchange</span></div>
               <div class="detail-copy">
@@ -5220,7 +5202,15 @@
               </div>
               <aside class="detail-evidence"><span>Fastest profile</span><strong>51.6%</strong><small>of the BF16 attention communication payload</small></aside>
             </article>
+          </div>
 
+          <div class="acceleration-pair">
+            <article class="tech-card reveal" data-index="03">
+              <span class="tech-label">Sparse-attention setup</span>
+              <h3>Fuse the setup work</h3>
+              <div class="tech-summary"><strong>K/V summaries · threshold · metadata</strong></div>
+              <div class="tech-viz route-viz" aria-hidden="true"><span><i style="--w:100%"></i><b>Before</b></span><span><i style="--w:24%"></i><b>Fused</b></span></div>
+            </article>
             <article class="detail-row reveal" id="detail-setup">
               <div class="detail-marker"><strong>03</strong><span>Sparse setup</span></div>
               <div class="detail-copy">
@@ -5232,7 +5222,15 @@
               </div>
               <aside class="detail-evidence"><span>Measured setup</span><strong>0.285 ms</strong><small>from 1.206 ms · 76.4% lower</small></aside>
             </article>
+          </div>
 
+          <div class="acceleration-pair featured">
+            <article class="tech-card reveal" data-index="04">
+              <span class="tech-label">Sol-Attn</span>
+              <h3>Sparsify on the fly</h3>
+              <div class="tech-summary"><strong>Query-dependent · one-pass · training-free</strong></div>
+              <div class="tech-viz prefix-viz" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i><i></i></div>
+            </article>
             <article class="detail-row featured reveal" id="detail-sol-attn">
               <div class="detail-marker"><strong>04</strong><span>Sol-Attn</span></div>
               <div class="detail-copy">
@@ -5244,7 +5242,20 @@
               </div>
               <aside class="detail-evidence"><span>Key property</span><strong>One pass</strong><small>query-dependent · training-free sparsification</small></aside>
             </article>
+          </div>
 
+          <div class="acceleration-pair">
+            <article class="tech-card reveal" data-index="05">
+              <span class="tech-label">Video decoding</span>
+              <h3>Parallel VAE decoding</h3>
+              <div class="tech-summary"><strong>Tile parallel · batch · compile</strong></div>
+              <div class="tech-viz tile-viz" aria-hidden="true">
+                <i style="--p:1"></i><i style="--p:2"></i><i style="--p:3"></i><i style="--p:4"></i><i style="--p:5"></i><i style="--p:6"></i><i style="--p:7"></i>
+                <i style="--p:2"></i><i style="--p:3"></i><i style="--p:4"></i><i style="--p:5"></i><i style="--p:6"></i><i style="--p:7"></i><i style="--p:8"></i>
+                <i style="--p:3"></i><i style="--p:4"></i><i style="--p:5"></i><i style="--p:6"></i><i style="--p:7"></i><i style="--p:8"></i><i style="--p:9"></i>
+                <i style="--p:4"></i><i style="--p:5"></i><i style="--p:6"></i><i style="--p:7"></i><i style="--p:8"></i><i style="--p:9"></i><i style="--p:10"></i>
+              </div>
+            </article>
             <article class="detail-row reveal" id="detail-vae">
               <div class="detail-marker"><strong>05</strong><span>VAE decoding</span></div>
               <div class="detail-copy">
@@ -5256,7 +5267,19 @@
               </div>
               <aside class="detail-evidence"><span>5s VAE decode</span><strong>0.602 s</strong><small>7.55 → 1.16 s with tiles · then 0.602 s with batching</small></aside>
             </article>
+          </div>
 
+          <div class="acceleration-pair">
+            <article class="tech-card reveal" data-index="06">
+              <span class="tech-label">Conditioning</span>
+              <h3>Precompute AdaLN</h3>
+              <div class="tech-summary"><strong>Precompute · cache · direct lookup</strong></div>
+              <div class="tech-viz adaln-viz" aria-hidden="true">
+                <i style="--p:1"></i><i style="--p:5"></i><i style="--p:2"></i><i style="--p:7"></i><i style="--p:4"></i><i style="--p:9"></i>
+                <i style="--p:6"></i><i style="--p:2"></i><i style="--p:8"></i><i style="--p:3"></i><i style="--p:10"></i><i style="--p:4"></i>
+                <i style="--p:3"></i><i style="--p:8"></i><i style="--p:4"></i><i style="--p:9"></i><i style="--p:5"></i><i style="--p:10"></i>
+              </div>
+            </article>
             <article class="detail-row reveal" id="detail-adaln">
               <div class="detail-marker"><strong>06</strong><span>AdaLN cache</span></div>
               <div class="detail-copy">
@@ -5269,7 +5292,15 @@
               <aside class="detail-evidence"><span>Memory released</span><strong>≈24 GB</strong><small>per GPU · plus ≈400 indexing launches removed</small></aside>
             </article>
           </div>
-        </section>
+        </div>
+
+        <div class="release-contract reveal" aria-label="Measured Sol-H3 profile">
+          <span>Audited T2V</span>
+          <span>5 / 10 / 15 seconds</span>
+          <span>1344×768 · 24 FPS</span>
+          <span>INT8 QKV · FP8 attention output</span>
+          <span>8× NVIDIA B300</span>
+        </div>
       </div>
     </section>
 

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -3029,12 +3029,36 @@
     .release-contract { display: flex; flex-wrap: wrap; margin-top: 16px; border: 1px solid var(--line); border-radius: 12px; overflow: hidden; background: rgba(255, 255, 255, .018); }
     .release-contract span { flex: 1 1 190px; padding: 18px 20px; border-right: 1px solid var(--line); color: var(--fog); font-family: "SFMono-Regular", Consolas, monospace; font-size: 13px; font-weight: 700; text-align: center; }
     .release-contract span:last-child { border-right: 0; }
-    /* Expanded implementation notes: readable rows, separate from overview cards. */
-    .technical-details {
-      border-block: 1px solid var(--line);
-      background:
-        radial-gradient(circle at 82% 16%, rgba(114, 245, 186, .045), transparent 28rem),
-        rgba(255, 255, 255, .008);
+    /* Implementation notes continue inside the acceleration chapter. */
+    .implementation-notes {
+      margin-top: clamp(44px, 5vw, 64px);
+      padding-top: clamp(34px, 4vw, 46px);
+      border-top: 1px solid var(--line-bright);
+      scroll-margin-top: calc(var(--header-h) + 18px);
+    }
+
+    .implementation-head {
+      display: grid;
+      grid-template-columns: minmax(250px, .72fr) minmax(0, 1fr);
+      gap: clamp(24px, 5vw, 72px);
+      align-items: end;
+      margin-bottom: clamp(28px, 4vw, 42px);
+    }
+
+    .implementation-head h3 {
+      margin: 12px 0 0;
+      color: var(--white);
+      font-size: clamp(34px, 4vw, 54px);
+      line-height: 1;
+      letter-spacing: -.045em;
+    }
+
+    .implementation-head p {
+      max-width: 650px;
+      margin: 0;
+      color: var(--muted);
+      font-size: 17px;
+      line-height: 1.62;
     }
 
     .detail-list { border-top: 1px solid var(--line); }
@@ -3154,6 +3178,13 @@
     }
 
     @media (max-width: 720px) {
+
+      .implementation-head {
+        grid-template-columns: 1fr;
+        gap: 12px;
+        margin-bottom: 28px;
+      }
+      .implementation-head p { max-width: 680px; }
       .tech-summary { max-width: 100%; }
       .detail-row {
         grid-template-columns: 1fr;
@@ -5156,100 +5187,96 @@
           <span>8× NVIDIA B300</span>
         </div>
 
-      </div>
-    </section>
+        <section class="implementation-notes" id="details" aria-labelledby="details-title">
+          <header class="implementation-head reveal">
+            <div>
+              <span class="section-kicker">Implementation notes</span>
+              <h3 id="details-title">Inside each optimization.</h3>
+            </div>
+            <p>How each part works, where the time is saved, and the measured evidence.</p>
+          </header>
 
-    <section class="section technical-details" id="details" aria-labelledby="details-title">
-      <div class="wide-shell">
-        <header class="section-head reveal">
-          <div class="section-index">05</div>
-          <div>
-            <span class="section-kicker">Six implementation notes</span>
-            <h2 id="details-title">What each optimization does.</h2>
+          <div class="detail-list">
+            <article class="detail-row reveal" id="detail-kernels">
+              <div class="detail-marker"><strong>01</strong><span>GPU kernels</span></div>
+              <div class="detail-copy">
+                <h3>Move less data between operations.</h3>
+                <div class="detail-explanation">
+                  <div class="detail-part"><span>Mechanism</span><p>Sol-H3 fuses three repeated chains: residual + RMSNorm + modulation, QKNorm + partial RoPE, and SwiGLU. Their intermediate tensors stay in registers or on chip instead of returning to GPU memory between operations.</p></div>
+                  <div class="detail-part"><span>Why it is faster</span><p>These operations touch wide tensors but do relatively little math, so memory traffic is often the limit. Fewer reads, writes, and launches save traffic across all 50 transformer blocks.</p></div>
+                </div>
+              </div>
+              <aside class="detail-evidence"><span>Evidence</span><strong>≈178 GB</strong><small>less intermediate traffic per GPU per evaluation</small></aside>
+            </article>
+
+            <article class="detail-row reveal" id="detail-communication">
+              <div class="detail-marker"><strong>02</strong><span>8-GPU exchange</span></div>
+              <div class="detail-copy">
+                <h3>Pack, exchange, and merge directly.</h3>
+                <div class="detail-explanation">
+                  <div class="detail-part"><span>Mechanism</span><p>Ulysses changes sequence shards into head shards before attention, then changes them back. Sol-H3 writes normalized and RoPE-applied Q/K, together with V, directly in destination-major order; one packed all-to-all sends them, and the return is decoded directly into merged-head order.</p></div>
+                  <div class="detail-part"><span>Why it is faster</span><p>This removes separate stack, permute, and contiguous copies. The fastest profile uses one scale per 32 INT8 QKV values and E4M3 FP8 output clamped to ±448; BF16 transport remains available.</p></div>
+                </div>
+              </div>
+              <aside class="detail-evidence"><span>Fastest profile</span><strong>51.6%</strong><small>of the BF16 attention communication payload</small></aside>
+            </article>
+
+            <article class="detail-row reveal" id="detail-setup">
+              <div class="detail-marker"><strong>03</strong><span>Sparse setup</span></div>
+              <div class="detail-copy">
+                <h3>Build the sparse plan in fewer passes.</h3>
+                <div class="detail-explanation">
+                  <div class="detail-part"><span>Mechanism</span><p>One preprocessing kernel computes each key centroid and value sum together. Thresholding also returns the pooled query for reuse; the final compaction step applies threshold, local-band, and exact-prefix rules while emitting the mask and compact block lists.</p></div>
+                  <div class="detail-part"><span>Why it is faster</span><p>The cuDNN block-sparse path receives everything it needs without separately materializing each setup stage. This metadata path is separate from the native one-pass Sol-Attn kernel below; reuse and fusion reduce its temporary traffic and launch overhead.</p></div>
+                </div>
+              </div>
+              <aside class="detail-evidence"><span>Measured setup</span><strong>0.285 ms</strong><small>from 1.206 ms · 76.4% lower</small></aside>
+            </article>
+
+            <article class="detail-row featured reveal" id="detail-sol-attn">
+              <div class="detail-marker"><strong>04</strong><span>Sol-Attn</span></div>
+              <div class="detail-copy">
+                <h3>Select blocks while attention runs.</h3>
+                <div class="detail-explanation">
+                  <div class="detail-part"><span>Mechanism</span><p>Each 64-token query block sets its own threshold: mean + β × standard deviation over lightweight query–key scores. Blocks above it run exact attention; skipped blocks contribute a low-cost approximation using pooled keys and value sums.</p></div>
+                  <div class="detail-part"><span>Why it is faster</span><p>Sol-Attn consumes each score tile inside online softmax: the same tile selects exact blocks and updates the approximation. It writes no separate router output, full score map, or routing-index tensor, and needs no retraining.</p></div>
+                </div>
+              </div>
+              <aside class="detail-evidence"><span>Key property</span><strong>One pass</strong><small>query-dependent · training-free sparsification</small></aside>
+            </article>
+
+            <article class="detail-row reveal" id="detail-vae">
+              <div class="detail-marker"><strong>05</strong><span>VAE decoding</span></div>
+              <div class="detail-copy">
+                <h3>Decode spatial tiles in parallel.</h3>
+                <div class="detail-explanation">
+                  <div class="detail-part"><span>Mechanism</span><p>A 5s output has seven temporal clips, each split into a 4 × 7 grid of 28 equal spatial tiles. Sol-H3 distributes them over eight GPUs and batches each GPU’s four tiles into one compiled decoder call.</p></div>
+                  <div class="detail-part"><span>Why it is faster</span><p>Tile parallelism reduces work per GPU; batching replaces many small decoder launches. Optional global mode balances all 196 tiles and gathers once, but remains optional because the larger compiled batch shows small measured rounding drift.</p></div>
+                </div>
+              </div>
+              <aside class="detail-evidence"><span>5s VAE decode</span><strong>0.602 s</strong><small>7.55 → 1.16 s with tiles · then 0.602 s with batching</small></aside>
+            </article>
+
+            <article class="detail-row reveal" id="detail-adaln">
+              <div class="detail-marker"><strong>06</strong><span>AdaLN cache</span></div>
+              <div class="detail-copy">
+                <h3>Compute conditioning once, then reuse it.</h3>
+                <div class="detail-explanation">
+                  <div class="detail-part"><span>Mechanism</span><p>All AdaLN values are knowable before denoising. Sol-H3 projects every block-and-step value up front, caches the full trajectory, and releases the projection weights before the denoising loop.</p></div>
+                  <div class="detail-part"><span>Why it is faster</span><p>Each block reads its cached slice directly instead of running two index selections. Across 50 blocks and four steps, that removes about 400 small launches and avoids roughly 26 GB of GPU-memory reads per step without changing output.</p></div>
+                </div>
+              </div>
+              <aside class="detail-evidence"><span>Memory released</span><strong>≈24 GB</strong><small>per GPU · plus ≈400 indexing launches removed</small></aside>
+            </article>
           </div>
-          <p>How each part works, where the time is saved, and the evidence behind it.</p>
-        </header>
-
-        <div class="detail-list">
-          <article class="detail-row reveal" id="detail-kernels">
-            <div class="detail-marker"><strong>01</strong><span>GPU kernels</span></div>
-            <div class="detail-copy">
-              <h3>Move less data between operations.</h3>
-              <div class="detail-explanation">
-                <div class="detail-part"><span>Mechanism</span><p>Sol-H3 fuses three repeated chains: residual + RMSNorm + modulation, QKNorm + partial RoPE, and SwiGLU. Their intermediate tensors stay in registers or on chip instead of returning to GPU memory between operations.</p></div>
-                <div class="detail-part"><span>Why it is faster</span><p>These operations touch wide tensors but do relatively little math, so memory traffic is often the limit. Fewer reads, writes, and launches save traffic across all 50 transformer blocks.</p></div>
-              </div>
-            </div>
-            <aside class="detail-evidence"><span>Evidence</span><strong>≈178 GB</strong><small>less intermediate traffic per GPU per evaluation</small></aside>
-          </article>
-
-          <article class="detail-row reveal" id="detail-communication">
-            <div class="detail-marker"><strong>02</strong><span>8-GPU exchange</span></div>
-            <div class="detail-copy">
-              <h3>Pack, exchange, and merge directly.</h3>
-              <div class="detail-explanation">
-                <div class="detail-part"><span>Mechanism</span><p>Ulysses changes sequence shards into head shards before attention, then changes them back. Sol-H3 writes normalized and RoPE-applied Q/K, together with V, directly in destination-major order; one packed all-to-all sends them, and the return is decoded directly into merged-head order.</p></div>
-                <div class="detail-part"><span>Why it is faster</span><p>This removes separate stack, permute, and contiguous copies. The fastest profile uses one scale per 32 INT8 QKV values and E4M3 FP8 output clamped to ±448; BF16 transport remains available.</p></div>
-              </div>
-            </div>
-            <aside class="detail-evidence"><span>Fastest profile</span><strong>51.6%</strong><small>of the BF16 attention communication payload</small></aside>
-          </article>
-
-          <article class="detail-row reveal" id="detail-setup">
-            <div class="detail-marker"><strong>03</strong><span>Sparse setup</span></div>
-            <div class="detail-copy">
-              <h3>Build the sparse plan in fewer passes.</h3>
-              <div class="detail-explanation">
-                <div class="detail-part"><span>Mechanism</span><p>One preprocessing kernel computes each key centroid and value sum together. Thresholding also returns the pooled query for reuse; the final compaction step applies threshold, local-band, and exact-prefix rules while emitting the mask and compact block lists.</p></div>
-                <div class="detail-part"><span>Why it is faster</span><p>The cuDNN block-sparse path receives everything it needs without separately materializing each setup stage. This metadata path is separate from the native one-pass Sol-Attn kernel below; reuse and fusion reduce its temporary traffic and launch overhead.</p></div>
-              </div>
-            </div>
-            <aside class="detail-evidence"><span>Measured setup</span><strong>0.285 ms</strong><small>from 1.206 ms · 76.4% lower</small></aside>
-          </article>
-
-          <article class="detail-row featured reveal" id="detail-sol-attn">
-            <div class="detail-marker"><strong>04</strong><span>Sol-Attn</span></div>
-            <div class="detail-copy">
-              <h3>Select blocks while attention runs.</h3>
-              <div class="detail-explanation">
-                <div class="detail-part"><span>Mechanism</span><p>Each 64-token query block sets its own threshold: mean + β × standard deviation over lightweight query–key scores. Blocks above it run exact attention; skipped blocks contribute a low-cost approximation using pooled keys and value sums.</p></div>
-                <div class="detail-part"><span>Why it is faster</span><p>Sol-Attn consumes each score tile inside online softmax: the same tile selects exact blocks and updates the approximation. It writes no separate router output, full score map, or routing-index tensor, and needs no retraining.</p></div>
-              </div>
-            </div>
-            <aside class="detail-evidence"><span>Key property</span><strong>One pass</strong><small>query-dependent · training-free sparsification</small></aside>
-          </article>
-
-          <article class="detail-row reveal" id="detail-vae">
-            <div class="detail-marker"><strong>05</strong><span>VAE decoding</span></div>
-            <div class="detail-copy">
-              <h3>Decode spatial tiles in parallel.</h3>
-              <div class="detail-explanation">
-                <div class="detail-part"><span>Mechanism</span><p>A 5s output has seven temporal clips, each split into a 4 × 7 grid of 28 equal spatial tiles. Sol-H3 distributes them over eight GPUs and batches each GPU’s four tiles into one compiled decoder call.</p></div>
-                <div class="detail-part"><span>Why it is faster</span><p>Tile parallelism reduces work per GPU; batching replaces many small decoder launches. Optional global mode balances all 196 tiles and gathers once, but remains optional because the larger compiled batch shows small measured rounding drift.</p></div>
-              </div>
-            </div>
-            <aside class="detail-evidence"><span>5s VAE decode</span><strong>0.602 s</strong><small>7.55 → 1.16 s with tiles · then 0.602 s with batching</small></aside>
-          </article>
-
-          <article class="detail-row reveal" id="detail-adaln">
-            <div class="detail-marker"><strong>06</strong><span>AdaLN cache</span></div>
-            <div class="detail-copy">
-              <h3>Compute conditioning once, then reuse it.</h3>
-              <div class="detail-explanation">
-                <div class="detail-part"><span>Mechanism</span><p>All AdaLN values are knowable before denoising. Sol-H3 projects every block-and-step value up front, caches the full trajectory, and releases the projection weights before the denoising loop.</p></div>
-                <div class="detail-part"><span>Why it is faster</span><p>Each block reads its cached slice directly instead of running two index selections. Across 50 blocks and four steps, that removes about 400 small launches and avoids roughly 26 GB of GPU-memory reads per step without changing output.</p></div>
-              </div>
-            </div>
-            <aside class="detail-evidence"><span>Memory released</span><strong>≈24 GB</strong><small>per GPU · plus ≈400 indexing launches removed</small></aside>
-          </article>
-        </div>
+        </section>
       </div>
     </section>
 
     <section class="future-plan" id="future" aria-labelledby="future-title">
       <div class="wide-shell">
         <header class="section-head reveal">
-          <div class="section-index">06</div>
+          <div class="section-index">05</div>
           <div>
             <span class="section-kicker">Future Plan</span>
             <h2 id="future-title">Where Sol-H3 goes next.</h2>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -948,15 +948,6 @@
       gap: 8px;
     }
 
-    .benchmark-scale {
-      color: var(--muted);
-      font-family: "SFMono-Regular", Consolas, monospace;
-      font-size: 11px;
-      font-weight: 700;
-      letter-spacing: .055em;
-      text-transform: uppercase;
-    }
-
     .latency-matrix [hidden] { display: none !important; }
     .latency-matrix [data-benchmark-duration]:not([hidden]) { border-right: 0; }
 
@@ -3940,7 +3931,7 @@
     .future-plan .wide-shell { position: relative; z-index: 1; }
     .future-grid {
       display: grid;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
+      grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 16px;
       margin-top: clamp(38px, 5vw, 66px);
     }
@@ -4064,7 +4055,6 @@
 
     @media (max-width: 1180px) {
       .future-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-      .future-card:last-child { grid-column: 1 / -1; }
     }
 
     .publication-notes {
@@ -4995,7 +4985,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M7 17 17 7M8 7h9v9"/></svg>
           </a>
           <p class="collaboration-statement">
-            Built by <strong>NVIDIA Research’s Efficient AI Team and Singapore Lab</strong>. <a href="https://www.reactor.inc/" target="_blank" rel="noopener noreferrer">Reactor</a> is collaborating on the online demo. <a href="https://github.com/humanfia/humanize2" target="_blank" rel="noopener noreferrer">Humanize</a> and <a href="https://github.com/mit-han-lab/kernel-design-agents" target="_blank" rel="noopener noreferrer">KDA</a> helped tune GPU kernels on Sol-Engine. Any MiniMax-H3 few-step LoRA can plug into the same Sol-H3 engine.
+            One engine supports <strong>Text-to-Video, Image-to-Video, and Reference-to-Video</strong>. Built by <strong>NVIDIA Research’s Efficient AI Team and Singapore Lab</strong>. <a href="https://www.reactor.inc/" target="_blank" rel="noopener noreferrer">Reactor</a> is collaborating on the online demo. <a href="https://github.com/humanfia/humanize2" target="_blank" rel="noopener noreferrer">Humanize</a> and <a href="https://github.com/mit-han-lab/kernel-design-agents" target="_blank" rel="noopener noreferrer">KDA</a> helped tune GPU kernels on Sol-Engine. Compatible MiniMax-H3 few-step LoRAs can plug into the same Sol-H3 engine.
           </p>
         </aside>
       </div>
@@ -5025,7 +5015,6 @@
                 <button class="duration-tab" id="benchmark-duration-10" type="button" role="tab" aria-selected="false" tabindex="-1" data-benchmark-duration-control="10" aria-controls="latency-panel">10s</button>
                 <button class="duration-tab" id="benchmark-duration-15" type="button" role="tab" aria-selected="false" tabindex="-1" data-benchmark-duration-control="15" aria-controls="latency-panel">15s</button>
               </div>
-              <span class="benchmark-scale" id="benchmark-scale">Base H3 = 100% · exact seconds shown</span>
             </div>
           </header>
 
@@ -5045,20 +5034,20 @@
                   <th scope="row"><span class="matrix-gpu"><strong>8×</strong><small>NVIDIA B300</small></span></th>
                   <td data-duration="5s · 124 frames" data-benchmark-duration="5">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>18.250 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 9.058%;"><span>Sol-H3<small>Ours</small></span><strong>1.653 s</strong><span class="matrix-speedup" aria-label="11.04 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>11.04×<span> faster</span></strong></span></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense · 50 steps</small></span><strong>18.250 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 9.058%;"><span>Sol-H3<small>Ours · 4 steps</small></span><strong>1.653 s</strong><span class="matrix-speedup" aria-label="11.04 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>11.04×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                   <td data-duration="10s · 243 frames" data-benchmark-duration="10" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>50.660 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 7.367%;"><span>Sol-H3<small>Ours</small></span><strong>3.732 s</strong><span class="matrix-speedup" aria-label="13.57 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>13.57×<span> faster</span></strong></span></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense · 50 steps</small></span><strong>50.660 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 7.367%;"><span>Sol-H3<small>Ours · 4 steps</small></span><strong>3.732 s</strong><span class="matrix-speedup" aria-label="13.57 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>13.57×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                   <td data-duration="15s · 362 frames" data-benchmark-duration="15" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>99.513 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 6.644%;"><span>Sol-H3<small>Ours</small></span><strong>6.612 s</strong><span class="matrix-speedup" aria-label="15.05 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>15.05×<span> faster</span></strong></span></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense · 50 steps</small></span><strong>99.513 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 6.644%;"><span>Sol-H3<small>Ours · 4 steps</small></span><strong>6.612 s</strong><span class="matrix-speedup" aria-label="15.05 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>15.05×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                 </tr>
@@ -5066,20 +5055,20 @@
                   <th scope="row"><span class="matrix-gpu"><strong>4×</strong><small>NVIDIA B300</small></span></th>
                   <td data-duration="5s · 124 frames" data-benchmark-duration="5">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>35.328 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 8.260%;"><span>Sol-H3<small>Ours</small></span><strong>2.918 s</strong><span class="matrix-speedup" aria-label="12.11 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>12.11×<span> faster</span></strong></span></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense · 50 steps</small></span><strong>35.328 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 8.260%;"><span>Sol-H3<small>Ours · 4 steps</small></span><strong>2.918 s</strong><span class="matrix-speedup" aria-label="12.11 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>12.11×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                   <td data-duration="10s · 243 frames" data-benchmark-duration="10" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>100.440 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 6.962%;"><span>Sol-H3<small>Ours</small></span><strong>6.993 s</strong><span class="matrix-speedup" aria-label="14.36 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>14.36×<span> faster</span></strong></span></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense · 50 steps</small></span><strong>100.440 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 6.962%;"><span>Sol-H3<small>Ours · 4 steps</small></span><strong>6.993 s</strong><span class="matrix-speedup" aria-label="14.36 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>14.36×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                   <td data-duration="15s · 362 frames" data-benchmark-duration="15" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>194.930 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 6.434%;"><span>Sol-H3<small>Ours</small></span><strong>12.542 s</strong><span class="matrix-speedup" aria-label="15.54 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>15.54×<span> faster</span></strong></span></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense · 50 steps</small></span><strong>194.930 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 6.434%;"><span>Sol-H3<small>Ours · 4 steps</small></span><strong>12.542 s</strong><span class="matrix-speedup" aria-label="15.54 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>15.54×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                 </tr>
@@ -5087,20 +5076,20 @@
                   <th scope="row"><span class="matrix-gpu"><strong>1×</strong><small>NVIDIA B300</small></span></th>
                   <td data-duration="5s · 124 frames" data-benchmark-duration="5">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>129.898 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 10.581%;"><span>Sol-H3<small>Ours</small></span><strong>13.745 s</strong><span class="matrix-speedup" aria-label="9.45 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>9.45×<span> faster</span></strong></span></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense · 50 steps</small></span><strong>129.898 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 10.581%;"><span>Sol-H3<small>Ours · 4 steps</small></span><strong>13.745 s</strong><span class="matrix-speedup" aria-label="9.45 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>9.45×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                   <td data-duration="10s · 243 frames" data-benchmark-duration="10" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>376.942 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 10.032%;"><span>Sol-H3<small>Ours</small></span><strong>37.813 s</strong><span class="matrix-speedup" aria-label="9.97 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>9.97×<span> faster</span></strong></span></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense · 50 steps</small></span><strong>376.942 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 10.032%;"><span>Sol-H3<small>Ours · 4 steps</small></span><strong>37.813 s</strong><span class="matrix-speedup" aria-label="9.97 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>9.97×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                   <td data-duration="15s · 362 frames" data-benchmark-duration="15" hidden>
                     <div class="matrix-cell">
-                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense</small></span><strong>746.885 s</strong></div>
-                      <div class="matrix-measure ours" style="--w: 6.997%;"><span>Sol-H3<small>Ours</small></span><strong>52.260 s</strong><span class="matrix-speedup" aria-label="14.29 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>14.29×<span> faster</span></strong></span></div>
+                      <div class="matrix-measure base" style="--w: 100%;"><span>Base H3<small>Dense · 50 steps</small></span><strong>746.885 s</strong></div>
+                      <div class="matrix-measure ours" style="--w: 6.997%;"><span>Sol-H3<small>Ours · 4 steps</small></span><strong>52.260 s</strong><span class="matrix-speedup" aria-label="14.29 times faster than Base H3"><svg viewBox="0 0 26 16" aria-hidden="true" focusable="false"><path d="M24 14C14 14 8 10 3.5 3.5M3.5 3.5l1 6M3.5 3.5l6 1"/></svg><strong>14.29×<span> faster</span></strong></span></div>
                     </div>
                   </td>
                 </tr>
@@ -5111,7 +5100,7 @@
 
         <div class="method-note reveal">
           <strong>Measured scope</strong>
-          <span id="benchmark-method">All runs use 1344×768, 24 FPS, the same prompt and seed 20260903, and reference-free T2V with stereo audio. Sol-H3 uses Dense attention on 1× B300 and SOL on 4× / 8× B300. Each value is the median of three measured runs after one warmup. Timing includes text encoding, DiT, and video/audio VAE decoding; model loading, compilation warmup, and final MP4 encoding are not timed.</span>
+          <span id="benchmark-method">All runs use 1344×768, 24 FPS, the same prompt and seed 20260903, and reference-free T2V with stereo audio. In this benchmark, Sol-H3 uses Dense attention on 1× B300 and the SOL sparse-attention path on 4× / 8× B300. Each value is the median of three measured runs after one warmup. Timing includes text encoding, DiT, and video/audio VAE decoding; model loading, compilation warmup, and final MP4 encoding are not timed.</span>
         </div>
       </div>
     </section>
@@ -5121,12 +5110,9 @@
         const tabs = [...document.querySelectorAll('[data-benchmark-duration-control]')];
         const cells = [...document.querySelectorAll('[data-benchmark-duration]')];
         const panel = document.getElementById('latency-panel');
-        const scale = document.getElementById('benchmark-scale');
-        const scaleLabel = 'Base H3 = 100% · exact seconds shown';
-
         const selectDuration = (duration, moveFocus = false) => {
           const activeTab = tabs.find((tab) => tab.dataset.benchmarkDurationControl === duration);
-          if (!activeTab || !panel || !scale) return;
+          if (!activeTab || !panel) return;
 
           tabs.forEach((tab) => {
             const active = tab === activeTab;
@@ -5136,7 +5122,6 @@
           cells.forEach((cell) => {
             cell.hidden = cell.dataset.benchmarkDuration !== duration;
           });
-          scale.textContent = scaleLabel;
           panel.setAttribute('aria-labelledby', activeTab.id);
           if (moveFocus) activeTab.focus();
         };
@@ -5477,19 +5462,11 @@
             <span class="section-kicker">Future Plan</span>
             <h2 id="future-title">Where Sol-H3 goes next.</h2>
           </div>
-          <p>Sol-H3 is moving toward reference-guided generation, continuous 24 FPS output, and direct real-time interaction.</p>
+          <p>Sol-H3 is moving toward continuous 24 FPS output and direct real-time interaction.</p>
         </header>
 
         <div class="future-grid">
           <article class="future-card reveal" data-index="01">
-            <span class="future-status">In development</span>
-            <span class="future-label">Reference-guided generation</span>
-            <h3>Ref2AV</h3>
-            <p>Generate video and native audio from a reference image or video, with Sol-Engine optimizing the complete inference path.</p>
-            <span class="future-flow">Reference → video + audio</span>
-          </article>
-
-          <article class="future-card reveal" data-index="02">
             <span class="future-status">Research direction</span>
             <span class="future-label">Continuous generation</span>
             <h3>24 FPS live streaming</h3>
@@ -5497,7 +5474,7 @@
             <span class="future-flow">Generate → decode → stream</span>
           </article>
 
-          <article class="future-card reveal" data-index="03">
+          <article class="future-card reveal" data-index="02">
             <span class="future-status">Coming next</span>
             <span class="future-label">Interactive access</span>
             <h3>Real-time interactive demo</h3>
@@ -5530,7 +5507,7 @@
             <li><a class="ack-entity" href="https://huggingface.co/MiniMaxAI/MiniMax-H3" target="_blank" rel="noopener noreferrer">MiniMax</a><span class="ack-role">MiniMax-H3 open weights and code.</span></li>
             <li><a class="ack-entity" href="https://www.reactor.inc/" target="_blank" rel="noopener noreferrer">Reactor</a><span class="ack-role">Forthcoming online demo and deployment collaboration.</span></li>
             <li><span class="ack-entity"><a href="https://github.com/humanfia/humanize2" target="_blank" rel="noopener noreferrer">Humanize</a> + <a href="https://github.com/mit-han-lab/kernel-design-agents" target="_blank" rel="noopener noreferrer">KDA</a></span><span class="ack-role">Operator and fused-kernel optimization on top of Sol-Engine.</span></li>
-            <li><a class="ack-entity" href="https://github.com/ModelTC/LightX2V" target="_blank" rel="noopener noreferrer">LightX2V</a><span class="ack-role">Open MiniMax-H3 Turbo LoRAs and the Ref2AV workflow used by Sol-Engine.</span></li>
+            <li><a class="ack-entity" href="https://github.com/ModelTC/LightX2V" target="_blank" rel="noopener noreferrer">LightX2V</a><span class="ack-role">Open MiniMax-H3 Turbo LoRAs and the Ref2VA workflow used by Sol-Engine.</span></li>
             <li><a class="ack-entity" href="https://openvdn.github.io/h3-vda-blog.html" target="_blank" rel="noopener noreferrer">Video DeltaNet · UC Berkeley</a><span class="ack-role">Complementary hybrid-attention work for MiniMax-H3.</span></li>
             <li><a class="ack-entity" href="https://haoailab.com/blogs/fasth3-preview/" target="_blank" rel="noopener noreferrer">Hao AI Lab @ UCSD</a><span class="ack-role">Default FastH3 four-step model.</span></li>
           </ul>
@@ -5603,7 +5580,7 @@
             <li><span>03</span><div><a href="https://huggingface.co/MiniMaxAI/MiniMax-H3" target="_blank" rel="noopener noreferrer">MiniMax-H3</a> — official open-weight base model.</div></li>
             <li><span>04</span><div><a href="https://haoailab.com/blogs/fasth3-preview/" target="_blank" rel="noopener noreferrer">FastH3 Preview v1</a> — the default four-step MiniMax-H3 model used by Sol-H3.</div></li>
             <li><span>05</span><div><a href="https://openvdn.github.io/h3-vda-blog.html" target="_blank" rel="noopener noreferrer">Video DeltaNet on MiniMax H3</a> — a complementary near-lossless hybrid-attention approach.</div></li>
-            <li><span>06</span><div><a href="https://github.com/ModelTC/LightX2V" target="_blank" rel="noopener noreferrer">LightX2V</a> — open MiniMax-H3 Turbo LoRAs and Ref2AV support used by Sol-Engine.</div></li>
+            <li><span>06</span><div><a href="https://github.com/ModelTC/LightX2V" target="_blank" rel="noopener noreferrer">LightX2V</a> — open MiniMax-H3 Turbo LoRAs and Ref2VA support used by Sol-Engine.</div></li>
           </ol>
         </div>
       </div>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -1217,14 +1217,15 @@
     }
     .latency-fill {
       display: block;
-      width: max(var(--w), 8px);
+      width: var(--w);
+      min-width: 1px;
       height: 100%;
       border-radius: inherit;
     }
     .latency-fill.base { background: var(--dim); }
     .latency-fill.sol {
       position: relative;
-      overflow: hidden;
+      overflow: visible;
       background: linear-gradient(90deg, var(--green), var(--acid));
       box-shadow: 0 0 18px rgba(167, 255, 46, .16);
     }
@@ -1233,8 +1234,9 @@
       position: absolute;
       top: 0;
       right: 0;
-      width: 2px;
+      width: 3px;
       height: 100%;
+      transform: translateX(50%);
       background: rgba(255, 255, 255, .9);
       box-shadow: 0 0 10px 2px rgba(255, 255, 255, .45);
     }
@@ -4521,7 +4523,7 @@
               <div class="console-label">Measured request latency · lower is better</div>
               <h3 id="latency-title">Latency by output length.</h3>
             </div>
-            <span class="latency-direction">Each model · 15s = full bar</span>
+            <span class="latency-direction">Shared scale · 0–131.647 s</span>
           </header>
 
           <div class="latency-groups">
@@ -4535,7 +4537,7 @@
                 </div>
                 <div class="latency-row ours">
                   <span class="latency-model">Sol-H3<small>Ours</small></span>
-                  <span class="latency-track" aria-hidden="true"><i class="latency-fill sol" style="--w: 25.215%"></i></span>
+                  <span class="latency-track" aria-hidden="true"><i class="latency-fill sol" style="--w: 1.268%"></i></span>
                   <strong class="latency-number">1.669 s</strong>
                 </div>
                 <small class="latency-settings">124 frames · 1344×768 · 24 FPS · native audio · 8× NVIDIA B300</small>
@@ -4553,7 +4555,7 @@
                 </div>
                 <div class="latency-row ours">
                   <span class="latency-model">Sol-H3<small>Ours</small></span>
-                  <span class="latency-track" aria-hidden="true"><i class="latency-fill sol" style="--w: 56.474%"></i></span>
+                  <span class="latency-track" aria-hidden="true"><i class="latency-fill sol" style="--w: 2.839%"></i></span>
                   <strong class="latency-number">3.738 s</strong>
                 </div>
                 <small class="latency-settings">243 frames · 1344×768 · 24 FPS · native audio · 8× NVIDIA B300</small>
@@ -4571,7 +4573,7 @@
                 </div>
                 <div class="latency-row ours">
                   <span class="latency-model">Sol-H3<small>Ours</small></span>
-                  <span class="latency-track" aria-hidden="true"><i class="latency-fill sol" style="--w: 100%"></i></span>
+                  <span class="latency-track" aria-hidden="true"><i class="latency-fill sol" style="--w: 5.028%"></i></span>
                   <strong class="latency-number">6.619 s</strong>
                 </div>
                 <small class="latency-settings">362 frames · 1344×768 · 24 FPS · native audio · 8× NVIDIA B300</small>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -4953,6 +4953,10 @@
             Sol-Engine × Sol-Attn unifies sparse attention, fused kernels, fast multi-GPU communication, parallel video decoding, and other serving optimizations in one runtime.
           </p>
           <div class="hero-actions">
+            <a class="button" href="https://nvlabs.github.io/Sana/Sol-Engine/" target="_blank" rel="noopener noreferrer">
+              Sol-Engine page
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M7 17 17 7M8 7h9v9"/></svg>
+            </a>
             <a class="button primary" href="https://github.com/NVlabs/Sana/tree/sol-engine/models/minimax_h3/Sol-H3" target="_blank" rel="noopener noreferrer">
               Sol-H3 code
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M7 17 17 7M8 7h9v9"/></svg>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -1292,7 +1292,7 @@
       --w: 100%;
     }
 
-    .matrix-measure > span {
+    .matrix-measure > span:first-child {
       grid-column: 1;
       grid-row: 1;
     }
@@ -1318,14 +1318,14 @@
       border-top: 1px solid var(--line);
     }
 
-    .matrix-measure > span {
+    .matrix-measure > span:first-child {
       color: var(--fog);
       font-size: 14px;
       font-weight: 760;
       line-height: 1.2;
     }
 
-    .matrix-measure > span small {
+    .matrix-measure > span:first-child small {
       display: block;
       margin-top: 4px;
       color: var(--dim);
@@ -1354,10 +1354,10 @@
       font-weight: 650;
     }
 
-    .matrix-measure.ours > span,
+    .matrix-measure.ours > span:first-child,
     .matrix-measure.ours > strong { color: var(--acid); }
 
-    .matrix-speedup {
+    .matrix-measure > .matrix-speedup {
       position: relative;
       z-index: 2;
       grid-column: 2;

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -4953,16 +4953,16 @@
             Sol-Engine × Sol-Attn unifies sparse attention, fused kernels, fast multi-GPU communication, parallel video decoding, and other serving optimizations in one runtime.
           </p>
           <div class="hero-actions">
-            <a class="button" href="https://nvlabs.github.io/Sana/Sol-Engine/" target="_blank" rel="noopener noreferrer">
-              Sol-Engine page
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M7 17 17 7M8 7h9v9"/></svg>
-            </a>
             <a class="button primary" href="https://github.com/NVlabs/Sana/tree/sol-engine/models/minimax_h3/Sol-H3" target="_blank" rel="noopener noreferrer">
               Sol-H3 code
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M7 17 17 7M8 7h9v9"/></svg>
             </a>
+            <a class="button" href="https://nvlabs.github.io/Sana/Sol-Engine/" target="_blank" rel="noopener noreferrer">
+              Sol-Engine page
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M7 17 17 7M8 7h9v9"/></svg>
+            </a>
             <a class="button" href="#real-time-interactive">
-              Real-time interactive
+              Real-time demo
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M12 5v14M6 13l6 6 6-6"/></svg>
             </a>
           </div>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -1302,8 +1302,8 @@
       grid-column: 2;
       grid-row: 1;
       width: 100%;
-      height: clamp(18px, 1.2vw, 22px);
-      border-radius: 4px;
+      height: clamp(18px, 1.4vw, 26px);
+      border-radius: 5px;
       background: linear-gradient(90deg, var(--dim) 0 var(--w), var(--line) var(--w) 100%);
     }
 

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -4916,16 +4916,12 @@
             Sol-Engine × Sol-Attn unifies sparse attention, fused kernels, fast multi-GPU communication, parallel video decoding, and more in one runtime.
           </p>
           <div class="hero-actions">
-            <a class="button primary" href="#performance">
-              See the numbers
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M12 5v14M6 13l6 6 6-6"/></svg>
-            </a>
-            <a class="button" href="https://github.com/NVlabs/Sana/tree/sol-engine/models/minimax_h3" target="_blank" rel="noopener noreferrer">
-              MiniMax-H3 code
+            <a class="button primary" href="https://github.com/NVlabs/Sana/tree/sol-engine/models/minimax_h3" target="_blank" rel="noopener noreferrer">
+              Sol-H3 code
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M7 17 17 7M8 7h9v9"/></svg>
             </a>
             <a class="button" href="#future">
-              Reactor demo · coming soon
+              Demo · coming soon
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M12 5v14M6 13l6 6 6-6"/></svg>
             </a>
           </div>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -6,17 +6,17 @@
   <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#050705">
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f5f8f1">
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
-  <meta name="description" content="Sol-H3 accelerates MiniMax-H3 video generation with native audio, delivering up to 19.89× speedup over Base H3 across 5s, 10s, and 15s outputs on 8× NVIDIA B300 GPUs.">
+  <meta name="description" content="Sol-H3 accelerates MiniMax-H3 video generation with native audio, delivering up to 15.05× speedup over Base H3 across 5s, 10s, and 15s outputs on 8× NVIDIA B300 GPUs.">
   <meta property="og:type" content="article">
   <meta property="og:title" content="Sol-H3: Speed-of-Light MiniMax-H3 on an 8× NVIDIA B300 Blackwell System">
-  <meta property="og:description" content="Five seconds of world in 1.669 seconds. Across 5s–15s outputs, Sol-H3 is 18.38×–19.89× faster than Base H3 on 8× NVIDIA B300 GPUs.">
+  <meta property="og:description" content="Five seconds of world in 1.653 seconds. Across 5s–15s outputs, Sol-H3 is 11.04×–15.05× faster than Base H3 on 8× NVIDIA B300 GPUs.">
   <meta property="og:url" content="https://nvlabs.github.io/Sana/Sol-Engine/Sol-H3/">
   <meta property="og:image" content="https://nvlabs.github.io/Sana/Sol-Engine/Sol-H3/sol-h3-poster.jpg">
   <meta property="og:image:width" content="1280">
   <meta property="og:image:height" content="732">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Sol-H3: Speed-of-Light MiniMax-H3 on an 8× NVIDIA B300 Blackwell System">
-  <meta name="twitter:description" content="Five seconds of world in 1.669 seconds. Sol-H3 delivers up to 19.89× speedup over Base H3 on 8× NVIDIA B300 GPUs.">
+  <meta name="twitter:description" content="Five seconds of world in 1.653 seconds. Sol-H3 delivers up to 15.05× speedup over Base H3 on 8× NVIDIA B300 GPUs.">
   <meta name="twitter:image" content="https://nvlabs.github.io/Sana/Sol-Engine/Sol-H3/sol-h3-poster.jpg">
   <link rel="canonical" href="https://nvlabs.github.io/Sana/Sol-Engine/Sol-H3/">
   <title>Sol-H3: Speed-of-Light MiniMax-H3 on an 8× NVIDIA B300 Blackwell System | NVIDIA Research</title>
@@ -1290,12 +1290,8 @@
       white-space: nowrap;
     }
 
-    .matrix-measure.pending > span { color: var(--acid); }
-    .matrix-measure.pending > strong {
-      color: var(--dim);
-      font-size: 22px;
-      letter-spacing: 0;
-    }
+    .matrix-measure.ours > span,
+    .matrix-measure.ours > strong { color: var(--acid); }
 
     .matrix-speedup {
       display: flex;
@@ -1312,7 +1308,7 @@
       text-transform: uppercase;
     }
 
-    .matrix-speedup strong { color: var(--dim); }
+    .matrix-speedup strong { color: var(--acid); font-size: 15px; }
 
     @media (max-width: 900px) {
       .latency-head {
@@ -4835,9 +4831,9 @@
           <div class="hero-affiliation" aria-label="NVIDIA Research, Efficient AI Team and Singapore Lab">
             <span>NVIDIA Research, Efficient AI Team &amp; Singapore Lab.</span>
           </div>
-          <div class="hero-result-title" aria-label="Five seconds of world inferred in 1.669 seconds">
+          <div class="hero-result-title" aria-label="Five seconds of world inferred in 1.653 seconds">
             <span class="hero-result-line"><strong>5s</strong><small>of world.</small></span>
-            <span class="hero-result-line accent"><strong>1.669s</strong><small>to infer.</small></span>
+            <span class="hero-result-line accent"><strong>1.653s</strong><small>to infer.</small></span>
           </div>
           <p class="hero-dek">
             <strong>Sol-H3 generates MiniMax-H3 video with native audio faster than playback on one 8× NVIDIA B300 system.</strong>
@@ -4929,7 +4925,7 @@
             <span class="section-kicker">Scaling benchmark · 1 / 4 / 8× NVIDIA B300</span>
             <h2 id="performance-title">Latency across GPU counts.</h2>
           </div>
-          <p>Base H3 dense measurements establish the scaling baseline. Matching Sol-H3 latencies and speedups will fill the reserved slots.</p>
+          <p>Read every 5s, 10s, and 15s result across 1, 4, and 8 B300 GPUs at a glance.</p>
         </header>
 
         <article class="benchmark-console benchmark-console-wide reveal" aria-labelledby="latency-title" aria-describedby="benchmark-method">
@@ -4938,12 +4934,12 @@
               <div class="console-label">Measured request latency · lower is better</div>
               <h3 id="latency-title">Video length × GPU count.</h3>
             </div>
-            <span class="latency-direction">Base H3 measured · Sol-H3 pending</span>
+            <span class="latency-direction">Base H3 Dense · Sol-H3</span>
           </header>
 
           <div class="matrix-shell">
             <table class="latency-matrix">
-              <caption class="matrix-caption">Base H3 and pending Sol-H3 latency for 5, 10, and 15 second outputs on one, four, and eight NVIDIA B300 GPUs.</caption>
+              <caption class="matrix-caption">Measured Base H3 Dense and Sol-H3 latency for 5, 10, and 15 second outputs on one, four, and eight NVIDIA B300 GPUs.</caption>
               <thead>
                 <tr>
                   <th scope="col">GPU count</th>
@@ -4957,23 +4953,23 @@
                   <th scope="row"><span class="matrix-gpu"><strong>1×</strong><small>NVIDIA B300</small></span></th>
                   <td data-duration="5s · 124 frames">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>159.547 s</strong></div>
-                      <div class="matrix-measure pending"><span>Sol-H3<small>Ours</small></span><strong aria-label="Pending">—</strong></div>
-                      <div class="matrix-speedup"><span>Speedup</span><strong aria-label="Pending">—</strong></div>
+                      <div class="matrix-measure base"><span>Base H3<small>Dense · 49× DiT</small></span><strong>129.898 s</strong></div>
+                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours · Dense · 4× DiT</small></span><strong>13.745 s</strong></div>
+                      <div class="matrix-speedup"><span>vs Base H3</span><strong>9.45×</strong></div>
                     </div>
                   </td>
                   <td data-duration="10s · 243 frames">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>442.533 s</strong></div>
-                      <div class="matrix-measure pending"><span>Sol-H3<small>Ours</small></span><strong aria-label="Pending">—</strong></div>
-                      <div class="matrix-speedup"><span>Speedup</span><strong aria-label="Pending">—</strong></div>
+                      <div class="matrix-measure base"><span>Base H3<small>Dense · 49× DiT</small></span><strong>376.942 s</strong></div>
+                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours · Dense · 4× DiT</small></span><strong>37.813 s</strong></div>
+                      <div class="matrix-speedup"><span>vs Base H3</span><strong>9.97×</strong></div>
                     </div>
                   </td>
                   <td data-duration="15s · 362 frames">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>847.486 s</strong></div>
-                      <div class="matrix-measure pending"><span>Sol-H3<small>Ours</small></span><strong aria-label="Pending">—</strong></div>
-                      <div class="matrix-speedup"><span>Speedup</span><strong aria-label="Pending">—</strong></div>
+                      <div class="matrix-measure base"><span>Base H3<small>Dense · 49× DiT</small></span><strong>746.885 s</strong></div>
+                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours · Dense · 4× DiT</small></span><strong>52.260 s</strong></div>
+                      <div class="matrix-speedup"><span>vs Base H3</span><strong>14.29×</strong></div>
                     </div>
                   </td>
                 </tr>
@@ -4981,23 +4977,23 @@
                   <th scope="row"><span class="matrix-gpu"><strong>4×</strong><small>NVIDIA B300</small></span></th>
                   <td data-duration="5s · 124 frames">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>48.552 s</strong></div>
-                      <div class="matrix-measure pending"><span>Sol-H3<small>Ours</small></span><strong aria-label="Pending">—</strong></div>
-                      <div class="matrix-speedup"><span>Speedup</span><strong aria-label="Pending">—</strong></div>
+                      <div class="matrix-measure base"><span>Base H3<small>Dense · 49× DiT</small></span><strong>35.328 s</strong></div>
+                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours · SOL · 4× DiT</small></span><strong>2.918 s</strong></div>
+                      <div class="matrix-speedup"><span>vs Base H3</span><strong>12.11×</strong></div>
                     </div>
                   </td>
                   <td data-duration="10s · 243 frames">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>127.461 s</strong></div>
-                      <div class="matrix-measure pending"><span>Sol-H3<small>Ours</small></span><strong aria-label="Pending">—</strong></div>
-                      <div class="matrix-speedup"><span>Speedup</span><strong aria-label="Pending">—</strong></div>
+                      <div class="matrix-measure base"><span>Base H3<small>Dense · 49× DiT</small></span><strong>100.440 s</strong></div>
+                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours · SOL · 4× DiT</small></span><strong>6.993 s</strong></div>
+                      <div class="matrix-speedup"><span>vs Base H3</span><strong>14.36×</strong></div>
                     </div>
                   </td>
                   <td data-duration="15s · 362 frames">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>237.171 s</strong></div>
-                      <div class="matrix-measure pending"><span>Sol-H3<small>Ours</small></span><strong aria-label="Pending">—</strong></div>
-                      <div class="matrix-speedup"><span>Speedup</span><strong aria-label="Pending">—</strong></div>
+                      <div class="matrix-measure base"><span>Base H3<small>Dense · 49× DiT</small></span><strong>194.930 s</strong></div>
+                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours · SOL · 4× DiT</small></span><strong>12.542 s</strong></div>
+                      <div class="matrix-speedup"><span>vs Base H3</span><strong>15.54×</strong></div>
                     </div>
                   </td>
                 </tr>
@@ -5005,23 +5001,23 @@
                   <th scope="row"><span class="matrix-gpu"><strong>8×</strong><small>NVIDIA B300</small></span></th>
                   <td data-duration="5s · 124 frames">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>30.673 s</strong></div>
-                      <div class="matrix-measure pending"><span>Sol-H3<small>Ours</small></span><strong aria-label="Pending">—</strong></div>
-                      <div class="matrix-speedup"><span>Speedup</span><strong aria-label="Pending">—</strong></div>
+                      <div class="matrix-measure base"><span>Base H3<small>Dense · 49× DiT</small></span><strong>18.250 s</strong></div>
+                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours · SOL · 4× DiT</small></span><strong>1.653 s</strong></div>
+                      <div class="matrix-speedup"><span>vs Base H3</span><strong>11.04×</strong></div>
                     </div>
                   </td>
                   <td data-duration="10s · 243 frames">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>71.316 s</strong></div>
-                      <div class="matrix-measure pending"><span>Sol-H3<small>Ours</small></span><strong aria-label="Pending">—</strong></div>
-                      <div class="matrix-speedup"><span>Speedup</span><strong aria-label="Pending">—</strong></div>
+                      <div class="matrix-measure base"><span>Base H3<small>Dense · 49× DiT</small></span><strong>50.660 s</strong></div>
+                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours · SOL · 4× DiT</small></span><strong>3.732 s</strong></div>
+                      <div class="matrix-speedup"><span>vs Base H3</span><strong>13.57×</strong></div>
                     </div>
                   </td>
                   <td data-duration="15s · 362 frames">
                     <div class="matrix-cell">
-                      <div class="matrix-measure base"><span>Base H3<small>Dense</small></span><strong>131.647 s</strong></div>
-                      <div class="matrix-measure pending"><span>Sol-H3<small>Ours</small></span><strong aria-label="Pending">—</strong></div>
-                      <div class="matrix-speedup"><span>Speedup</span><strong aria-label="Pending">—</strong></div>
+                      <div class="matrix-measure base"><span>Base H3<small>Dense · 49× DiT</small></span><strong>99.513 s</strong></div>
+                      <div class="matrix-measure ours"><span>Sol-H3<small>Ours · SOL · 4× DiT</small></span><strong>6.612 s</strong></div>
+                      <div class="matrix-speedup"><span>vs Base H3</span><strong>15.05×</strong></div>
                     </div>
                   </td>
                 </tr>
@@ -5032,7 +5028,7 @@
 
         <div class="method-note reveal">
           <strong>Measured scope</strong>
-          <span id="benchmark-method">Base H3 uses dense attention at 1344×768 and 24 FPS with native audio: 124 / 243 / 362 frames for 5s / 10s / 15s outputs. Timing includes prompt encoding, diffusion denoising, VAE video decoding, and native audio; final MP4 encoding is excluded. Sol-H3 cells remain placeholders until matching 1× / 4× / 8× B300 runs are complete.</span>
+          <span id="benchmark-method">All runs use 1344×768, 24 FPS, the same prompt and seed 20260903, and reference-free T2V with stereo audio. Base H3 uses dense attention with a 50-point schedule and 49 DiT evaluations; Sol-H3 uses four DiT evaluations, with Dense attention on 1× B300 and SOL on 4× / 8× B300. Each value is the median of three measured runs after one warmup. Timing includes text encoding, DiT, and video/audio VAE decoding; model loading, compilation warmup, and final MP4 encoding are not timed.</span>
         </div>
       </div>
     </section>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -3259,6 +3259,26 @@
       line-height: 1.5;
     }
 
+    .detail-evidence .evidence-link {
+      display: inline-block;
+      margin-top: 9px;
+      color: var(--fog);
+      font-family: "SFMono-Regular", Consolas, monospace;
+      font-size: 13px;
+      font-weight: 800;
+      letter-spacing: .035em;
+      text-decoration: underline;
+      text-decoration-color: var(--line-bright);
+      text-underline-offset: 4px;
+      transition: color .2s ease, text-decoration-color .2s ease;
+    }
+
+    .detail-evidence .evidence-link:hover,
+    .detail-evidence .evidence-link:focus-visible {
+      color: var(--mint);
+      text-decoration-color: currentColor;
+    }
+
     @media (max-width: 1120px) {
       .detail-row { grid-template-columns: 110px minmax(0, 1fr); }
       .detail-evidence { grid-column: 2; }
@@ -5205,7 +5225,7 @@
                   <div class="detail-part"><span>Why it is faster</span><p>Sol-Attn consumes each score tile inside online softmax: the same tile selects exact blocks and updates the approximation. It writes no separate router output, full score map, or routing-index tensor, and needs no retraining.</p></div>
                 </div>
               </div>
-              <aside class="detail-evidence"><span>Video generation</span><strong>Up to 2.1×</strong><small>end-to-end in the Sol-Attn evaluation · versus dense attention</small></aside>
+              <aside class="detail-evidence"><span>Video generation</span><strong>Up to 2.1×</strong><small>end-to-end versus each model's dense-attention pipeline</small><a class="evidence-link" href="https://nvlabs.github.io/Sana/Sol-Attn/#comparison" target="_blank" rel="noopener noreferrer">Models &amp; settings ↗</a></aside>
             </article>
           </div>
 

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -4741,7 +4741,7 @@
             <article class="core-block attention">
               <span>02 · Sol-Attn</span>
               <h3>Select the blocks that matter.</h3>
-              <p>Sol-Attn scores key-value blocks as attention runs. Query-dependent thresholding selects the important blocks for sparse attention, while proxy scores cheaply account for the rest—all in one pass.</p>
+              <p>Sol-Attn forms lightweight proxy scores from pooled query and key blocks. A threshold computed for each query block can keep a different number of important key/value blocks. <strong>Selected blocks run exact attention; skipped blocks retain a low-cost approximation from the same score tile.</strong> Because every decision comes from the live Q/K/V tensors, Sol-Attn needs no learned router or retraining.</p>
             </article>
           </div>
         </div>
@@ -4763,35 +4763,35 @@
           <article class="tech-card span-6 reveal" data-index="01">
             <span class="tech-label">GPU kernels</span>
             <h3>Fuse repeated operations</h3>
-            <p>Sol-H3 combines normalization, conditioning, position encoding (RoPE), and MLP work into fewer GPU kernels. This moves about 178 GB less intermediate data per GPU for a full model evaluation. <a href="https://github.com/humanfia/humanize2" target="_blank" rel="noopener noreferrer">Humanize</a> and <a href="https://github.com/mit-han-lab/kernel-design-agents" target="_blank" rel="noopener noreferrer">KDA</a> supported this tuning.</p>
+            <p>RMSNorm/modulation, partial RoPE, and SwiGLU do little math relative to the wide tensors they repeatedly move, so memory bandwidth—not compute—is the limit. Sol-H3 fuses neighboring work and keeps intermediates in registers instead of writing them to HBM and reading them back. Across 50 blocks, this avoids about 178 GB of intermediate traffic per GPU per evaluation. <a href="https://github.com/humanfia/humanize2" target="_blank" rel="noopener noreferrer">Humanize</a> and <a href="https://github.com/mit-han-lab/kernel-design-agents" target="_blank" rel="noopener noreferrer">KDA</a> supported this tuning.</p>
             <div class="tech-viz fusion-viz" aria-hidden="true"><div class="fusion-stack"><i></i><i></i><i></i><i></i></div><span class="fusion-arrow"></span><span class="fusion-one"></span></div>
           </article>
 
           <article class="tech-card span-6 reveal" data-index="02">
             <span class="tech-label">Multi-GPU communication</span>
             <h3>Faster 8-GPU data exchange</h3>
-            <p>Sol-H3 fuses packing, the all-to-all GPU exchange, unpacking, and merging. It sends query/key/value (QKV) data in INT8 and returns attention results in FP8, reducing communication among eight GPUs.</p>
+            <p>Ulysses swaps sequence shards for head shards before attention, then reverses the exchange. Sol-H3 writes Q/K/V straight into the all-to-all send layout and decodes the return into merged-head order, removing intermediate copies. Its fastest profile scales every 32 QKV values separately and clamps E4M3 FP8 returns to ±448, nearly halving the payload; BF16 remains available for higher fidelity.</p>
             <div class="tech-viz ulysses-viz" aria-hidden="true"><i style="--n:0"></i><i style="--n:1"></i><i style="--n:2"></i><i style="--n:3"></i><i style="--n:4"></i><i style="--n:5"></i><i style="--n:6"></i><i style="--n:7"></i></div>
           </article>
 
           <article class="tech-card span-6 reveal" data-index="03">
             <span class="tech-label">Sparse-attention setup</span>
             <h3>Fuse the setup work</h3>
-            <p>Sol-H3 builds key/value summaries, block metadata, and the attention mask together. This cuts setup from 1.206 to 0.285 ms (−76.4%). Reusing query summaries also avoids about 400 small GPU launches per request.</p>
+            <p>For Sol-H3’s cuDNN block-sparse path, setup means building key centroids, value sums, query thresholds, the selection mask, and compact block metadata. One kernel builds each key/value summary pair; the threshold kernel returns the pooled query for reuse; another applies the routing rules and packs the metadata. Together this cuts setup from 1.206 to 0.285 ms (−76.4%).</p>
             <div class="tech-viz route-viz" aria-hidden="true"><span><i style="--w:100%"></i><b>1.206 ms</b></span><span><i style="--w:24%"></i><b>0.285 ms</b></span></div>
           </article>
 
           <article class="tech-card span-6 reveal" data-index="04">
             <span class="tech-label">Sol-Attn</span>
             <h3>Sparsify on the fly</h3>
-            <p>Sol-Attn selects important attention blocks while computing attention, avoiding a separate routing pass and extra score-map or block-list storage in GPU memory.</p>
+            <p>Inside its native kernel, Sol-Attn scans pooled-key chunks within online softmax. The same token-to-block score tile selects important blocks and approximates the rest; only selected blocks enter the exact inner loop. Scores are consumed immediately, so no separate routing pass, full proxy map, or routing-index tensor is written to GPU memory.</p>
             <div class="tech-viz prefix-viz" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i><i></i></div>
           </article>
 
           <article class="tech-card span-6 reveal" data-index="05">
             <span class="tech-label">Video decoding</span>
             <h3>Parallel VAE decoding</h3>
-            <p>Eight GPUs decode video tiles in parallel, reducing latency from 7.55 to 1.16 s. Batching each clip’s tiles lowers it again to 0.602 s; the fastest profile batches VAE work globally.</p>
+            <p>At 5s, the VAE splits seven temporal clips into 28 equal spatial tiles each. Tile parallelism spreads them across eight GPUs (7.55 → 1.16 s); per-clip batching combines each GPU’s four tiles into one decoder call (→ 0.602 s). Global mode balances all 196 tiles and runs decode/gather once instead of seven; it remains optional because the larger compiled batch causes a small measured rounding drift.</p>
             <div class="tech-viz tile-viz" aria-hidden="true">
               <i style="--p:1"></i><i style="--p:2"></i><i style="--p:3"></i><i style="--p:4"></i><i style="--p:5"></i><i style="--p:6"></i><i style="--p:7"></i>
               <i style="--p:2"></i><i style="--p:3"></i><i style="--p:4"></i><i style="--p:5"></i><i style="--p:6"></i><i style="--p:7"></i><i style="--p:8"></i>
@@ -4803,7 +4803,7 @@
           <article class="tech-card span-6 reveal" data-index="06">
             <span class="tech-label">Conditioning</span>
             <h3>Precompute AdaLN</h3>
-            <p>Sol-H3 computes adaptive layer-normalization (AdaLN) values before denoising and reuses them from a cache at every step. This frees about 24 GB per GPU and avoids roughly 26 GB of GPU-memory reads per step without changing the output.</p>
+            <p>Sol-H3 computes adaptive layer-normalization (AdaLN) values before denoising and reuses them from a cache at every step. This frees about 24 GB per GPU and avoids roughly 26 GB of GPU-memory reads per step without changing the output. Direct table lookup also removes about 400 tiny GPU indexing launches from a four-step request.</p>
             <div class="tech-viz adaln-viz" aria-hidden="true">
               <i style="--p:1"></i><i style="--p:5"></i><i style="--p:2"></i><i style="--p:7"></i><i style="--p:4"></i><i style="--p:9"></i>
               <i style="--p:6"></i><i style="--p:2"></i><i style="--p:8"></i><i style="--p:3"></i><i style="--p:10"></i><i style="--p:4"></i>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -4900,7 +4900,7 @@
         <svg class="theme-icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z"/></svg>
         <svg class="theme-icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.42 1.42M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.42-1.42M17.66 6.34l1.41-1.41"/></svg>
       </button>
-      <a class="nav-cta" href="https://github.com/NVlabs/Sana/tree/sol-engine/models/minimax_h3" target="_blank" rel="noopener noreferrer">
+      <a class="nav-cta" href="https://github.com/NVlabs/Sana/tree/sol-engine/models/minimax_h3/Sol-H3" target="_blank" rel="noopener noreferrer">
         <span>Codebase</span>
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M7 17 17 7M8 7h9v9"/></svg>
       </a>
@@ -4929,7 +4929,7 @@
             Sol-Engine × Sol-Attn unifies sparse attention, fused kernels, fast multi-GPU communication, parallel video decoding, and more in one runtime.
           </p>
           <div class="hero-actions">
-            <a class="button primary" href="https://github.com/NVlabs/Sana/tree/sol-engine/models/minimax_h3" target="_blank" rel="noopener noreferrer">
+            <a class="button primary" href="https://github.com/NVlabs/Sana/tree/sol-engine/models/minimax_h3/Sol-H3" target="_blank" rel="noopener noreferrer">
               Sol-H3 code
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M7 17 17 7M8 7h9v9"/></svg>
             </a>

--- a/Sol-Engine/Sol-H3/index.html
+++ b/Sol-Engine/Sol-H3/index.html
@@ -1302,8 +1302,8 @@
       grid-column: 2;
       grid-row: 1;
       width: 100%;
-      height: 18px;
-      border-radius: 3px;
+      height: clamp(18px, 1.2vw, 22px);
+      border-radius: 4px;
       background: linear-gradient(90deg, var(--dim) 0 var(--w), var(--line) var(--w) 100%);
     }
 
@@ -1365,7 +1365,7 @@
       display: inline-flex;
       align-items: center;
       gap: 7px;
-      margin-top: 7px;
+      margin-top: 2px;
       margin-left: max(calc(var(--w) - 8px), 0px);
       pointer-events: none;
     }


### PR DESCRIPTION
## Summary

- publish the final Sol-H3 project page for MiniMax-H3 video and native-audio inference
- compare Base H3 Dense with Sol-H3 at 5s, 10s, and 15s across 8×, 4×, and 1× NVIDIA B300, using proportional bars and exact displayed medians
- explain the Sol-Engine × Sol-Attn stack through six concise mechanism/evidence pairs
- include 13 curated Sol-H3 videos, collaborator credits, citations, responsive navigation, light/dark themes, and a favicon
- harden the page for mobile layouts, no-JavaScript rendering, and media loading failures

## Measured benchmark

| GPUs | Output | Base H3 | Sol-H3 | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| 8× B300 | 5s | 18.250 s | 1.653 s | 11.04× |
| 8× B300 | 10s | 50.660 s | 3.732 s | 13.57× |
| 8× B300 | 15s | 99.513 s | 6.612 s | 15.05× |
| 4× B300 | 5s | 35.328 s | 2.918 s | 12.11× |
| 4× B300 | 10s | 100.440 s | 6.993 s | 14.36× |
| 4× B300 | 15s | 194.930 s | 12.542 s | 15.54× |
| 1× B300 | 5s | 129.898 s | 13.745 s | 9.45× |
| 1× B300 | 10s | 376.942 s | 37.813 s | 9.97× |
| 1× B300 | 15s | 746.885 s | 52.260 s | 14.29× |

The bars compare complete profiles: Base H3 uses 50 scheduler points (49 DiT forwards), while Sol-H3 uses four DiT forwards. Sol-H3 uses Dense attention on 1× B300 and SOL with INT8 QKV / FP8 output transport on 4× / 8× B300. Values are medians of three measured runs after one warmup.

## Validation

- `xmllint` passes on the final HTML
- all 5 inline scripts parse successfully
- all 72 IDs are unique; internal anchors and ARIA references resolve
- all 9 bar widths and displayed speedups recompute correctly from the shown latencies
- all local assets resolve; the prompt manifest contains exactly 13 unique, publication-complete examples
- no-JavaScript content remains visible and gallery load/error states are user-visible

## Merge order

Merge #484 before this PR so the post-merge **Sol-H3 Code** link resolves on the `sol-engine` branch.

## CI note

The repository `pre-commit` job exits before checking changed files because the `page` branch does not contain `.pre-commit-config.yaml` (`InvalidConfigError`). The page-specific validations above pass locally.
