### PR TITLE
Add showcase examples

### DIFF
--- a/Sol-Engine/Sol-H3-Spark/README.md
+++ b/Sol-Engine/Sol-H3-Spark/README.md
@@ -2,14 +2,18 @@
 
 Static project page, separate from the existing eight-B300 Sol-H3 release.
 Serve this directory over HTTP; no Node server or build step is required.
-The page retains the blog's dark/light themes, responsive navigation, muted
+The page retains the blog's dark/light themes, responsive navigation,
 hero loop, synchronized showcase playback, prompt details and BibTeX copy.
+The hero defaults to sound on; showcase videos default to muted. Browsers
+that block audible autoplay retain the hero's click-to-play control.
 
 ## Assets
 
 All video, poster, logo and favicon assets are hosted in
 [Sana-assets](https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/tree/main/Sol-Engine/Sol-H3-Spark/20260907).
-URLs are pinned to dataset commit `f9de325489994d3d5f8cf607164238b1edb1ee08`.
+Existing asset URLs retain their pinned dataset revisions. The four new
+showcase examples use revision `efed7c62d78352b703adaf1d5a1d0a8de445c8fd`
+under `Sol-Engine/Sol-H3-Spark/20260910/showcase/`.
 No access token or authentication is needed to view them.
 
 The homepage hero is the 35.333-second animated Sol-H3 on Spark introduction,
@@ -17,10 +21,10 @@ at 1344x768 / 24 FPS with native dialogue and an instrumental music bed. Its
 MP4 and frame-derived poster are pinned to Sana-assets revision
 `e237daa52e404622250583edcff46d027d02241c` under
 `Sol-Engine/Sol-H3-Spark/20260910/hero/`. The film was produced with Base H3
-Ref2VA on HSG (50 scheduler points / 49 DiT evaluations, no LoRA), not with
+Ref2VA (50 scheduler points / 49 DiT evaluations, no LoRA), not with
 the 56-second Spark inference pipeline. Hero labels identify it as an
 introduction rather than a measured Spark generation. The benchmark claims
-and showcase media remain unchanged; the older showreel assets are retained.
+and existing showcase media remain unchanged; older showreel assets are retained.
 
 ## Content and maintenance
 
@@ -36,3 +40,14 @@ The FastH3 comparison cites its published 374 s cold/phased-loading run;
 the visible methodology note explicitly identifies the different timing
 regimes and geometry. It is not a matched benchmark or quality-equivalence
 claim. These values and the frozen three-step pipeline are unchanged here.
+
+## Showcase additions
+
+The first four examples are Snow Leopard Ridge, Wildflower Firefly Portrait,
+Fountain Pen Blue Ink and Astronaut Reentry Cockpit, in that order. The eight
+previous examples follow in their existing order. Pagination remains two
+examples per page, with six pages and muted playback.
+
+The videos use the existing two-stage pipeline. They and their posters are
+hosted on HF under descriptive public paths, with no media binaries committed
+to this branch. The current homepage introduction and timing claims are retained.

--- a/Sol-Engine/Sol-H3-Spark/index.html
+++ b/Sol-Engine/Sol-H3-Spark/index.html
@@ -99,7 +99,7 @@
 <small>e2e latency</small>
 </span>
 </div>
-<p class="hero-dek">A two-stage pipeline specialized for a single NVIDIA DGX Spark generates a 384p draft and refines it to 768p without cross-model latent decoding/re-encoding or runtime text-encoder switching.</p>
+<p class="hero-dek">A two-stage pipeline specialized for a single NVIDIA DGX Spark generates a 384p draft and refines it to 768p.</p>
 <div class="hero-actions spark-hero-actions" aria-label="Project links">
 <a class="button spark-code-button" href="https://github.com/NVlabs/Sana/tree/sol-engine/models/minimax_h3/Sol-H3" target="_blank" rel="noreferrer">Sol-H3 code<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-up-right" aria-hidden="true">
 <path d="M7 7h10v10">
