### PR TITLE
Replace Sol-H3 Spark homepage hero with the new promo

### DIFF
--- a/Sol-Engine/Sol-H3-Spark/README.md
+++ b/Sol-Engine/Sol-H3-Spark/README.md
@@ -10,9 +10,17 @@ hero loop, synchronized showcase playback, prompt details and BibTeX copy.
 All video, poster, logo and favicon assets are hosted in
 [Sana-assets](https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/tree/main/Sol-Engine/Sol-H3-Spark/20260907).
 URLs are pinned to dataset commit `f9de325489994d3d5f8cf607164238b1edb1ee08`.
-No access token or authentication is needed to view them. The four-clip hero
-order is elderly couple, skateboarding, flowing water and orbital greenhouse.
-No dragon or eagle clip appears on the page.
+No access token or authentication is needed to view them.
+
+The homepage hero is the 35.333-second animated Sol-H3 on Spark introduction,
+at 1344x768 / 24 FPS with native dialogue and an instrumental music bed. Its
+MP4 and frame-derived poster are pinned to Sana-assets revision
+`e237daa52e404622250583edcff46d027d02241c` under
+`Sol-Engine/Sol-H3-Spark/20260910/hero/`. The film was produced with Base H3
+Ref2VA on HSG (50 scheduler points / 49 DiT evaluations, no LoRA), not with
+the 56-second Spark inference pipeline. Hero labels identify it as an
+introduction rather than a measured Spark generation. The benchmark claims
+and showcase media remain unchanged; the older showreel assets are retained.
 
 ## Content and maintenance
 

--- a/Sol-Engine/Sol-H3-Spark/index.html
+++ b/Sol-Engine/Sol-H3-Spark/index.html
@@ -117,9 +117,9 @@
 </a>
 </div>
 </div>
-<div class="hero-visual" aria-label="Sol-H3 Spark generation preview">
+<div class="hero-visual" aria-label="Sol-H3 on Spark introduction">
 <div class="video-terminal">
-<video controls="" class="hero-film" muted="" loop="" playsInline="" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/seaside-coffee.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/684fda076add94955cd52f202f60825e471d3eee/Sol-Engine/Sol-H3-Spark/20260907/media/sol-h3-showreel.mp4" aria-label="Four Sol-H3 Spark generations: elderly couple, skateboarding, flowing water, and a garden above Earth">
+<video controls="" class="hero-film" muted="" loop="" playsInline="" poster="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/e237daa52e404622250583edcff46d027d02241c/Sol-Engine/Sol-H3-Spark/20260910/hero/sol-h3-on-spark-base-ref2va50-poster.jpg" src="https://huggingface.co/datasets/Efficient-Large-Model/Sana-assets/resolve/e237daa52e404622250583edcff46d027d02241c/Sol-Engine/Sol-H3-Spark/20260910/hero/sol-h3-on-spark-base-ref2va50.mp4" aria-label="Sol-H3 on Spark: a 35-second animated introduction">
 </video>
 <button type="button" tabindex="0" data-slot="button" aria-label="Play background video" class="group/button inline-flex shrink-0 items-center justify-center rounded-lg border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&amp;_svg]:pointer-events-none [&amp;_svg]:shrink-0 [&amp;_svg:not([class*=&#x27;size-&#x27;])]:size-4 border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 button spark-hero-control">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-play" aria-hidden="true">
@@ -131,12 +131,12 @@
 <div class="terminal-top">
 <span class="live-pill">
 <i aria-hidden="true">
-</i>Generated on Spark</span>
+</i>Sol-H3 introduction</span>
 <span class="terminal-code">1344×768 / 24 FPS</span>
 </div>
 </div>
 <div class="video-credit">
-<span class="video-credit-copy">Generated on one DGX Spark · 1344 × 768 · 24 FPS</span>
+<span class="video-credit-copy">Sol-H3 on Spark · Introduction · 1344 × 768 · 24 FPS</span>
 </div>
 </div>
 </div>


### PR DESCRIPTION
Replaces only the Sol-H3-Spark homepage hero video and frame-derived poster with the completed 35-second native Base Ref2VA50 promo. Media is hosted on the existing Sana-assets dataset and pinned to revision e237daa52e404622250583edcff46d027d02241c. Hero copy identifies it as an introduction, not a measured Spark-generated clip. Playback behavior, benchmark content, styles and showcase are unchanged. Both media URLs passed anonymous HTTP 206 range reads; the 848-frame MP4 passed full decode and visual transition review. Built from current page head a91e26d and does not include the separate unmerged showcase PR #495. User requested replacing the live homepage.