### PR TITLE
feat(MiniMax-H3): add fused MXFP8 compute

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ support a wider range of models.
 
 ## 📰 News
 
-- **[2026/09/07]** 🔥 **Sol-H3** \[[Code](models/minimax_h3/Sol-H3/) | [Project Page](https://nvlabs.github.io/Sana/Sol-Engine/Sol-H3/)\] — production MiniMax-H3 inference for T2V, I2V, and Ref2VA with synchronized audio. On 8× NVIDIA B300 at 1344×768, warm T2V latency is **1.653 / 3.732 / 6.612 s** for 5 / 10 / 15-second outputs.
+- **[2026/09/08]** 🔥 **Sol-H3** \[[Code](models/minimax_h3/Sol-H3/) | [Project Page](https://nvlabs.github.io/Sana/Sol-Engine/Sol-H3/)\] — production MiniMax-H3 inference for T2V, I2V, and Ref2VA with synchronized audio. On 8× NVIDIA B300 at 1344×768, warm BF16-compute T2V latency is **1.653 / 3.732 / 6.612 s** for 5 / 10 / 15-second outputs; optional fused MXFP8 compute reaches **1.472 s** for the 5-second case.
 - **[2026/08/22]** 🔥 **MiniMax-H3 Super Acceleration** [[Code](models/minimax_h3/super_acceleration/) | [Blog](https://nvlabs.github.io/Sana/Sol-Engine/H3-Super-Acceleration/)] — combines a 4-step MiniMax-H3 draft with a 3-step LTX-2.5 refinement pass, reaching **22.2×** end-to-end speedup for 5-second 768p video and **27.7×** for 10-second video on one NVIDIA GB200.
 - **[2026/08/17]** 🔥 **[MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3) on GeForce RTX 4090** \[[Code](models/minimax_h3/)\] — reaches **4.44×** end-to-end on RTX 4090. Sol-Attn now includes an optimized SM89 CuTe DSL kernel for RTX 4090.
 - **[2026/08/13]** 🔥 **[LTX-2.5](https://github.com/Lightricks/LTX-2) across B200, GeForce RTX 5090, and DGX Spark** \[[Code](models/ltx25/) | [Blog](https://nvlabs.github.io/Sana/Sol-Engine/LTX25/)\] — reaches up to **4.68×** multi-step pipeline speedup and **1.90×** distilled pipeline speedup.

--- a/models/minimax_h3/Sol-H3/README.md
+++ b/models/minimax_h3/Sol-H3/README.md
@@ -9,8 +9,11 @@ Production inference package for MiniMax-H3 with synchronized video and audio ou
 - 5, 10, or 15 second output
 - 1, 2, 4, or 8 GPUs; validated on 8x NVIDIA B300
 - Fast SOL/BSA profile enabled by default
+- Optional fused MXFP8 DiT compute on SM100-family GPUs
 
-The default profile prioritizes speed and uses lossy acceleration. Select `dense` when a dense-attention reference is required or when running on one GPU.
+The default profile prioritizes speed and uses lossy attention/communication acceleration. Select
+`dense` when a dense-attention reference is required or when running on one GPU. DiT linear compute
+remains BF16 unless `--compute-quant mxfp8` is selected.
 
 ## Validation
 
@@ -50,18 +53,32 @@ Checkpoint loading, warmup/compilation, and MP4 encoding are excluded.
 | Diffusers | 8 | 30.673 s | 71.316 s | 131.647 s |
 
 #### Detailed Settings
-  Diffusers: Base BF16 dense model with 50 scheduler points (49 DiT forwards); Ulysses on 4/8 GPUs.
-  
-  SGLang: Base BF16 dense model with 50 scheduler points (49 DiT forwards); Ulysses on 4/8 GPUs.
-  
-  Sol-H3: FastH3 adapter with five scheduler points (four DiT forwards); dense attention on 1 GPU and
-SOL/BSA on 4/8 GPUs. The multi-GPU profile uses INT8 QKV transport, FP8 output transport, and
-parallel video/audio VAE decoding.
 
-  The official and SGLang rows are directly comparable. Sol-H3 uses a distilled four-forward adapter
+- Diffusers: Base BF16 dense model with 50 scheduler points (49 DiT forwards); Ulysses on 4/8 GPUs.
+- SGLang: Base BF16 dense model with 50 scheduler points (49 DiT forwards); Ulysses on 4/8 GPUs.
+- Sol-H3: FastH3 adapter with five scheduler points (four DiT forwards) and BF16 compute; dense
+  attention on 1 GPU and SOL/BSA on 4/8 GPUs. The multi-GPU profile uses INT8 QKV transport, FP8
+  output transport, and parallel video/audio VAE decoding.
+
+The official and SGLang rows are directly comparable. Sol-H3 uses a distilled four-forward adapter
 and its multi-GPU profile uses approximate SOL/BSA attention, so the difference from either
 49-forward baseline is not a runtime-only speedup.
 
+### Optional MXFP8 compute
+
+On 8x B300, fused MXFP8 attention and FFN linears in transformer blocks 2 through 46 reduce the
+same 5-second T2V request from 1.655 s to 1.472 s. The selected linear weights occupy 16.65 GiB per
+rank instead of 32.30 GiB.
+
+| Compute | 5 s / 124f median | Latency change | Selected weight storage |
+|---|---:|---:|---:|
+| BF16 | 1.655 s | baseline | 32.30 GiB |
+| MXFP8 | **1.472 s** | **-11.1%** | **16.65 GiB** |
+
+This is a lossy mode: the generated video measured 13.82 dB decoded-RGB PSNR and 0.540 SSIM against
+the BF16 output from the same prompt and seed. One-GPU dense and eight-GPU SOL/BSA T2V paths passed
+end-to-end checks on B300; the table above is the eight-GPU A/B result. T2V, I2V, and Ref2VA all use
+the same task-selected transformer integration. Enable it explicitly with `--compute-quant mxfp8`.
 
 ## Setup
 
@@ -135,6 +152,7 @@ Main options:
 | `--task` | `t2v`, `i2v`, or `ref2va` |
 | `--duration` | `5`, `10`, or `15` |
 | `--attention-backend` | `sol_bsa` (default), `sol`, or `dense` |
+| `--compute-quant` | `none` (BF16 default) or `mxfp8` (lossy, SM100-family only) |
 | `--prompt` / `--prompt-file` | Prompt text or UTF-8 prompt file |
 | `--image` | First frame for `i2v` |
 | `--reference` | Ordered `image:PATH`, `video:PATH`, or `audio:PATH` for `ref2va`; repeat as needed |

--- a/models/minimax_h3/Sol-H3/README.md
+++ b/models/minimax_h3/Sol-H3/README.md
@@ -78,7 +78,9 @@ rank instead of 32.30 GiB.
 This is a lossy mode: the generated video measured 13.82 dB decoded-RGB PSNR and 0.540 SSIM against
 the BF16 output from the same prompt and seed. One-GPU dense and eight-GPU SOL/BSA T2V paths passed
 end-to-end checks on B300; the table above is the eight-GPU A/B result. T2V, I2V, and Ref2VA all use
-the same task-selected transformer integration. Enable it explicitly with `--compute-quant mxfp8`.
+the same task-selected transformer integration. With FP8 multi-GPU output transport, quantized
+blocks reuse the received E4M3 data directly for the output projection instead of converting it to
+BF16 and immediately back to MXFP8. Enable the mode explicitly with `--compute-quant mxfp8`.
 
 ## Setup
 

--- a/models/minimax_h3/Sol-H3/SOURCE_SNAPSHOT.json
+++ b/models/minimax_h3/Sol-H3/SOURCE_SNAPSHOT.json
@@ -19,10 +19,15 @@
       "repo": "https://github.com/NVIDIA/cudnn-frontend.git",
       "revision": "29106622617bfd9031a53099a6fbbc5e74a474e9",
       "role": "cuDNN frontend and block-sparse attention API"
+    },
+    {
+      "repo": "https://github.com/yujincheng08/minimax-h3-deploy.git",
+      "revision": "bae3c859d7ffa4adcf860f4fef57456d52cb168c",
+      "role": "fused MXFP8 DiT compute path"
     }
   ],
   "validation": {
-    "date": "2026-09-07",
+    "date": "2026-09-08",
     "hardware": "NVIDIA B300 SXM6 AC",
     "kernel_architectures": {
       "validated": ["SM103 (B300) via the SM100-family backend"],
@@ -95,6 +100,27 @@
         "prompt_tokens": 26,
         "repeats": 3,
         "warm_pipeline_median_seconds": [2.191815, 4.347622, 5.946699]
+      }
+    },
+    "mxfp8_compute": {
+      "status": "B300 T2V end-to-end validated; latency A/B measured on 8 GPUs",
+      "hardware": "NVIDIA B300 SXM6 AC",
+      "validated_gpu_counts": [1, 8],
+      "benchmark_gpu_count": 8,
+      "transformer_blocks": [2, 46],
+      "quantized_blocks": 45,
+      "quantized_linears": 180,
+      "original_weight_storage_bytes_per_rank": 34681651200,
+      "quantized_weight_storage_bytes_per_rank": 17882726400,
+      "t2v_5s": {
+        "frame_count": 124,
+        "warmups": 1,
+        "repeats": 3,
+        "bf16_median_seconds": 1.655326,
+        "mxfp8_median_seconds": 1.471855,
+        "latency_reduction_percent": 11.0837,
+        "decoded_rgb_psnr_db_vs_bf16": 13.820436,
+        "ffmpeg_yuv420p_ssim_vs_bf16": 0.53996
       }
     },
     "timing_includes": ["text encoding", "DiT denoising", "video/audio VAE decoding"],

--- a/models/minimax_h3/Sol-H3/h3_runtime/comm_quant.py
+++ b/models/minimax_h3/Sol-H3/h3_runtime/comm_quant.py
@@ -28,6 +28,9 @@ QKV_DECODE_WARPS = 4
 OUTPUT_RECORDS_PER_PROGRAM = 16
 
 
+_MXFP8_UNIT_SCALES: dict[tuple[int, int, int], torch.Tensor] = {}
+
+
 @triton.jit
 def _encode_output_kernel(input_ptr, packet_ptr, records,
                           RECORDS: tl.constexpr, PACKET: tl.constexpr,
@@ -137,7 +140,7 @@ def _encode_output_fp8_kernel(input_ptr, packet_ptr, elements, BLOCK: tl.constex
 
 
 @triton.jit
-def _decode_merge_output_fp8_kernel(
+def _merge_output_fp8_kernel(
     packet_ptr,
     output_ptr,
     elements,
@@ -146,6 +149,7 @@ def _decode_merge_output_fp8_kernel(
     inner,
     BLOCK: tl.constexpr,
 ):
+    """Merge rank-major E4M3 bytes into a row-major BF16 or E4M3 output."""
     offsets = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
     valid = offsets < elements
     tail = offsets % inner
@@ -187,7 +191,7 @@ def dequantize_merge_output_fp8(packet: torch.Tensor, world: int) -> torch.Tenso
     )
     if output.numel():
         block = 1024
-        _decode_merge_output_fp8_kernel[(triton.cdiv(output.numel(), block),)](
+        _merge_output_fp8_kernel[(triton.cdiv(output.numel(), block),)](
             packet,
             output,
             output.numel(),
@@ -198,6 +202,71 @@ def dequantize_merge_output_fp8(packet: torch.Tensor, world: int) -> torch.Tenso
             num_warps=8,
         )
     return output
+
+
+def merge_output_fp8_as_mxfp8(
+    packet: torch.Tensor,
+    world: int,
+    shape: tuple[int, ...],
+):
+    """Reuse raw FP8 transport bytes as an MXFP8 linear activation.
+
+    The return collective already carries E4M3 values.  With an E8M0 scale of
+    one they are also a valid block-scaled MXFP8 activation, so the only work
+    left is the rank-major to row-major head merge.  This removes both the
+    intermediate BF16 tensor and the following dynamic MXFP8 quantization.
+    """
+    if packet.dtype != torch.uint8 or not packet.is_cuda or not packet.is_contiguous():
+        raise ValueError("FP8 output transport requires contiguous CUDA uint8 packets")
+    if packet.ndim != 4 or packet.shape[0] != world or packet.shape[-1] != VECTOR:
+        raise ValueError(
+            f"expected [{world}, rows, heads_local, {VECTOR}], got {tuple(packet.shape)}"
+        )
+    _, rows, heads_local, _ = packet.shape
+    k = world * heads_local * VECTOR
+    leading_rows = 1
+    for dimension in shape[:-1]:
+        leading_rows *= dimension
+    if not shape or shape[-1] != k or leading_rows != rows:
+        raise ValueError(
+            f"MXFP8 output shape {shape} does not match merged packet shape ({rows}, {k})"
+        )
+
+    from .mxfp8 import MXActivation
+
+    quantized = torch.empty(
+        (rows, k), dtype=torch.float8_e4m3fn, device=packet.device
+    )
+    if quantized.numel():
+        block = 1024
+        # The same merge kernel stores either BF16 or E4M3 according to the
+        # output pointer type. An E4M3 destination preserves the packet bytes.
+        _merge_output_fp8_kernel[(triton.cdiv(quantized.numel(), block),)](
+            packet,
+            quantized,
+            quantized.numel(),
+            world,
+            rows,
+            heads_local * VECTOR,
+            BLOCK=block,
+            num_warps=8,
+        )
+
+    num_groups = k // 32
+    scale_numel = triton.cdiv(rows, 128) * 128 * triton.cdiv(num_groups, 4) * 4
+    device_index = packet.device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    scale_key = (device_index, rows, k)
+    scale = _MXFP8_UNIT_SCALES.get(scale_key)
+    if scale is None:
+        # E8M0 byte 127 is 2**0. The buffer is immutable and shape-stable for a
+        # resident request, so allocate/fill it only once instead of per block.
+        scale = torch.full(
+            (scale_numel,), 127, dtype=torch.uint8, device=packet.device
+        )
+        _MXFP8_UNIT_SCALES[scale_key] = scale
+    return MXActivation(quantized, scale, shape, torch.bfloat16)
 
 
 @triton.jit

--- a/models/minimax_h3/Sol-H3/h3_runtime/compute_quant.py
+++ b/models/minimax_h3/Sol-H3/h3_runtime/compute_quant.py
@@ -1,0 +1,153 @@
+"""Install the mixed-precision compute profile on MiniMax-H3 transformer blocks."""
+
+from __future__ import annotations
+
+import gc
+from dataclasses import dataclass
+
+import torch
+
+
+FIRST_QUANTIZED_BLOCK = 2
+LAST_QUANTIZED_BLOCK = 46
+COMPUTE_QUANT_MODES = {"none", "mxfp8"}
+
+
+@dataclass(frozen=True)
+class ComputeQuantizationReport:
+    mode: str
+    first_block: int
+    last_block: int
+    quantized_blocks: int
+    quantized_linears: int
+    original_bytes: int
+    quantized_bytes: int
+
+
+def validate_platform() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("MXFP8 compute quantization requires CUDA")
+    capability = torch.cuda.get_device_capability()
+    if capability[0] != 10:
+        raise RuntimeError(
+            "MXFP8 compute quantization is enabled only for the validated "
+            f"SM100-family path; detected SM{capability[0]}{capability[1]}"
+        )
+    required = ("ScalingType", "SwizzleType", "scaled_mm")
+    missing = [name for name in required if not hasattr(torch.nn.functional, name)]
+    if not hasattr(torch, "float8_e8m0fnu"):
+        missing.append("torch.float8_e8m0fnu")
+    if missing:
+        raise RuntimeError(
+            "the installed PyTorch build lacks MXFP8 support: " + ", ".join(missing)
+        )
+
+
+def _make_fused_qkv_source(attention) -> torch.nn.Linear:
+    projections = (attention.to_q, attention.to_k, attention.to_v)
+    if any(projection.bias is not None for projection in projections):
+        raise ValueError("MiniMax-H3 attention projections must be bias-free")
+    source = torch.nn.Linear(
+        projections[0].in_features,
+        sum(projection.out_features for projection in projections),
+        bias=False,
+        device="meta",
+    )
+    source.weight = torch.nn.Parameter(
+        torch.cat([projection.weight for projection in projections], dim=0),
+        requires_grad=False,
+    )
+    return source
+
+
+def _replace(parent, attribute: str | int, replacement: torch.nn.Module) -> None:
+    if isinstance(attribute, int):
+        parent[attribute] = replacement
+    else:
+        setattr(parent, attribute, replacement)
+
+
+def install(
+    transformer,
+    *,
+    first_block: int = FIRST_QUANTIZED_BLOCK,
+    last_block: int = LAST_QUANTIZED_BLOCK,
+) -> ComputeQuantizationReport:
+    """Replace attention and FFN linears in inclusive ``[first_block, last_block]``.
+
+    Boundary blocks, AdaLN projections, refiners, VAE, and text/audio encoders stay
+    in BF16.  Installation is intentionally one-way for a resident worker: keeping
+    BF16 rollback tensors would defeat the memory reduction.
+    """
+    validate_platform()
+    blocks = transformer.transformer_blocks
+    if not (0 <= first_block <= last_block < len(blocks)):
+        raise ValueError(
+            f"invalid MXFP8 block range [{first_block}, {last_block}] for "
+            f"{len(blocks)} transformer blocks"
+        )
+
+    from .mxfp8 import MXFP8Linear
+
+    original_bytes = 0
+    quantized_bytes = 0
+    quantized_linears = 0
+
+    for index in range(first_block, last_block + 1):
+        block = blocks[index]
+        attention = block.attn
+
+        if getattr(attention, "fused_projections", False):
+            qkv_source = attention.to_qkv
+        else:
+            qkv_source = _make_fused_qkv_source(attention)
+        qkv = MXFP8Linear(qkv_source)
+        original_bytes += qkv_source.weight.numel() * qkv_source.weight.element_size()
+        quantized_bytes += qkv.storage_bytes
+        quantized_linears += 1
+        attention.to_qkv = qkv
+        attention.fused_projections = True
+        for name in ("to_q", "to_k", "to_v"):
+            if hasattr(attention, name):
+                delattr(attention, name)
+        del qkv_source, qkv
+
+        candidates = (
+            (attention.to_out, 0),
+            (block.ff.net[0], "proj"),
+            (block.ff.net, 2),
+        )
+        for parent, attribute in candidates:
+            source = (
+                parent[attribute]
+                if isinstance(attribute, int)
+                else getattr(parent, attribute)
+            )
+            quantized = MXFP8Linear(source)
+            original_bytes += source.weight.numel() * source.weight.element_size()
+            quantized_bytes += quantized.storage_bytes
+            quantized_linears += 1
+            _replace(parent, attribute, quantized)
+            del source, quantized
+
+    gc.collect()
+    torch.cuda.empty_cache()
+    return ComputeQuantizationReport(
+        mode="mxfp8",
+        first_block=first_block,
+        last_block=last_block,
+        quantized_blocks=last_block - first_block + 1,
+        quantized_linears=quantized_linears,
+        original_bytes=original_bytes,
+        quantized_bytes=quantized_bytes,
+    )
+
+
+__all__ = [
+    "COMPUTE_QUANT_MODES",
+    "ComputeQuantizationReport",
+    "FIRST_QUANTIZED_BLOCK",
+    "LAST_QUANTIZED_BLOCK",
+    "install",
+    "validate_platform",
+]

--- a/models/minimax_h3/Sol-H3/h3_runtime/engine.py
+++ b/models/minimax_h3/Sol-H3/h3_runtime/engine.py
@@ -13,6 +13,8 @@ import torch
 import torch.distributed as dist
 from PIL import Image, ImageOps
 
+from .compute_quant import COMPUTE_QUANT_MODES
+
 
 WIDTH = 1344
 HEIGHT = 768
@@ -117,6 +119,7 @@ class MiniMaxH3Inference:
         attention_backend: str = "sol_bsa",
         task: str = "t2v",
         reference_image_resize_mode: str = "match",
+        compute_quant: str = "none",
     ) -> None:
         self._owns_process_group = False
         local_rank = int(os.environ.get("LOCAL_RANK", "0"))
@@ -151,9 +154,17 @@ class MiniMaxH3Inference:
                 "reference_image_resize_mode must be one of "
                 f"{sorted(REFERENCE_IMAGE_RESIZE_MODES)}"
             )
+        compute_quant = compute_quant.lower()
+        if compute_quant not in COMPUTE_QUANT_MODES:
+            raise ValueError(f"compute_quant must be one of {sorted(COMPUTE_QUANT_MODES)}")
+        if compute_quant == "mxfp8":
+            from .compute_quant import validate_platform
+
+            validate_platform()
         self.task = task
         self.attention_backend = attention_backend
         self.reference_image_resize_mode = reference_image_resize_mode
+        self.compute_quant = compute_quant
 
         from diffusers import ComponentsManager, ModularPipeline
 
@@ -228,6 +239,21 @@ class MiniMaxH3Inference:
 
         from . import adaln, fusion_install, sparse_attention, ulysses, vae_parallel
 
+        self.compute_quant_report = None
+        if compute_quant == "mxfp8":
+            from .compute_quant import install as install_compute_quant
+
+            self.compute_quant_report = install_compute_quant(self.transformer)
+            if self.rank == 0:
+                report = self.compute_quant_report
+                ratio = report.original_bytes / report.quantized_bytes
+                print(
+                    "MXFP8 compute: "
+                    f"blocks={report.first_block}..{report.last_block}, "
+                    f"linears={report.quantized_linears}, "
+                    f"storage={report.original_bytes / 2**30:.2f}->"
+                    f"{report.quantized_bytes / 2**30:.2f} GiB ({ratio:.2f}x)"
+                )
         fusion_install.install(self.transformer)
         adaln.enable_adaln_precompute(
             self.transformer,

--- a/models/minimax_h3/Sol-H3/h3_runtime/fusion_install.py
+++ b/models/minimax_h3/Sol-H3/h3_runtime/fusion_install.py
@@ -26,19 +26,54 @@ from .fusions import (
 )
 
 
+def _accepts_mxfp8(module) -> bool:
+    return getattr(module, "layout", None) == "MXFP8Swizzled"
+
+
 def _patch_blocks(transformer, use_modulate: bool, use_swiglu: bool) -> list:
     """Replace the block forward with one that fuses its elementwise chain."""
+    uses_mxfp8 = any(
+        _accepts_mxfp8(getattr(block.attn, "to_qkv", None))
+        or _accepts_mxfp8(block.ff.net[0].proj)
+        or _accepts_mxfp8(block.ff.net[2])
+        for block in transformer.transformer_blocks
+    )
+    if uses_mxfp8:
+        from .mxfp8 import (
+            fused_residual_gate_rmsnorm_modulate_mxfp8,
+            fused_rmsnorm_modulate_mxfp8,
+            fused_swiglu_mxfp8,
+        )
+
     restores = []
     for block in transformer.transformer_blocks:
         original = block.forward
         restores.append((block, "forward", original))
+        attention_mxfp8 = _accepts_mxfp8(getattr(block.attn, "to_qkv", None))
+        ffn_up_mxfp8 = _accepts_mxfp8(block.ff.net[0].proj)
+        ffn_down_mxfp8 = _accepts_mxfp8(block.ff.net[2])
 
-        def make(block=block, original=original):
+        def make(
+            block=block,
+            original=original,
+            attention_mxfp8=attention_mxfp8,
+            ffn_up_mxfp8=ffn_up_mxfp8,
+            ffn_down_mxfp8=ffn_down_mxfp8,
+        ):
             def forward(hidden_states, temb, adaln_indices, rotary_emb, attention_mask=None):
                 shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = block.adaln_proj(temb)
                 eps = block.norm1.eps
 
-                if use_modulate:
+                if use_modulate and attention_mxfp8:
+                    normed = fused_rmsnorm_modulate_mxfp8(
+                        hidden_states,
+                        block.norm1.weight,
+                        scale_msa,
+                        shift_msa,
+                        adaln_indices,
+                        eps,
+                    )
+                elif use_modulate:
                     normed = fused_rmsnorm_modulate(
                         hidden_states, block.norm1.weight, scale_msa, shift_msa, adaln_indices, eps)
                 else:
@@ -48,7 +83,18 @@ def _patch_blocks(transformer, use_modulate: bool, use_swiglu: bool) -> list:
 
                 attn_output = block.attn(normed, rotary_emb, attention_mask)
 
-                if use_modulate:
+                if use_modulate and ffn_up_mxfp8:
+                    hidden_states, normed = fused_residual_gate_rmsnorm_modulate_mxfp8(
+                        hidden_states,
+                        attn_output,
+                        gate_msa,
+                        block.norm2.weight,
+                        scale_mlp,
+                        shift_mlp,
+                        adaln_indices,
+                        block.norm2.eps,
+                    )
+                elif use_modulate:
                     # One kernel produces both the new residual and the next half's normalized,
                     # modulated input, which is where most of the saving in this fusion sits.
                     hidden_states, normed = fused_residual_gate_rmsnorm_modulate(
@@ -62,7 +108,10 @@ def _patch_blocks(transformer, use_modulate: bool, use_swiglu: bool) -> list:
 
                 if use_swiglu:
                     swiglu, _, out_proj = block.ff.net
-                    ff_output = out_proj(fused_swiglu(swiglu.proj(normed)))
+                    activation = (
+                        fused_swiglu_mxfp8 if ffn_down_mxfp8 else fused_swiglu
+                    )
+                    ff_output = out_proj(activation(swiglu.proj(normed)))
                 else:
                     ff_output = block.ff(normed)
 

--- a/models/minimax_h3/Sol-H3/h3_runtime/mxfp8.py
+++ b/models/minimax_h3/Sol-H3/h3_runtime/mxfp8.py
@@ -1,0 +1,534 @@
+"""Blackwell MXFP8 linear layers with fused activation producers.
+
+Weights and activations use E4M3 values with one E8M0 scale per 32 values
+along K in cuBLASLt's ``SWIZZLE_32_4_4`` layout.  The producer variants emit
+that representation directly from the existing RMSNorm/modulation and SwiGLU
+kernels, avoiding an intermediate BF16 activation.
+
+The swizzled layout and exponent selection follow the Apache-2.0 MiniMax-H3
+implementation at yujincheng08/minimax-h3-deploy@bae3c859.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from torch.nn.functional import ScalingType, SwizzleType, scaled_mm
+
+
+_E4M3 = torch.float8_e4m3fn
+_E8M0 = torch.float8_e8m0fnu
+
+
+@triton.jit
+def _mx_e8m0_from_amax(amax):
+    bits = amax.to(tl.int32, bitcast=True)
+    e0 = ((bits >> 23) & 0xFF) - 135
+    threshold = (((e0 + 135) << 23) | 0x600000).to(tl.float32, bitcast=True)
+    exponent = e0 + (amax > threshold).to(tl.int32)
+    exponent = tl.maximum(exponent, -127)
+    inverse = ((127 - exponent) << 23).to(tl.float32, bitcast=True)
+    return exponent + 127, inverse
+
+
+@triton.jit
+def _mx_scale_offsets(row, column, column_blocks):
+    tile = (row // 128) * column_blocks + (column // 4)
+    return (
+        tile * 512
+        + (row % 32) * 16
+        + ((row % 128) // 32) * 4
+        + (column % 4)
+    )
+
+
+@triton.jit
+def _store_mx_row(
+    quantized_ptr,
+    scale_ptr,
+    value,
+    row,
+    columns,
+    mask,
+    num_columns,
+    num_groups,
+    column_blocks,
+    BLOCK: tl.constexpr,
+):
+    values = tl.reshape(value, [BLOCK // 32, 32])
+    amax = tl.max(tl.abs(values), axis=1)
+    scale_byte, inverse = _mx_e8m0_from_amax(amax)
+    quantized = tl.reshape(values * inverse[:, None], [BLOCK])
+    tl.store(
+        quantized_ptr + row.to(tl.int64) * num_columns + columns,
+        quantized.to(tl.float8e4nv),
+        mask=mask,
+    )
+    group = tl.arange(0, BLOCK // 32)
+    tl.store(
+        scale_ptr + _mx_scale_offsets(row, group, column_blocks),
+        scale_byte.to(tl.uint8),
+        mask=group < num_groups,
+    )
+
+
+@triton.jit
+def _mxfp8_quant_kernel(
+    input_ptr,
+    quantized_ptr,
+    scale_ptr,
+    rows,
+    k,
+    num_groups,
+    column_blocks,
+    input_row_stride,
+    BLOCK_ROWS: tl.constexpr,
+    GROUPS: tl.constexpr,
+):
+    row_program = tl.program_id(0)
+    group_program = tl.program_id(1)
+    row = row_program * BLOCK_ROWS + tl.arange(0, BLOCK_ROWS)
+    group = group_program * GROUPS + tl.arange(0, GROUPS)
+    column = group_program * (GROUPS * 32) + tl.arange(0, GROUPS * 32)
+    row_mask = row < rows
+    mask = row_mask[:, None] & (column < k)[None, :]
+    value = tl.load(
+        input_ptr
+        + row[:, None].to(tl.int64) * input_row_stride
+        + column[None, :],
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    values = tl.reshape(value, [BLOCK_ROWS, GROUPS, 32])
+    amax = tl.max(tl.abs(values), axis=2)
+    scale_byte, inverse = _mx_e8m0_from_amax(amax)
+    quantized = tl.reshape(values * inverse[:, :, None], [BLOCK_ROWS, GROUPS * 32])
+    tl.store(
+        quantized_ptr + row[:, None].to(tl.int64) * k + column[None, :],
+        quantized.to(tl.float8e4nv),
+        mask=mask,
+    )
+    scale_mask = row_mask[:, None] & (group < num_groups)[None, :]
+    tl.store(
+        scale_ptr + _mx_scale_offsets(row[:, None], group[None, :], column_blocks),
+        scale_byte.to(tl.uint8),
+        mask=scale_mask,
+    )
+
+
+@triton.jit
+def _rmsnorm_modulate_mxfp8_kernel(
+    quantized_ptr,
+    output_scale_ptr,
+    input_ptr,
+    weight_ptr,
+    scale_ptr,
+    shift_ptr,
+    index_ptr,
+    num_columns,
+    num_indices,
+    num_groups,
+    column_blocks,
+    eps,
+    row_stride,
+    table_row_stride,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    columns = tl.arange(0, BLOCK)
+    mask = columns < num_columns
+    offset = row.to(tl.int64) * row_stride + columns
+    table_offset = tl.load(index_ptr + (row % num_indices)) * table_row_stride + columns
+
+    value = tl.load(input_ptr + offset, mask=mask, other=0.0).to(tl.float32)
+    variance = tl.sum(value * value, axis=0) / num_columns
+    normed = value * tl.math.rsqrt(variance + eps)
+    weight = tl.load(weight_ptr + columns, mask=mask, other=0.0).to(tl.float32)
+    normed = normed * weight
+
+    scale = tl.load(scale_ptr + table_offset, mask=mask, other=0.0).to(tl.float32)
+    shift = tl.load(shift_ptr + table_offset, mask=mask, other=0.0).to(tl.float32)
+    output = (normed * (1.0 + scale) + shift).to(tl.bfloat16).to(tl.float32)
+    _store_mx_row(
+        quantized_ptr,
+        output_scale_ptr,
+        output,
+        row,
+        columns,
+        mask,
+        num_columns,
+        num_groups,
+        column_blocks,
+        BLOCK,
+    )
+
+
+@triton.jit
+def _residual_gate_rmsnorm_modulate_mxfp8_kernel(
+    hidden_output_ptr,
+    quantized_ptr,
+    output_scale_ptr,
+    residual_ptr,
+    branch_ptr,
+    weight_ptr,
+    gate_ptr,
+    scale_ptr,
+    shift_ptr,
+    index_ptr,
+    num_columns,
+    num_indices,
+    num_groups,
+    column_blocks,
+    eps,
+    row_stride,
+    table_row_stride,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    columns = tl.arange(0, BLOCK)
+    mask = columns < num_columns
+    offset = row.to(tl.int64) * row_stride + columns
+    table_row = tl.load(index_ptr + (row % num_indices))
+    table_offset = table_row * table_row_stride + columns
+
+    residual = tl.load(residual_ptr + offset, mask=mask, other=0.0).to(tl.float32)
+    branch = tl.load(branch_ptr + offset, mask=mask, other=0.0).to(tl.float32)
+    gate = tl.load(gate_ptr + table_offset, mask=mask, other=0.0).to(tl.float32)
+
+    hidden = residual + gate * branch
+    tl.store(
+        hidden_output_ptr + offset,
+        hidden.to(hidden_output_ptr.dtype.element_ty),
+        mask=mask,
+    )
+
+    variance = tl.sum(hidden * hidden, axis=0) / num_columns
+    normed = hidden * tl.math.rsqrt(variance + eps)
+    weight = tl.load(weight_ptr + columns, mask=mask, other=0.0).to(tl.float32)
+    normed = normed * weight
+
+    scale = tl.load(scale_ptr + table_offset, mask=mask, other=0.0).to(tl.float32)
+    shift = tl.load(shift_ptr + table_offset, mask=mask, other=0.0).to(tl.float32)
+    output = (normed * (1.0 + scale) + shift).to(tl.bfloat16).to(tl.float32)
+    _store_mx_row(
+        quantized_ptr,
+        output_scale_ptr,
+        output,
+        row,
+        columns,
+        mask,
+        num_columns,
+        num_groups,
+        column_blocks,
+        BLOCK,
+    )
+
+
+@triton.jit
+def _swiglu_mxfp8_kernel(
+    quantized_ptr,
+    output_scale_ptr,
+    input_ptr,
+    num_columns,
+    num_groups,
+    column_blocks,
+    input_row_stride,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    columns = tl.arange(0, BLOCK)
+    mask = columns < num_columns
+    base = input_ptr + row.to(tl.int64) * input_row_stride
+    value = tl.load(base + columns, mask=mask, other=0.0).to(tl.float32)
+    gate = tl.load(base + num_columns + columns, mask=mask, other=0.0).to(tl.float32)
+    output = (value * (gate * tl.sigmoid(gate))).to(tl.bfloat16).to(tl.float32)
+    _store_mx_row(
+        quantized_ptr,
+        output_scale_ptr,
+        output,
+        row,
+        columns,
+        mask,
+        num_columns,
+        num_groups,
+        column_blocks,
+        BLOCK,
+    )
+
+
+class MXActivation:
+    """Prequantized activation accepted by :class:`MXFP8Linear`."""
+
+    __slots__ = ("q", "s", "shape", "dtype", "device")
+
+    def __init__(
+        self,
+        quantized: torch.Tensor,
+        scale: torch.Tensor,
+        shape: tuple[int, ...],
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> None:
+        self.q = quantized
+        self.s = scale
+        self.shape = tuple(shape)
+        self.dtype = dtype
+        self.device = quantized.device
+
+    def dequantize(self) -> torch.Tensor:
+        return mxfp8_dequantize_swizzled(self.q, self.s).to(self.dtype).view(self.shape)
+
+
+def _scale_numel(rows: int, k: int) -> int:
+    num_groups = k // 32
+    return -(-rows // 128) * 128 * (-(-num_groups // 4) * 4)
+
+
+def _allocate(rows: int, k: int, device) -> tuple[torch.Tensor, torch.Tensor]:
+    quantized = torch.empty(rows, k, dtype=_E4M3, device=device)
+    scale = torch.zeros(_scale_numel(rows, k), dtype=torch.uint8, device=device)
+    return quantized, scale
+
+
+def _check_k(k: int) -> None:
+    if k % 32 != 0:
+        raise ValueError(f"MXFP8 requires K % 32 == 0, got K={k}")
+
+
+def _next_power_of_two(value: int) -> int:
+    return 1 << (value - 1).bit_length()
+
+
+def _warps_for(block: int) -> int:
+    if block >= 8192:
+        return 16
+    if block >= 2048:
+        return 8
+    return 4
+
+
+def _row_addressable(table: torch.Tensor) -> torch.Tensor:
+    return table if table.stride(-1) == 1 else table.contiguous()
+
+
+def mxfp8_quantize_swizzled(input_: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a row-major BF16 ``[rows, K]`` tensor for block-scaled GEMM."""
+    if input_.ndim != 2 or input_.stride(-1) != 1 or input_.dtype != torch.bfloat16:
+        raise ValueError("expected a row-major BF16 [rows, K] tensor")
+    rows, k = input_.shape
+    _check_k(k)
+    quantized, scale = _allocate(rows, k, input_.device)
+    if rows == 0:
+        return quantized, scale
+    num_groups = k // 32
+    column_blocks = -(-num_groups // 4)
+    block_rows, groups = 32, 8
+    grid = (triton.cdiv(rows, block_rows), triton.cdiv(num_groups, groups))
+    _mxfp8_quant_kernel[grid](
+        input_,
+        quantized,
+        scale,
+        rows,
+        k,
+        num_groups,
+        column_blocks,
+        input_.stride(0),
+        BLOCK_ROWS=block_rows,
+        GROUPS=groups,
+        num_warps=4,
+    )
+    return quantized, scale
+
+
+def mxfp8_dequantize_swizzled(
+    quantized: torch.Tensor, scale: torch.Tensor
+) -> torch.Tensor:
+    """Slow FP32 inverse used by validation tests."""
+    rows, k = quantized.shape
+    num_groups = k // 32
+    column_blocks = -(-num_groups // 4)
+    row = torch.arange(rows, device=quantized.device)[:, None]
+    column = torch.arange(num_groups, device=quantized.device)[None, :]
+    tile = (row // 128) * column_blocks + (column // 4)
+    offsets = (
+        tile * 512
+        + (row % 32) * 16
+        + ((row % 128) // 32) * 4
+        + (column % 4)
+    )
+    exponent = scale[offsets].to(torch.int32) - 127
+    factors = torch.ldexp(torch.ones((), device=quantized.device), exponent)
+    values = quantized.to(torch.float32).view(rows, num_groups, 32)
+    return (values * factors[:, :, None].to(torch.float32)).view(rows, k)
+
+
+def fused_rmsnorm_modulate_mxfp8(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor,
+    index: torch.Tensor,
+    eps: float,
+) -> MXActivation:
+    """Fused RMSNorm/modulation producing MXFP8 instead of BF16."""
+    columns = input_.shape[-1]
+    _check_k(columns)
+    flat = input_.reshape(-1, columns).contiguous()
+    rows = flat.shape[0]
+    scale = _row_addressable(scale)
+    shift = _row_addressable(shift)
+    quantized, output_scale = _allocate(rows, columns, input_.device)
+    num_groups = columns // 32
+    block = _next_power_of_two(columns)
+    _rmsnorm_modulate_mxfp8_kernel[(rows,)](
+        quantized,
+        output_scale,
+        flat,
+        weight,
+        scale,
+        shift,
+        index,
+        columns,
+        index.numel(),
+        num_groups,
+        -(-num_groups // 4),
+        eps,
+        flat.stride(0),
+        scale.stride(0),
+        BLOCK=block,
+        num_warps=_warps_for(block),
+    )
+    return MXActivation(quantized, output_scale, input_.shape, input_.dtype)
+
+
+def fused_residual_gate_rmsnorm_modulate_mxfp8(
+    residual: torch.Tensor,
+    branch: torch.Tensor,
+    gate: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor,
+    index: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, MXActivation]:
+    """Fused residual update producing a BF16 residual and MXFP8 norm output."""
+    columns = residual.shape[-1]
+    _check_k(columns)
+    residual_flat = residual.reshape(-1, columns).contiguous()
+    branch_flat = branch.reshape(-1, columns).contiguous()
+    rows = residual_flat.shape[0]
+    gate = _row_addressable(gate)
+    scale = _row_addressable(scale)
+    shift = _row_addressable(shift)
+    hidden = torch.empty_like(residual_flat)
+    quantized, output_scale = _allocate(rows, columns, residual.device)
+    num_groups = columns // 32
+    block = _next_power_of_two(columns)
+    _residual_gate_rmsnorm_modulate_mxfp8_kernel[(rows,)](
+        hidden,
+        quantized,
+        output_scale,
+        residual_flat,
+        branch_flat,
+        weight,
+        gate,
+        scale,
+        shift,
+        index,
+        columns,
+        index.numel(),
+        num_groups,
+        -(-num_groups // 4),
+        eps,
+        residual_flat.stride(0),
+        gate.stride(0),
+        BLOCK=block,
+        num_warps=_warps_for(block),
+    )
+    activation = MXActivation(
+        quantized, output_scale, residual.shape, residual.dtype
+    )
+    return hidden.view_as(residual), activation
+
+
+def fused_swiglu_mxfp8(input_: torch.Tensor) -> MXActivation:
+    """Fused SwiGLU producing MXFP8 instead of BF16."""
+    columns = input_.shape[-1] // 2
+    _check_k(columns)
+    flat = input_.reshape(-1, input_.shape[-1]).contiguous()
+    rows = flat.shape[0]
+    quantized, output_scale = _allocate(rows, columns, input_.device)
+    num_groups = columns // 32
+    block = _next_power_of_two(columns)
+    _swiglu_mxfp8_kernel[(rows,)](
+        quantized,
+        output_scale,
+        flat,
+        columns,
+        num_groups,
+        -(-num_groups // 4),
+        flat.stride(0),
+        BLOCK=block,
+        num_warps=_warps_for(block),
+    )
+    return MXActivation(
+        quantized, output_scale, (*input_.shape[:-1], columns), input_.dtype
+    )
+
+
+class MXFP8Linear(torch.nn.Module):
+    """Bias-free block-scaled MXFP8 linear for Blackwell GPUs."""
+
+    layout = "MXFP8Swizzled"
+
+    def __init__(self, source: torch.nn.Linear) -> None:
+        super().__init__()
+        if source.bias is not None:
+            raise ValueError("MXFP8Linear expects a bias-free linear")
+        weight = source.weight.detach()
+        if weight.dtype != torch.bfloat16:
+            raise ValueError(f"MXFP8Linear expects a BF16 weight, got {weight.dtype}")
+        if weight.shape[0] % 16 != 0:
+            raise ValueError(f"MXFP8 requires N % 16 == 0, got N={weight.shape[0]}")
+        self.in_features = source.in_features
+        self.out_features = source.out_features
+        quantized, scale = mxfp8_quantize_swizzled(weight.contiguous())
+        self.register_buffer("weight", quantized, persistent=False)
+        self.register_buffer("weight_scale", scale.view(_E8M0), persistent=False)
+
+    @property
+    def storage_bytes(self) -> int:
+        return self.weight.nbytes + self.weight_scale.nbytes
+
+    def forward(self, input_: torch.Tensor | MXActivation) -> torch.Tensor:
+        if isinstance(input_, MXActivation):
+            activation = input_.q
+            scale = input_.s
+            leading_shape = input_.shape[:-1]
+        else:
+            leading_shape = input_.shape[:-1]
+            flat = input_.reshape(-1, input_.shape[-1]).contiguous()
+            activation, scale = mxfp8_quantize_swizzled(flat)
+        output = scaled_mm(
+            activation,
+            self.weight.t(),
+            scale_a=scale.view(_E8M0),
+            scale_recipe_a=ScalingType.BlockWise1x32,
+            swizzle_a=SwizzleType.SWIZZLE_32_4_4,
+            scale_b=self.weight_scale,
+            scale_recipe_b=ScalingType.BlockWise1x32,
+            swizzle_b=SwizzleType.SWIZZLE_32_4_4,
+            output_dtype=torch.bfloat16,
+        )
+        return output.view(*leading_shape, self.out_features)
+
+
+__all__ = [
+    "MXActivation",
+    "MXFP8Linear",
+    "fused_residual_gate_rmsnorm_modulate_mxfp8",
+    "fused_rmsnorm_modulate_mxfp8",
+    "fused_swiglu_mxfp8",
+    "mxfp8_dequantize_swizzled",
+    "mxfp8_quantize_swizzled",
+]

--- a/models/minimax_h3/Sol-H3/h3_runtime/ulysses.py
+++ b/models/minimax_h3/Sol-H3/h3_runtime/ulysses.py
@@ -226,8 +226,14 @@ def _packed_qkv_all_to_all(q, k, v, world: int, group, packed_send=None,
     return x.reshape(rows_full, heads_local, 3 * head_dim)
 
 
-def _packed_out_all_to_all(out: torch.Tensor, rows_local: int, world: int, group,
-                           wire_dtype: str = "bf16") -> torch.Tensor:
+def _packed_out_all_to_all(
+    out: torch.Tensor,
+    rows_local: int,
+    world: int,
+    group,
+    wire_dtype: str = "bf16",
+    mxfp8_shape: tuple[int, ...] | None = None,
+):
     """The inverse: full sequence with local heads back to local rows with every head.
 
     `out` is `(rows_full, heads_local, head_dim)` contiguous, so the pre-collective step is free —
@@ -238,7 +244,11 @@ def _packed_out_all_to_all(out: torch.Tensor, rows_local: int, world: int, group
     _, heads_local, head_dim = out.shape
     counts = _row_counts(rows_local, world, group)
     if wire_dtype == "fp8":
-        from .comm_quant import dequantize_merge_output_fp8, quantize_output_fp8
+        from .comm_quant import (
+            dequantize_merge_output_fp8,
+            merge_output_fp8_as_mxfp8,
+            quantize_output_fp8,
+        )
 
         if head_dim != 128:
             raise ValueError("FP8 output transport requires head_dim=128")
@@ -256,9 +266,10 @@ def _packed_out_all_to_all(out: torch.Tensor, rows_local: int, world: int, group
             output_split_sizes=[rows_local * block] * world,
             group=group,
         )
-        return dequantize_merge_output_fp8(
-            received.reshape(world, rows_local, heads_local, head_dim), world
-        )
+        received = received.reshape(world, rows_local, heads_local, head_dim)
+        if mxfp8_shape is not None:
+            return merge_output_fp8_as_mxfp8(received, world, mxfp8_shape)
+        return dequantize_merge_output_fp8(received, world)
     if wire_dtype == "int8":
         from .comm_quant import OUTPUT_PACKET, dequantize_merge_output, quantize_output
 
@@ -310,6 +321,11 @@ def install(transformer, group=None, attention_fn=None):
     world = dist.get_world_size(group)
     if world == 1:
         return lambda: None
+
+    reuse_fp8_mxfp8 = os.environ.get("H3_REUSE_OUTPUT_FP8_AS_MXFP8", "1")
+    if reuse_fp8_mxfp8 not in {"0", "1"}:
+        raise ValueError("H3_REUSE_OUTPUT_FP8_AS_MXFP8 must be '0' or '1'")
+    reuse_fp8_mxfp8 = reuse_fp8_mxfp8 == "1"
 
     from .parallel_hooks import with_cp_reapplied
     restores = []
@@ -389,10 +405,22 @@ def install(transformer, group=None, attention_fn=None):
                 out = attention_fn(q, k, v).contiguous()
 
             output_wire_dtype = _output_wire_dtype(attention_fn, wire_dtype)
-            out = _packed_out_all_to_all(
-                out, rows_local, world, group, wire_dtype=output_wire_dtype
+            output_shape = (batch, rows_local, heads * head_dim)
+            reuse_output = (
+                reuse_fp8_mxfp8
+                and output_wire_dtype == "fp8"
+                and getattr(attn.to_out[0], "layout", None) == "MXFP8Swizzled"
             )
-            out = out.reshape(batch, rows_local, heads * head_dim).to(hidden_states.dtype)
+            out = _packed_out_all_to_all(
+                out,
+                rows_local,
+                world,
+                group,
+                wire_dtype=output_wire_dtype,
+                mxfp8_shape=output_shape if reuse_output else None,
+            )
+            if not reuse_output:
+                out = out.reshape(output_shape).to(hidden_states.dtype)
             return attn.to_out[1](attn.to_out[0](out))
 
         return original, forward

--- a/models/minimax_h3/Sol-H3/h3_runtime/ulysses.py
+++ b/models/minimax_h3/Sol-H3/h3_runtime/ulysses.py
@@ -327,15 +327,20 @@ def install(transformer, group=None, attention_fn=None):
             batch, rows_local, _ = hidden_states.shape
             heads, head_dim = attn.heads, attn.head_dim
 
-            # Three separate projections, never concatenated. The earlier sweep measured a fused
-            # QKV GEMM as a *loss* here, so three GEMMs is what we run — and once the pack kernel
-            # reads through strides, there is no reason to glue their outputs together either. The
-            # `torch.cat` this replaces wrote and re-read rows x 21504 bfloat16 per block, ~7 ms a
-            # step, purely to satisfy a layout the collective no longer needs.
             rows = batch * rows_local
-            q = attn.to_q(hidden_states).reshape(rows, heads, head_dim)
-            k = attn.to_k(hidden_states).reshape(rows, heads, head_dim)
-            v = attn.to_v(hidden_states).reshape(rows, heads, head_dim)
+            if getattr(attn, "fused_projections", False):
+                # The MXFP8 path shares one activation quantization across q/k/v.
+                # The pack kernel accepts the resulting strided views directly.
+                q, k, v = (
+                    attn.to_qkv(hidden_states)
+                    .reshape(rows, 3, heads, head_dim)
+                    .unbind(1)
+                )
+            else:
+                # Separate BF16 projections avoid an otherwise unnecessary QKV concat.
+                q = attn.to_q(hidden_states).reshape(rows, heads, head_dim)
+                k = attn.to_k(hidden_states).reshape(rows, heads, head_dim)
+                v = attn.to_v(hidden_states).reshape(rows, heads, head_dim)
             wire_dtype = _qkv_wire_dtype(attention_fn)
 
             if rotary_emb is not None:

--- a/models/minimax_h3/Sol-H3/infer.py
+++ b/models/minimax_h3/Sol-H3/infer.py
@@ -20,6 +20,12 @@ def parse_args() -> argparse.Namespace:
         default="sol_bsa",
         help="Attention backend (default: sol_bsa)",
     )
+    parser.add_argument(
+        "--compute-quant",
+        choices=("none", "mxfp8"),
+        default="none",
+        help="DiT linear compute mode (default: none/BF16)",
+    )
     parser.add_argument("--task", choices=("t2v", "i2v", "ref2va"), required=True)
     parser.add_argument("--prompt")
     parser.add_argument("--prompt-file", type=Path)
@@ -94,6 +100,7 @@ def main() -> int:
         attention_backend=args.attention_backend,
         task=args.task,
         reference_image_resize_mode=args.reference_image_resize_mode,
+        compute_quant=args.compute_quant,
     ) as engine:
         if args.warmup:
             engine.warmup(
@@ -119,6 +126,7 @@ def main() -> int:
                         "duration": args.duration,
                         "seed": args.seed,
                         "attention_backend": args.attention_backend,
+                        "compute_quant": args.compute_quant,
                         "reference_image_resize_mode": (
                             args.reference_image_resize_mode if args.task == "ref2va" else None
                         ),


### PR DESCRIPTION
## Summary

- add optional `--compute-quant mxfp8` for attention and FFN linears in blocks 2 through 46
- fuse RMSNorm/modulation and SwiGLU producers directly into the MXFP8 activation layout
- support fused QKV through both single-GPU attention and multi-GPU Ulysses
- reuse the raw E4M3 Ulysses return payload directly in MXFP8 output projections, avoiding the FP8-to-BF16-to-MXFP8 round trip
- retain BF16 as the default and reject MXFP8 outside the validated SM100-family path

## Validation

- NVIDIA B300: 1-GPU dense and 8-GPU SOL/BSA T2V end-to-end runs passed
- 8-GPU 5-second T2V median: 1.655 s BF16 to 1.472 s MXFP8, 11.1% lower latency
- follow-up receive-reuse A/B: 1.4434 s to 1.4342 s, saving 9.2 ms (0.64%)
- production-shape receive conversion/requantization: 0.0851 ms to 0.0507 ms per layer, about 40% lower
- selected linear weight storage per rank: 32.30 GiB to 16.65 GiB
- same-prompt/seed quality against BF16: 13.82 dB decoded-RGB PSNR, 0.540 SSIM
- reused E4M3 activations and the following MXFP8 output projection were bit-exact in the numerical probe
- Python compile, Ruff diagnostics, diff check, and 8-GPU end-to-end validation passed

The compute integration is shared by the task-selected transformer for T2V, I2V, and Ref2VA. The reported end-to-end A/B is specifically the 8-GPU T2V case.