@@ -119,7 +119,7 @@
 </div>
 <div class="hero-visual" aria-label="Sol-H3 on Spark introduction">
 <div class="video-terminal">
-<video controls="" class="hero-film" muted="" loop="" playsInline="" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/e237daa52e404622250583edcff46d027d02241c/Sol-Engine/Sol-H3-Spark/20260910/hero/sol-h3-on-spark-base-ref2va50-poster.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/e237daa52e404622250583edcff46d027d02241c/Sol-Engine/Sol-H3-Spark/20260910/hero/sol-h3-on-spark-base-ref2va50.mp4" aria-label="Sol-H3 on Spark: a 35-second animated introduction">
+<video controls="" class="hero-film" loop="" playsInline="" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/e237daa52e404622250583edcff46d027d02241c/Sol-Engine/Sol-H3-Spark/20260910/hero/sol-h3-on-spark-base-ref2va50-poster.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/e237daa52e404622250583edcff46d027d02241c/Sol-Engine/Sol-H3-Spark/20260910/hero/sol-h3-on-spark-base-ref2va50.mp4" aria-label="Sol-H3 on Spark: a 35-second animated introduction">
 </video>
 <button type="button" tabindex="0" data-slot="button" aria-label="Play background video" class="group/button inline-flex shrink-0 items-center justify-center rounded-lg border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*=&#x27;size-&#x27;])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 button spark-hero-control">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-play" aria-hidden="true">
@@ -302,7 +302,7 @@
 <rect x="5" y="3" width="5" height="18" rx="1">
 </rect>
 </svg>Pause all</button>
-<button type="button" tabindex="0" data-slot="button" aria-label="Show showcase page 4" title="Show showcase page 4" class="group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*=&#x27;size-&#x27;])]:size-4 hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50 h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 button spark-gallery-page">
+<button type="button" tabindex="0" data-slot="button" aria-label="Show showcase page 6" title="Show showcase page 6" class="group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*=&#x27;size-&#x27;])]:size-4 hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50 h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 button spark-gallery-page">
 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-left" aria-hidden="true">
 <path d="m15 18-6-6 6-6">
 </path>
@@ -319,14 +319,82 @@
 <p role="status" class="playback-status">
 </p>
 <div class="comparison-grid">
-<section class="comparison-pane" aria-label="Example 1: Human craft">
+<section class="comparison-pane" data-case-id="snow-leopard-ridge" aria-label="Example 1: Snow Leopard Ridge">
 <div class="comparison-pane-head">
 <div class="comparison-pane-label">
-<small>Example 01 · Human craft</small>
+<small>Example 01 · Wildlife</small>
 </div>
 </div>
 <div class="comparison-media" data-state="ready">
