### PR TITLE
fix: inherit HF_TOKEN in sana-run

### DIFF
--- a/sana/cli/run.py
+++ b/sana/cli/run.py
@@ -72,7 +72,8 @@ def main() -> None:
     account = os.environ["SANA_SLURM_ACCOUNT"]
     partition = os.environ["SANA_SLURM_PARTITION"]
 
-    # Set environment variables
+    # Preserve credentials such as HF_TOKEN for the Slurm job. Hub clients use
+    # HF_TOKEN directly, so no stateful CLI login is needed.
     env = os.environ.copy()
     env["RUN_NAME"] = args.job_name
     env["OUTPUT_DIR"] = output_dir
@@ -102,17 +103,13 @@ def main() -> None:
         conda_path = shutil.which("conda")
         wrapped_cmd = ""
 
-        # HuggingFace login command if HF_TOKEN is set
-        hf_token = os.environ.get("HF_TOKEN", "")
-        hf_login_cmd = f"hf auth login --token {hf_token} && " if hf_token else ""
-
         if conda_path:
             conda_base_path = os.path.dirname(os.path.dirname(conda_path))
             conda_sh_path = os.path.join(conda_base_path, "etc", "profile.d", "conda.sh")
 
             if os.path.exists(conda_sh_path):
                 print(colored(f"Using Conda activation script: {conda_sh_path}", "cyan"))
-                wrapped_cmd = f'bash -c "source {conda_sh_path} && conda activate {conda_env_name} && {hf_login_cmd}{original_cmd}"'
+                wrapped_cmd = f'bash -c "source {conda_sh_path} && conda activate {conda_env_name} && {original_cmd}"'
             else:
                 print(
                     colored(
@@ -123,7 +120,9 @@ def main() -> None:
             print(colored("'conda' not found in PATH, falling back to 'conda shell.bash hook'", "yellow"))
 
         if not wrapped_cmd:
-            wrapped_cmd = f'bash -c "eval \\$(conda shell.bash hook) && conda activate {conda_env_name} && {hf_login_cmd}{original_cmd}"'
+            wrapped_cmd = (
+                f'bash -c "eval \\$(conda shell.bash hook) && conda activate {conda_env_name} && {original_cmd}"'
+            )
 
         cmd += [wrapped_cmd]
     else:

--- a/tests/test_sana_cli_run.py
+++ b/tests/test_sana_cli_run.py
@@ -1,0 +1,58 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from sana.cli import run as sana_run
+
+
+@pytest.mark.parametrize("conda_available", [False, True])
+def test_hf_token_is_forwarded_without_cli_login(monkeypatch, conda_available):
+    token = "hf_test_token"
+    captured = {}
+
+    monkeypatch.setenv("SANA_SLURM_ACCOUNT", "test-account")
+    monkeypatch.setenv("SANA_SLURM_PARTITION", "test-partition")
+    monkeypatch.setenv("CONDA_ENV_NAME", "test-env")
+    monkeypatch.setenv("HF_TOKEN", token)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["sana-run", "--job-name", "test", "--mode", "ci", "echo", "ok"],
+    )
+    if conda_available:
+        monkeypatch.setattr(sana_run.shutil, "which", lambda _: "/opt/conda/bin/conda")
+        monkeypatch.setattr(sana_run.os.path, "exists", lambda _: True)
+    else:
+        monkeypatch.setattr(sana_run.shutil, "which", lambda _: None)
+
+    def fake_run(command, *, env, shell):
+        captured.update(command=command, env=env, shell=shell)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(sana_run.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit) as exc_info:
+        sana_run.main()
+
+    assert exc_info.value.code == 0
+    assert captured["env"]["HF_TOKEN"] == token
+    assert captured["shell"] is True
+    assert "hf auth login" not in captured["command"]
+    assert token not in captured["command"]


### PR DESCRIPTION
## Summary

- let Slurm jobs inherit `HF_TOKEN` through the existing environment forwarding
- remove the redundant `hf auth login` call and its `/whoami-v2` request
- keep the token out of the rendered `srun` command
- cover both conda activation paths with a regression test

## Motivation

The manually dispatched `test-inference` job in [run 34335979698](https://github.com/NVlabs/Sana/actions/runs/34335979698/job/102415533175) failed before the inference script started because `hf auth login` hit the strict `/whoami-v2` rate limit. Hugging Face clients already consume `HF_TOKEN` directly, and `sana-run` forwards the current environment to the Slurm process.

## Validation

- `python -m pytest -q tests/test_sana_cli_run.py` (`2 passed`)
- `python -m py_compile sana/cli/run.py tests/test_sana_cli_run.py`
- `PRE_COMMIT_HOME=/tmp/sana-pr-precommit python -m pre_commit run --all-files`
