### PR TITLE
fix: use updated sana-run in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,6 +91,7 @@ jobs:
           source "$CONDA_SH_PATH"
           conda activate "$CONDA_ENV_NAME"
           pip install -e .
+          echo "$CONDA_PREFIX/bin" >> "$GITHUB_PATH"
           echo "--- 'sana-run' command updated. ---"
       - name: Run inference tests
         env:
@@ -138,6 +139,7 @@ jobs:
           source "$CONDA_SH_PATH"
           conda activate "$CONDA_ENV_NAME"
           pip install -e .
+          echo "$CONDA_PREFIX/bin" >> "$GITHUB_PATH"
           echo "--- 'sana-run' command updated. ---"
       - name: Run online VAE training test
         env:
@@ -185,6 +187,7 @@ jobs:
           source "$CONDA_SH_PATH"
           conda activate "$CONDA_ENV_NAME"
           pip install -e .
+          echo "$CONDA_PREFIX/bin" >> "$GITHUB_PATH"
           echo "--- 'sana-run' command updated. ---"
       - name: Run FSDP training test
         env:
@@ -232,6 +235,7 @@ jobs:
           source "$CONDA_SH_PATH"
           conda activate "$CONDA_ENV_NAME"
           pip install -e .
+          echo "$CONDA_PREFIX/bin" >> "$GITHUB_PATH"
           echo "--- 'sana-run' command updated. ---"
       - name: Run video training test
         env:
@@ -275,6 +279,7 @@ jobs:
           source "$CONDA_SH_PATH"
           conda activate "$CONDA_ENV_NAME"
           pip install -e .
+          echo "$CONDA_PREFIX/bin" >> "$GITHUB_PATH"
           echo "--- 'sana-run' command updated. ---"
       - name: Run SANA-WM stage-1 training test
         env:
@@ -318,6 +323,7 @@ jobs:
           source "$CONDA_SH_PATH"
           conda activate "$CONDA_ENV_NAME"
           pip install -e .
+          echo "$CONDA_PREFIX/bin" >> "$GITHUB_PATH"
           echo "--- 'sana-run' command updated. ---"
       - name: Run SANA-WM distillation training test
         env:
@@ -361,6 +367,7 @@ jobs:
           source "$CONDA_SH_PATH"
           conda activate "$CONDA_ENV_NAME"
           pip install -e .
+          echo "$CONDA_PREFIX/bin" >> "$GITHUB_PATH"
           echo "--- 'sana-run' command updated. ---"
       - name: Run longsana training test
         env:
@@ -404,6 +411,7 @@ jobs:
           source "$CONDA_SH_PATH"
           conda activate "$CONDA_ENV_NAME"
           pip install -e .
+          echo "$CONDA_PREFIX/bin" >> "$GITHUB_PATH"
           echo "--- 'sana-run' command updated. ---"
       - name: Run Sol-RL training test
         env:


### PR DESCRIPTION
## Summary

- persist the activated conda environment bin directory through GITHUB_PATH after installing Sana
- ensure every CI test step resolves the freshly installed sana-run instead of the stale runner-global entry point
- apply the fix consistently to inference and training jobs

## Why

The completed inference run passed, but its logs showed that the next GitHub Actions step still resolved an older global sana-run containing hf auth login. Conda activation is local to one shell step, so the editable install path must be carried into following steps.

## Validation

- targeted pre-commit hooks passed for .github/workflows/ci.yaml
- YAML syntax check passed
- git diff --check passed
- GPU inference was not rerun, per request