-<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/paper-fox-studio.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/paper-fox-studio.mp4" aria-label="Example 1: Human craft">
+<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/efed7c62d78352b703adaf1d5a1d0a8de445c8fd/Sol-Engine/Sol-H3-Spark/20260910/showcase/snow-leopard-ridge.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/efed7c62d78352b703adaf1d5a1d0a8de445c8fd/Sol-Engine/Sol-H3-Spark/20260910/showcase/snow-leopard-ridge.mp4" aria-label="Snow Leopard Ridge">
+</video>
+</div>
+<details class="comparison-prompt">
+<summary>View exact prompt</summary>
+<div class="comparison-prompt-body">
+<p>integrated_multimodal_description: [Shot 1] Photoreal wildlife documentary in crisp mountain daylight, a medium-wide view frames one majestic snow leopard with thick spotted fur moving across a jagged, snow-covered ridge beneath towering Himalayan peaks and a clear blue sky. During one continuous five-second shot, the camera pans slowly to follow its low stalking gait as each paw sinks slightly into fresh powder. The leopard pauses near the end, its long bushy tail twitching for balance while its green eyes scan the valley; frost-dusted whiskers and individual hairs remain sharply visible. Preserve the animal&#x27;s anatomy, markings, scale, paw contact, and ridge geometry throughout, with no cuts, text, or logos. overall_soundscape: Soft mountain wind passes over the ridge while paws compress fresh snow with muted crunches. A faint tail brush and the leopard&#x27;s quiet breathing are audible in the cold open air. non_diegetic_music: N/A</p>
+</div>
+</details>
+</section>
+<section class="comparison-pane" data-case-id="wildflower-firefly-portrait" aria-label="Example 2: Wildflower Firefly Portrait">
+<div class="comparison-pane-head">
+<div class="comparison-pane-label">
+<small>Example 02 · Cinematic portrait</small>
+</div>
+</div>
+<div class="comparison-media" data-state="ready">
+<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/efed7c62d78352b703adaf1d5a1d0a8de445c8fd/Sol-Engine/Sol-H3-Spark/20260910/showcase/wildflower-firefly-portrait.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/efed7c62d78352b703adaf1d5a1d0a8de445c8fd/Sol-Engine/Sol-H3-Spark/20260910/showcase/wildflower-firefly-portrait.mp4" aria-label="Wildflower Firefly Portrait">
+</video>
+</div>
+<details class="comparison-prompt">
+<summary>View exact prompt</summary>
+<div class="comparison-prompt-body">
+<p>integrated_multimodal_description: [Shot 1] Cinematic live-action portrait at twilight, a young person wearing a delicate crown of wildflowers sits on a deep green mossy forest floor under cool blue moonlight. In one continuous five-second shot, the camera makes a slow small-amplitude arc around them, revealing soft petals, damp moss, and fireflies blinking warmly in the background. Tiny points of bioluminescent light play across their face as they slowly turn their head to watch one firefly settle on their shoulder, ending with the same quiet expression of wonder. Preserve the person&#x27;s appearance, flower crown, seated pose, and forest layout; no cuts, captions, or logos. overall_soundscape: Quiet evening forest ambience continues beneath a light breeze through leaves and a soft rustle of clothing against moss. Sparse insects chirp in the distance as the person takes one calm breath. non_diegetic_music: N/A</p>
+</div>
+</details>
+</section>
+<section class="comparison-pane" hidden="" data-case-id="fountain-pen-blue-ink" aria-label="Example 3: Fountain Pen Blue Ink">
+<div class="comparison-pane-head">
+<div class="comparison-pane-label">
+<small>Example 03 · Macro detail</small>
+</div>
+</div>
+<div class="comparison-media" data-state="ready">
+<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/efed7c62d78352b703adaf1d5a1d0a8de445c8fd/Sol-Engine/Sol-H3-Spark/20260910/showcase/fountain-pen-blue-ink.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/efed7c62d78352b703adaf1d5a1d0a8de445c8fd/Sol-Engine/Sol-H3-Spark/20260910/showcase/fountain-pen-blue-ink.mp4" aria-label="Fountain Pen Blue Ink">
+</video>
+</div>
+<details class="comparison-prompt">
+<summary>View exact prompt</summary>
+<div class="comparison-prompt-body">
+<p>integrated_multimodal_description: [Shot 1] Photoreal macro product film in soft window daylight, an ornate gold nib on a handcrafted fountain pen moves across textured cream parchment while its polished mahogany barrel shows fine wood grain. In one continuous five-second shot, the camera tracks tightly with the nib as dark blue ink flows smoothly from the tip, follows a short curved stroke, and soaks into individual paper fibers. The metal flexes subtly under pressure and the fresh ink retains a wet sheen before beginning to dry. Keep the same pen, nib, ink line, and parchment surface coherent throughout, with no cuts, captions, or logos. overall_soundscape: The gold nib makes a delicate textured scratch across paper while the pen barrel shifts softly in the writer&#x27;s grip. Quiet room tone and a faint rustle of parchment remain underneath. non_diegetic_music: N/A</p>
+</div>
+</details>
+</section>
+<section class="comparison-pane" hidden="" data-case-id="astronaut-reentry-cockpit" aria-label="Example 4: Astronaut Reentry Cockpit">
+<div class="comparison-pane-head">
+<div class="comparison-pane-label">
+<small>Example 04 · Science fiction</small>
+</div>
+</div>
+<div class="comparison-media" data-state="ready">
+<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/efed7c62d78352b703adaf1d5a1d0a8de445c8fd/Sol-Engine/Sol-H3-Spark/20260910/showcase/astronaut-reentry-cockpit.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/efed7c62d78352b703adaf1d5a1d0a8de445c8fd/Sol-Engine/Sol-H3-Spark/20260910/showcase/astronaut-reentry-cockpit.mp4" aria-label="Astronaut Reentry Cockpit">
+</video>
+</div>
+<details class="comparison-prompt">
+<summary>View exact prompt</summary>
+<div class="comparison-prompt-body">
+<p>integrated_multimodal_description: [Shot 1] Cinematic live-action inside a cramped spacecraft cockpit during atmospheric reentry, a close view holds on an astronaut&#x27;s face behind a clear glass visor that reflects blinking red and green controls. In one continuous five-second shot, the camera shakes slightly with the vibrating cabin while beads of sweat travel down the astronaut&#x27;s temple and their wide determined eyes scan the instrument panel. Fierce orange friction light flickers through a small porthole and moves dynamically across the detailed flight suit, helmet, and visor. Preserve the astronaut&#x27;s appearance, helmet geometry, reflections, and cockpit layout; no cuts, captions, or logos. overall_soundscape: Deep mechanical vibration and rapid hull rattles fill the cockpit beneath intermittent electronic beeps. The astronaut&#x27;s controlled breathing remains close inside the helmet as a low reentry roar rises outside. non_diegetic_music: N/A</p>
+</div>
+</details>
+</section>
+<section class="comparison-pane" hidden="" aria-label="Example 5: Human craft">
+<div class="comparison-pane-head">
+<div class="comparison-pane-label">
+<small>Example 05 · Human craft</small>
+</div>
+</div>
+<div class="comparison-media" data-state="ready">
+<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/paper-fox-studio.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/paper-fox-studio.mp4" aria-label="Example 5: Human craft">
 </video>
 </div>
 <details class="comparison-prompt">
