### PR TITLE
ci: allow selecting a single test job for manual runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,21 @@ on:
         required: false
         type: boolean
         default: false
+      test_target:
+        description: 'Test job to run (requires run_tests)'
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - test-inference
+          - test-training-vae
+          - test-training-fsdp
+          - test-training-video
+          - test-training-sana-wm-stage1
+          - test-training-sana-wm-distill
+          - test-training-longsana
+          - test-training-sol-rl
   pull_request_target:
     types: [labeled, unlabeled, opened, synchronize, reopened]
     paths-ignore:
@@ -39,7 +54,8 @@ jobs:
   test-inference:
     needs: pre-commit
     if: |
-      github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' &&
+       (github.event.inputs.test_target == '' || github.event.inputs.test_target == 'all' || github.event.inputs.test_target == 'test-inference')) ||
       github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'run-tests')
     runs-on:
       - self-hosted
@@ -85,7 +101,8 @@ jobs:
   test-training-vae:
     needs: pre-commit
     if: |
-      github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' &&
+       (github.event.inputs.test_target == '' || github.event.inputs.test_target == 'all' || github.event.inputs.test_target == 'test-training-vae')) ||
       github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'run-tests')
     runs-on:
       - self-hosted
@@ -131,7 +148,8 @@ jobs:
   test-training-fsdp:
     needs: pre-commit
     if: |
-      github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' &&
+       (github.event.inputs.test_target == '' || github.event.inputs.test_target == 'all' || github.event.inputs.test_target == 'test-training-fsdp')) ||
       github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'run-tests')
     runs-on:
       - self-hosted
@@ -177,7 +195,8 @@ jobs:
   test-training-video:
     needs: pre-commit
     if: |
-      github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' &&
+       (github.event.inputs.test_target == '' || github.event.inputs.test_target == 'all' || github.event.inputs.test_target == 'test-training-video')) ||
       github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'run-tests')
     runs-on:
       - self-hosted
@@ -223,7 +242,8 @@ jobs:
   test-training-sana-wm-stage1:
     needs: pre-commit
     if: |
-      github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' &&
+       (github.event.inputs.test_target == '' || github.event.inputs.test_target == 'all' || github.event.inputs.test_target == 'test-training-sana-wm-stage1')) ||
       github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'run-tests')
     runs-on:
       - self-hosted
@@ -265,7 +285,8 @@ jobs:
   test-training-sana-wm-distill:
     needs: pre-commit
     if: |
-      github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' &&
+       (github.event.inputs.test_target == '' || github.event.inputs.test_target == 'all' || github.event.inputs.test_target == 'test-training-sana-wm-distill')) ||
       github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'run-tests')
     runs-on:
       - self-hosted
@@ -307,7 +328,8 @@ jobs:
   test-training-longsana:
     needs: pre-commit
     if: |
-      github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' &&
+       (github.event.inputs.test_target == '' || github.event.inputs.test_target == 'all' || github.event.inputs.test_target == 'test-training-longsana')) ||
       github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'run-tests')
     runs-on:
       - self-hosted
@@ -349,7 +371,8 @@ jobs:
   test-training-sol-rl:
     needs: pre-commit
     if: |
-      github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_tests == 'true' &&
+       (github.event.inputs.test_target == '' || github.event.inputs.test_target == 'all' || github.event.inputs.test_target == 'test-training-sol-rl')) ||
       github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'run-tests')
     runs-on:
       - self-hosted


### PR DESCRIPTION
Manual CI runs currently enable every GPU test job together. Add a `test_target` dropdown so enabling `run_tests` and selecting, for example, `test-training-video` runs pre-commit followed by only that test job.

The dropdown defaults to `all` and covers all eight existing test jobs. Missing or empty targets retain the previous full-suite behavior for existing callers. PRs with the `run-tests` label still run the full suite; `run_tests=false`, pre-commit dependencies, and PR-only label cleanup retain their existing behavior.

Usage: Actions → ci → Run workflow → select the branch → enable `run_tests` → choose `test_target`. This selects whole jobs; inference cases within `test-inference` still run together.

Validation: full repository pre-commit; YAML parsing and 1,440 job-condition combinations covering manual, PR, and push events, both label states, and every target; `git diff --check`. GPU training/inference jobs were not run for this workflow-only change.