@@ -336,14 +404,14 @@
 </div>
 </details>
 </section>
-<section class="comparison-pane" aria-label="Example 2: Character animation">
+<section class="comparison-pane" hidden="" aria-label="Example 6: Character animation">
 <div class="comparison-pane-head">
 <div class="comparison-pane-label">
-<small>Example 02 · Character animation</small>
+<small>Example 06 · Character animation</small>
 </div>
 </div>
 <div class="comparison-media" data-state="ready">
-<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/neon-dance-duet.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/neon-dance-duet.mp4" aria-label="Example 2: Character animation">
+<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/neon-dance-duet.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/neon-dance-duet.mp4" aria-label="Example 6: Character animation">
 </video>
 </div>
 <details class="comparison-prompt">
@@ -353,14 +421,14 @@
 </div>
 </details>
 </section>
-<section class="comparison-pane" hidden="" aria-label="Example 3: Wildlife">
+<section class="comparison-pane" hidden="" aria-label="Example 7: Wildlife">
 <div class="comparison-pane-head">
 <div class="comparison-pane-label">
-<small>Example 03 · Wildlife</small>
+<small>Example 07 · Wildlife</small>
 </div>
 </div>
 <div class="comparison-media" data-state="ready">
-<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/fox-winter-morning.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/fox-winter-morning.mp4" aria-label="Example 3: Wildlife">
+<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/fox-winter-morning.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/fox-winter-morning.mp4" aria-label="Example 7: Wildlife">
 </video>
 </div>
 <details class="comparison-prompt">
@@ -370,14 +438,14 @@
 </div>
 </details>
 </section>
-<section class="comparison-pane" hidden="" aria-label="Example 4: Everyday life">
+<section class="comparison-pane" hidden="" aria-label="Example 8: Everyday life">
 <div class="comparison-pane-head">
 <div class="comparison-pane-label">
-<small>Example 04 · Everyday life</small>
+<small>Example 08 · Everyday life</small>
 </div>
 </div>
 <div class="comparison-media" data-state="ready">
-<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/seaside-coffee.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/seaside-coffee.mp4" aria-label="Example 4: Everyday life">
+<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/seaside-coffee.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/seaside-coffee.mp4" aria-label="Example 8: Everyday life">
 </video>
 </div>
 <details class="comparison-prompt">
@@ -387,14 +455,14 @@
 </div>
 </details>
 </section>
-<section class="comparison-pane" hidden="" aria-label="Example 5: Natural motion">
+<section class="comparison-pane" hidden="" aria-label="Example 9: Natural motion">
 <div class="comparison-pane-head">
 <div class="comparison-pane-label">
-<small>Example 05 · Natural motion</small>
+<small>Example 09 · Natural motion</small>
 </div>
 </div>
 <div class="comparison-media" data-state="ready">
-<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/flood.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/flood.mp4" aria-label="Example 5: Natural motion">
+<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/flood.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/flood.mp4" aria-label="Example 9: Natural motion">
 </video>
 </div>
 <details class="comparison-prompt">
@@ -404,14 +472,14 @@
 </div>
 </details>
 </section>
-<section class="comparison-pane" hidden="" aria-label="Example 6: Sport and motion">
+<section class="comparison-pane" hidden="" aria-label="Example 10: Sport and motion">
 <div class="comparison-pane-head">
 <div class="comparison-pane-label">
-<small>Example 06 · Sport and motion</small>
+<small>Example 10 · Sport and motion</small>
 </div>
 </div>
 <div class="comparison-media" data-state="ready">
-<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/sunset-skatepark.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/sunset-skatepark.mp4" aria-label="Example 6: Sport and motion">
+<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/sunset-skatepark.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/sunset-skatepark.mp4" aria-label="Example 10: Sport and motion">
 </video>
 </div>
 <details class="comparison-prompt">
@@ -421,14 +489,14 @@
 </div>
 </details>
 </section>
-<section class="comparison-pane" hidden="" aria-label="Example 7: Science fiction">
+<section class="comparison-pane" hidden="" aria-label="Example 11: Science fiction">
 <div class="comparison-pane-head">
 <div class="comparison-pane-label">
-<small>Example 07 · Science fiction</small>
+<small>Example 11 · Science fiction</small>
 </div>
 </div>
 <div class="comparison-media" data-state="ready">
-<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/orbital-greenhouse.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/orbital-greenhouse.mp4" aria-label="Example 7: Science fiction">
+<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/orbital-greenhouse.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/orbital-greenhouse.mp4" aria-label="Example 11: Science fiction">
 </video>
 </div>
 <details class="comparison-prompt">
@@ -438,14 +506,14 @@
 </div>
 </details>
 </section>
-<section class="comparison-pane" hidden="" aria-label="Example 8: Fantasy cinema">
+<section class="comparison-pane" hidden="" aria-label="Example 12: Fantasy cinema">
 <div class="comparison-pane-head">
 <div class="comparison-pane-label">
-<small>Example 08 · Fantasy cinema</small>
+<small>Example 12 · Fantasy cinema</small>
 </div>
 </div>
 <div class="comparison-media" data-state="ready">
-<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/dragon-cloud-archipelago.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/dragon-cloud-archipelago.mp4" aria-label="Example 8: Fantasy cinema">
+<video controls="" muted="" playsInline="" preload="metadata" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/dragon-cloud-archipelago.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/dragon-cloud-archipelago.mp4" aria-label="Example 12: Fantasy cinema">
 </video>
 </div>
 <details class="comparison-prompt">


### PR DESCRIPTION
Add four showcase examples: Snow Leopard Ridge, Wildflower Firefly Portrait, Fountain Pen Blue Ink, and Astronaut Reentry Cockpit. Keep the existing examples afterward. Preserve the current homepage introduction, enable its sound by default, keep showcase videos muted by default, and shorten the introductory paragraph.